### PR TITLE
Releasing version 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.30.0 - 2021-01-19
+### Added
+- Support for Logging Analytics as a target in the Service Connector Hub service
+- Support for lookups, agent collection warnings, task commands, and data archive/recall in the Logging Analytics service
+
+### Fixed
+- Fixed a bug in the endpoint used for the Management Dashboard service
+
+### Breaking Changes
+- Parameter `sortBy` in requests `ListMetaSourceTypesRequest`, `ListParserFunctionsRequest`, `ListParserMetaPluginsRequest`, `ListSourceLabelOperatorsRequest`, `ListSourceMetaFunctionsRequest` has changed its datatype from `String` to `SortBy` enum in the Logging Analytics service
+- Parameter `lifecycleState` in `LogAnalyticsObjectCollectionRule` has changed its datatype from `LogAnalyticsObjectCollectionRule.LifecycleState` to `ObjectCollectionRuleLifecycleStates` in the Logging Analytics Service
+- Methods `builder()`, `toBuilder()`, and `get__explicitlySet__()` has been removed from `UpdateScheduledTaskDetails` in the Logging Analytics Service
+- Methods `builder()`, `toBuilder()`, and `get__explicitlySet__()` has been removed from `ScheduledTask` in the Logging Analytics Service
+
 ## 1.29.0 - 2021-01-12
 ### Added
 - Support for auto-scaling in the Big Data service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,402 +19,402 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalytics.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalytics.java
@@ -47,7 +47,7 @@ public interface LogAnalytics extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Adds association between input source log analytics entity and destination entities.
+     * Adds association between input source log analytics entity and one or more existing destination entities.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -55,6 +55,45 @@ public interface LogAnalytics extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/AddEntityAssociationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use AddEntityAssociation API.
      */
     AddEntityAssociationResponse addEntityAssociation(AddEntityAssociationRequest request);
+
+    /**
+     * Append data to a lookup.  The file containing the information to append
+     * must be provided.
+     *
+     *
+     * Note: This operation consumes a stream.
+     *
+     * If the stream supports {@link java.io.InputStream#mark(int)} and {@link java.io.InputStream#reset()}, when a retry is
+     * necessary, the stream is reset so it starts at the beginning (or whatever the stream's position was at the time this
+     * operation is called}.
+     *
+     * Note this means that if the caller has used {@link java.io.InputStream#mark(int)} before, then the mark
+     * will not be the same anymore after this operation, and a subsequent call to {@link java.io.InputStream#reset()} by
+     * the caller will reset the stream not to the caller's mark, but to the position the stream was in when this operation
+     * was called.
+     *
+     * If the stream is a {@link java.io.FileInputStream}, and the stream's {@link java.nio.channels.FileChannel} position
+     * can be changed (like for a regular file), the stream will be wrapped in such a way that it does provide
+     * support for {@link java.io.InputStream#mark(int)} and {@link java.io.InputStream#reset()}. Then the same procedure as
+     * above is followed. If the stream's {@link java.nio.channels.FileChannel} position cannot be changed (like for a
+     * named pipe), then the stream's contents will be buffered in memory, as described below.
+     *
+     * If the stream does not support {@link java.io.InputStream#mark(int)} and {@link java.io.InputStream#reset()}, then
+     * the stream is wrapped in a {@link java.io.BufferedInputStream}, which means the entire contents may
+     * be buffered in memory. Then the same procedure as above is followed.
+     *
+     * The contents of the stream, except when the stream is a {@link java.io.FileInputStream} whose
+     * {@link java.nio.channels.FileChannel} position can be changed, should be less than 2 GiB in size if retries are used.
+     * This is because streams 2 GiB in size or larger do no guarantee that mark-and-reset can be performed. If the stream
+     * is larger, do not use built-in retries and manage retries yourself.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/AppendLookupDataExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use AppendLookupData API.
+     */
+    AppendLookupDataResponse appendLookupData(AppendLookupDataRequest request);
 
     /**
      * get basic information about a specified set of labels
@@ -99,7 +138,7 @@ public interface LogAnalytics extends AutoCloseable {
             ChangeLogAnalyticsLogGroupCompartmentRequest request);
 
     /**
-     * Move the rule from it's current compartment to given compartment.
+     * Move the rule from it's current compartment to the given compartment.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -168,7 +207,7 @@ public interface LogAnalytics extends AutoCloseable {
             CreateLogAnalyticsLogGroupRequest request);
 
     /**
-     * Create a configuration to collect logs from object storage bucket.
+     * Creates a rule to collect logs from an object storage bucket.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -230,7 +269,7 @@ public interface LogAnalytics extends AutoCloseable {
             DeleteLogAnalyticsEntityRequest request);
 
     /**
-     * Delete the log analytics entity type with the given name.
+     * Delete log analytics entity type with the given name.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -252,8 +291,8 @@ public interface LogAnalytics extends AutoCloseable {
             DeleteLogAnalyticsLogGroupRequest request);
 
     /**
-     * Deletes a configured object storage bucket based collection rule to stop the log collection of the configured bucket .
-     * It will not delete the already collected log data from the configured bucket.
+     * Deletes the configured object storage bucket based collection rule and stop the log collection.
+     * It will not delete the existing processed data associated with this bucket from logging analytics storage.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -263,6 +302,17 @@ public interface LogAnalytics extends AutoCloseable {
      */
     DeleteLogAnalyticsObjectCollectionRuleResponse deleteLogAnalyticsObjectCollectionRule(
             DeleteLogAnalyticsObjectCollectionRuleRequest request);
+
+    /**
+     * Delete the specified lookup.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/DeleteLookupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteLookup API.
+     */
+    DeleteLookupResponse deleteLookup(DeleteLookupRequest request);
 
     /**
      * delete parser with specified name
@@ -307,8 +357,8 @@ public interface LogAnalytics extends AutoCloseable {
     DeleteUploadResponse deleteUpload(DeleteUploadRequest request);
 
     /**
-     * Deletes a specific log file inside an upload by providing upload file reference.
-     * It deletes all the logs in storage asscoiated with the upload file and the corresponding upload metadata.
+     * Deletes a specific log file inside an upload by upload file reference.
+     * It deletes all the logs from storage associated with the file and the corresponding metadata.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -361,6 +411,28 @@ public interface LogAnalytics extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/EstimatePurgeDataSizeExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use EstimatePurgeDataSize API.
      */
     EstimatePurgeDataSizeResponse estimatePurgeDataSize(EstimatePurgeDataSizeRequest request);
+
+    /**
+     * This API gives an active storage usage estimate for archived data to be recalled and the time range of such data.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/EstimateRecallDataSizeExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use EstimateRecallDataSize API.
+     */
+    EstimateRecallDataSizeResponse estimateRecallDataSize(EstimateRecallDataSizeRequest request);
+
+    /**
+     * This API gives an active storage usage estimate for recalled data to be released and the time range of such data.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/EstimateReleaseDataSizeExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use EstimateReleaseDataSize API.
+     */
+    EstimateReleaseDataSizeResponse estimateReleaseDataSize(EstimateReleaseDataSizeRequest request);
 
     /**
      * export
@@ -485,7 +557,7 @@ public interface LogAnalytics extends AutoCloseable {
     GetLabelSummaryResponse getLabelSummary(GetLabelSummaryRequest request);
 
     /**
-     * Returns log analytics entities count summary.
+     * Returns log analytics entities count summary report.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -547,6 +619,17 @@ public interface LogAnalytics extends AutoCloseable {
      */
     GetLogAnalyticsObjectCollectionRuleResponse getLogAnalyticsObjectCollectionRule(
             GetLogAnalyticsObjectCollectionRuleRequest request);
+
+    /**
+     * Obtains the lookup with the specified reference.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/GetLookupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetLookup API.
+     */
+    GetLookupResponse getLookup(GetLookupRequest request);
 
     /**
      * This API gets the namespace details of a tenancy already onboarded in Logging Analytics Application
@@ -667,7 +750,7 @@ public interface LogAnalytics extends AutoCloseable {
     GetStorageWorkRequestResponse getStorageWorkRequest(GetStorageWorkRequestRequest request);
 
     /**
-     * Gets an On-Demand Upload info by reference
+     * Gets an On-Demand Upload info by reference.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -838,7 +921,7 @@ public interface LogAnalytics extends AutoCloseable {
             ListLogAnalyticsLogGroupsRequest request);
 
     /**
-     * Gets list of configuration details of Object Storage based collection rules.
+     * Gets list of collection rules.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -847,6 +930,18 @@ public interface LogAnalytics extends AutoCloseable {
      */
     ListLogAnalyticsObjectCollectionRulesResponse listLogAnalyticsObjectCollectionRules(
             ListLogAnalyticsObjectCollectionRulesRequest request);
+
+    /**
+     * Obtains a list of lookups.  The list is filtered according to the filter criteria
+     * specified by the user, and sorted according to the ordering criteria specified.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ListLookupsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListLookups API.
+     */
+    ListLookupsResponse listLookups(ListLookupsRequest request);
 
     /**
      * get all meta source types
@@ -909,6 +1004,17 @@ public interface LogAnalytics extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ListQueryWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListQueryWorkRequests API.
      */
     ListQueryWorkRequestsResponse listQueryWorkRequests(ListQueryWorkRequestsRequest request);
+
+    /**
+     * This API returns the list of recalled data of a tenancy.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ListRecalledDataExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListRecalledData API.
+     */
+    ListRecalledDataResponse listRecalledData(ListRecalledDataRequest request);
 
     /**
      * Lists scheduled tasks.
@@ -1005,7 +1111,7 @@ public interface LogAnalytics extends AutoCloseable {
     ListStorageWorkRequestsResponse listStorageWorkRequests(ListStorageWorkRequestsRequest request);
 
     /**
-     * Gets the list of character encodings supported for log files.
+     * Gets list of character encodings which are supported by on-demand upload.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -1016,7 +1122,7 @@ public interface LogAnalytics extends AutoCloseable {
             ListSupportedCharEncodingsRequest request);
 
     /**
-     * Gets timezones that are supported when performing uploads.
+     * Gets list of timezones which are supported by on-demand upload.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -1026,7 +1132,7 @@ public interface LogAnalytics extends AutoCloseable {
     ListSupportedTimezonesResponse listSupportedTimezones(ListSupportedTimezonesRequest request);
 
     /**
-     * Gets list of files in an upload.
+     * Gets list of files in an upload along with its processing state.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -1036,7 +1142,7 @@ public interface LogAnalytics extends AutoCloseable {
     ListUploadFilesResponse listUploadFiles(ListUploadFilesRequest request);
 
     /**
-     * Gets list of warnings in an upload explaining the failures due to incorrect configuration.
+     * Gets list of warnings in an upload caused by incorrect configuration.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -1056,6 +1162,18 @@ public interface LogAnalytics extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ListUploadsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListUploads API.
      */
     ListUploadsResponse listUploads(ListUploadsRequest request);
+
+    /**
+     * Obtains a list of warnings.  The list is filtered according to the filter criteria
+     * specified by the user, and sorted according to the ordering criteria specified.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ListWarningsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWarnings API.
+     */
+    ListWarningsResponse listWarnings(ListWarningsRequest request);
 
     /**
      * Return a (paginated) list of errors for a given work request.
@@ -1120,6 +1238,17 @@ public interface LogAnalytics extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ParseQueryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ParseQuery API.
      */
     ParseQueryResponse parseQuery(ParseQueryRequest request);
+
+    /**
+     * Pause the scheduled task specified by {scheduledTaskId}.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/PauseScheduledTaskExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use PauseScheduledTask API.
+     */
+    PauseScheduledTaskResponse pauseScheduledTask(PauseScheduledTaskRequest request);
 
     /**
      * This API submits a work request to purge data. Only data from log groups that the user has permission to delete
@@ -1226,6 +1355,17 @@ public interface LogAnalytics extends AutoCloseable {
             RemoveEntityAssociationsRequest request);
 
     /**
+     * Resume the scheduled task specified by {scheduledTaskId}.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ResumeScheduledTaskExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ResumeScheduledTask API.
+     */
+    ResumeScheduledTaskResponse resumeScheduledTask(ResumeScheduledTaskRequest request);
+
+    /**
      * Execute the saved search acceleration task in the foreground.
      * The ScheduledTask taskType must be ACCELERATION.
      * Optionally specify time range (timeStart and timeEnd). The default is all time.
@@ -1249,6 +1389,19 @@ public interface LogAnalytics extends AutoCloseable {
     SuggestResponse suggest(SuggestRequest request);
 
     /**
+     * Accepts a list of warnings.  Any unsuppressed warnings in the input list will
+     * be suppressed.  Warnings in the input list which are already suppressed will
+     * not be modified.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/SuppressWarningExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SuppressWarning API.
+     */
+    SuppressWarningResponse suppressWarning(SuppressWarningRequest request);
+
+    /**
      * test parser
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1257,6 +1410,19 @@ public interface LogAnalytics extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/TestParserExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use TestParser API.
      */
     TestParserResponse testParser(TestParserRequest request);
+
+    /**
+     * Accepts a list of warnings.  Any suppressed warnings in the input list will
+     * be unsuppressed.  Warnings in the input list which are unsuppressed will
+     * not be modified.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/UnsuppressWarningExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UnsuppressWarning API.
+     */
+    UnsuppressWarningResponse unsuppressWarning(UnsuppressWarningRequest request);
 
     /**
      * Update the log analytics entity with the given id.
@@ -1292,7 +1458,7 @@ public interface LogAnalytics extends AutoCloseable {
             UpdateLogAnalyticsLogGroupRequest request);
 
     /**
-     * Update the rule with the given id.
+     * Updates configuration of the object collection rule for the given id.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -1301,6 +1467,56 @@ public interface LogAnalytics extends AutoCloseable {
      */
     UpdateLogAnalyticsObjectCollectionRuleResponse updateLogAnalyticsObjectCollectionRule(
             UpdateLogAnalyticsObjectCollectionRuleRequest request);
+
+    /**
+     * Updates the metadata of the specified lookup, such as the lookup description.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/UpdateLookupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateLookup API.
+     */
+    UpdateLookupResponse updateLookup(UpdateLookupRequest request);
+
+    /**
+     * Updates the specified lookup with the details provided.  This API will not update
+     * lookup metadata (such as lookup description).
+     *
+     *
+     * Note: This operation consumes a stream.
+     *
+     * If the stream supports {@link java.io.InputStream#mark(int)} and {@link java.io.InputStream#reset()}, when a retry is
+     * necessary, the stream is reset so it starts at the beginning (or whatever the stream's position was at the time this
+     * operation is called}.
+     *
+     * Note this means that if the caller has used {@link java.io.InputStream#mark(int)} before, then the mark
+     * will not be the same anymore after this operation, and a subsequent call to {@link java.io.InputStream#reset()} by
+     * the caller will reset the stream not to the caller's mark, but to the position the stream was in when this operation
+     * was called.
+     *
+     * If the stream is a {@link java.io.FileInputStream}, and the stream's {@link java.nio.channels.FileChannel} position
+     * can be changed (like for a regular file), the stream will be wrapped in such a way that it does provide
+     * support for {@link java.io.InputStream#mark(int)} and {@link java.io.InputStream#reset()}. Then the same procedure as
+     * above is followed. If the stream's {@link java.nio.channels.FileChannel} position cannot be changed (like for a
+     * named pipe), then the stream's contents will be buffered in memory, as described below.
+     *
+     * If the stream does not support {@link java.io.InputStream#mark(int)} and {@link java.io.InputStream#reset()}, then
+     * the stream is wrapped in a {@link java.io.BufferedInputStream}, which means the entire contents may
+     * be buffered in memory. Then the same procedure as above is followed.
+     *
+     * The contents of the stream, except when the stream is a {@link java.io.FileInputStream} whose
+     * {@link java.nio.channels.FileChannel} position can be changed, should be less than 2 GiB in size if retries are used.
+     * This is because streams 2 GiB in size or larger do no guarantee that mark-and-reset can be performed. If the stream
+     * is larger, do not use built-in retries and manage retries yourself.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/UpdateLookupDataExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateLookupData API.
+     */
+    UpdateLookupDataResponse updateLookupData(UpdateLookupDataRequest request);
 
     /**
      * Update the scheduled task. Schedules may be updated only for taskType SAVED_SEARCH and PURGE.
@@ -1423,7 +1639,7 @@ public interface LogAnalytics extends AutoCloseable {
             ValidateAssociationParametersRequest request);
 
     /**
-     * Validates a log file to check whether it is eligible to upload or not.
+     * Validates a log file to check whether it is eligible to be uploaded or not.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -1454,7 +1670,7 @@ public interface LogAnalytics extends AutoCloseable {
             ValidateSourceExtendedFieldDetailsRequest request);
 
     /**
-     * Validates the source mapping for given file and provides match status and parsed representation of log data.
+     * Validates the source mapping for a given file and provides match status and the parsed representation of log data.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsAsync.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsAsync.java
@@ -47,7 +47,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Adds association between input source log analytics entity and destination entities.
+     * Adds association between input source log analytics entity and one or more existing destination entities.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -60,6 +60,23 @@ public interface LogAnalyticsAsync extends AutoCloseable {
             AddEntityAssociationRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             AddEntityAssociationRequest, AddEntityAssociationResponse>
+                    handler);
+
+    /**
+     * Append data to a lookup.  The file containing the information to append
+     * must be provided.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<AppendLookupDataResponse> appendLookupData(
+            AppendLookupDataRequest request,
+            com.oracle.bmc.responses.AsyncHandler<AppendLookupDataRequest, AppendLookupDataResponse>
                     handler);
 
     /**
@@ -131,7 +148,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Move the rule from it's current compartment to given compartment.
+     * Move the rule from it's current compartment to the given compartment.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -233,7 +250,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Create a configuration to collect logs from object storage bucket.
+     * Creates a rule to collect logs from an object storage bucket.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -327,7 +344,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Delete the log analytics entity type with the given name.
+     * Delete log analytics entity type with the given name.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -360,8 +377,8 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes a configured object storage bucket based collection rule to stop the log collection of the configured bucket .
-     * It will not delete the already collected log data from the configured bucket.
+     * Deletes the configured object storage bucket based collection rule and stop the log collection.
+     * It will not delete the existing processed data associated with this bucket from logging analytics storage.
      *
      *
      * @param request The request object containing the details to send
@@ -378,6 +395,22 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                                     DeleteLogAnalyticsObjectCollectionRuleRequest,
                                     DeleteLogAnalyticsObjectCollectionRuleResponse>
                             handler);
+
+    /**
+     * Delete the specified lookup.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteLookupResponse> deleteLookup(
+            DeleteLookupRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteLookupRequest, DeleteLookupResponse>
+                    handler);
 
     /**
      * delete parser with specified name
@@ -443,8 +476,8 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes a specific log file inside an upload by providing upload file reference.
-     * It deletes all the logs in storage asscoiated with the upload file and the corresponding upload metadata.
+     * Deletes a specific log file inside an upload by upload file reference.
+     * It deletes all the logs from storage associated with the file and the corresponding metadata.
      *
      *
      * @param request The request object containing the details to send
@@ -523,6 +556,40 @@ public interface LogAnalyticsAsync extends AutoCloseable {
             EstimatePurgeDataSizeRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             EstimatePurgeDataSizeRequest, EstimatePurgeDataSizeResponse>
+                    handler);
+
+    /**
+     * This API gives an active storage usage estimate for archived data to be recalled and the time range of such data.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<EstimateRecallDataSizeResponse> estimateRecallDataSize(
+            EstimateRecallDataSizeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            EstimateRecallDataSizeRequest, EstimateRecallDataSizeResponse>
+                    handler);
+
+    /**
+     * This API gives an active storage usage estimate for recalled data to be released and the time range of such data.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<EstimateReleaseDataSizeResponse> estimateReleaseDataSize(
+            EstimateReleaseDataSizeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            EstimateReleaseDataSizeRequest, EstimateReleaseDataSizeResponse>
                     handler);
 
     /**
@@ -713,7 +780,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Returns log analytics entities count summary.
+     * Returns log analytics entities count summary report.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -813,6 +880,21 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                                     GetLogAnalyticsObjectCollectionRuleRequest,
                                     GetLogAnalyticsObjectCollectionRuleResponse>
                             handler);
+
+    /**
+     * Obtains the lookup with the specified reference.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetLookupResponse> getLookup(
+            GetLookupRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetLookupRequest, GetLookupResponse> handler);
 
     /**
      * This API gets the namespace details of a tenancy already onboarded in Logging Analytics Application
@@ -987,7 +1069,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets an On-Demand Upload info by reference
+     * Gets an On-Demand Upload info by reference.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -1205,7 +1287,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets list of configuration details of Object Storage based collection rules.
+     * Gets list of collection rules.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -1221,6 +1303,22 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                                     ListLogAnalyticsObjectCollectionRulesRequest,
                                     ListLogAnalyticsObjectCollectionRulesResponse>
                             handler);
+
+    /**
+     * Obtains a list of lookups.  The list is filtered according to the filter criteria
+     * specified by the user, and sorted according to the ordering criteria specified.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListLookupsResponse> listLookups(
+            ListLookupsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListLookupsRequest, ListLookupsResponse> handler);
 
     /**
      * get all meta source types
@@ -1315,6 +1413,22 @@ public interface LogAnalyticsAsync extends AutoCloseable {
             ListQueryWorkRequestsRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ListQueryWorkRequestsRequest, ListQueryWorkRequestsResponse>
+                    handler);
+
+    /**
+     * This API returns the list of recalled data of a tenancy.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListRecalledDataResponse> listRecalledData(
+            ListRecalledDataRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListRecalledDataRequest, ListRecalledDataResponse>
                     handler);
 
     /**
@@ -1464,7 +1578,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets the list of character encodings supported for log files.
+     * Gets list of character encodings which are supported by on-demand upload.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -1480,7 +1594,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets timezones that are supported when performing uploads.
+     * Gets list of timezones which are supported by on-demand upload.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -1496,7 +1610,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets list of files in an upload.
+     * Gets list of files in an upload along with its processing state.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -1511,7 +1625,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets list of warnings in an upload explaining the failures due to incorrect configuration.
+     * Gets list of warnings in an upload caused by incorrect configuration.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -1541,6 +1655,23 @@ public interface LogAnalyticsAsync extends AutoCloseable {
     java.util.concurrent.Future<ListUploadsResponse> listUploads(
             ListUploadsRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListUploadsRequest, ListUploadsResponse> handler);
+
+    /**
+     * Obtains a list of warnings.  The list is filtered according to the filter criteria
+     * specified by the user, and sorted according to the ordering criteria specified.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListWarningsResponse> listWarnings(
+            ListWarningsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListWarningsRequest, ListWarningsResponse>
+                    handler);
 
     /**
      * Return a (paginated) list of errors for a given work request.
@@ -1637,6 +1768,23 @@ public interface LogAnalyticsAsync extends AutoCloseable {
     java.util.concurrent.Future<ParseQueryResponse> parseQuery(
             ParseQueryRequest request,
             com.oracle.bmc.responses.AsyncHandler<ParseQueryRequest, ParseQueryResponse> handler);
+
+    /**
+     * Pause the scheduled task specified by {scheduledTaskId}.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<PauseScheduledTaskResponse> pauseScheduledTask(
+            PauseScheduledTaskRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            PauseScheduledTaskRequest, PauseScheduledTaskResponse>
+                    handler);
 
     /**
      * This API submits a work request to purge data. Only data from log groups that the user has permission to delete
@@ -1754,6 +1902,23 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Resume the scheduled task specified by {scheduledTaskId}.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ResumeScheduledTaskResponse> resumeScheduledTask(
+            ResumeScheduledTaskRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ResumeScheduledTaskRequest, ResumeScheduledTaskResponse>
+                    handler);
+
+    /**
      * Execute the saved search acceleration task in the foreground.
      * The ScheduledTask taskType must be ACCELERATION.
      * Optionally specify time range (timeStart and timeEnd). The default is all time.
@@ -1785,6 +1950,24 @@ public interface LogAnalyticsAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<SuggestRequest, SuggestResponse> handler);
 
     /**
+     * Accepts a list of warnings.  Any unsuppressed warnings in the input list will
+     * be suppressed.  Warnings in the input list which are already suppressed will
+     * not be modified.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SuppressWarningResponse> suppressWarning(
+            SuppressWarningRequest request,
+            com.oracle.bmc.responses.AsyncHandler<SuppressWarningRequest, SuppressWarningResponse>
+                    handler);
+
+    /**
      * test parser
      *
      * @param request The request object containing the details to send
@@ -1797,6 +1980,25 @@ public interface LogAnalyticsAsync extends AutoCloseable {
     java.util.concurrent.Future<TestParserResponse> testParser(
             TestParserRequest request,
             com.oracle.bmc.responses.AsyncHandler<TestParserRequest, TestParserResponse> handler);
+
+    /**
+     * Accepts a list of warnings.  Any suppressed warnings in the input list will
+     * be unsuppressed.  Warnings in the input list which are unsuppressed will
+     * not be modified.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UnsuppressWarningResponse> unsuppressWarning(
+            UnsuppressWarningRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UnsuppressWarningRequest, UnsuppressWarningResponse>
+                    handler);
 
     /**
      * Update the log analytics entity with the given id.
@@ -1848,7 +2050,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Update the rule with the given id.
+     * Updates configuration of the object collection rule for the given id.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -1864,6 +2066,39 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                                     UpdateLogAnalyticsObjectCollectionRuleRequest,
                                     UpdateLogAnalyticsObjectCollectionRuleResponse>
                             handler);
+
+    /**
+     * Updates the metadata of the specified lookup, such as the lookup description.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateLookupResponse> updateLookup(
+            UpdateLookupRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateLookupRequest, UpdateLookupResponse>
+                    handler);
+
+    /**
+     * Updates the specified lookup with the details provided.  This API will not update
+     * lookup metadata (such as lookup description).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateLookupDataResponse> updateLookupData(
+            UpdateLookupDataRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateLookupDataRequest, UpdateLookupDataResponse>
+                    handler);
 
     /**
      * Update the scheduled task. Schedules may be updated only for taskType SAVED_SEARCH and PURGE.
@@ -2006,7 +2241,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Validates a log file to check whether it is eligible to upload or not.
+     * Validates a log file to check whether it is eligible to be uploaded or not.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -2054,7 +2289,7 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Validates the source mapping for given file and provides match status and parsed representation of log data.
+     * Validates the source mapping for a given file and provides match status and the parsed representation of log data.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsAsyncClient.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsAsyncClient.java
@@ -368,6 +368,58 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<AppendLookupDataResponse> appendLookupData(
+            AppendLookupDataRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            AppendLookupDataRequest, AppendLookupDataResponse>
+                    handler) {
+        LOG.trace("Called async appendLookupData");
+        if (request.getRetryConfiguration() != null
+                || authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            request =
+                    com.oracle.bmc.retrier.Retriers.wrapBodyInputStreamIfNecessary(
+                            request, AppendLookupDataRequest.builder());
+        }
+        final AppendLookupDataRequest interceptedRequest =
+                AppendLookupDataConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AppendLookupDataConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, AppendLookupDataResponse>
+                transformer = AppendLookupDataConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<AppendLookupDataRequest, AppendLookupDataResponse>
+                handlerToUse =
+                        new com.oracle.bmc.responses.internal.StreamClosingAsyncHandler<>(handler);
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                AppendLookupDataRequest, AppendLookupDataResponse>,
+                        java.util.concurrent.Future<AppendLookupDataResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    AppendLookupDataRequest, AppendLookupDataResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {
+                    LOG.debug("Resetting stream");
+                    com.oracle.bmc.retrier.Retriers.tryResetStreamForRetry(
+                            interceptedRequest.getAppendLookupFileBody(), true);
+                }
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<BatchGetBasicInfoResponse> batchGetBasicInfo(
             BatchGetBasicInfoRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -1191,6 +1243,45 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DeleteLookupResponse> deleteLookup(
+            DeleteLookupRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<DeleteLookupRequest, DeleteLookupResponse>
+                    handler) {
+        LOG.trace("Called async deleteLookup");
+        final DeleteLookupRequest interceptedRequest =
+                DeleteLookupConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteLookupConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteLookupResponse>
+                transformer = DeleteLookupConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteLookupRequest, DeleteLookupResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteLookupRequest, DeleteLookupResponse>,
+                        java.util.concurrent.Future<DeleteLookupResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteLookupRequest, DeleteLookupResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<DeleteParserResponse> deleteParser(
             DeleteParserRequest request,
             final com.oracle.bmc.responses.AsyncHandler<DeleteParserRequest, DeleteParserResponse>
@@ -1535,6 +1626,88 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     EstimatePurgeDataSizeRequest, EstimatePurgeDataSizeResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<EstimateRecallDataSizeResponse> estimateRecallDataSize(
+            EstimateRecallDataSizeRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            EstimateRecallDataSizeRequest, EstimateRecallDataSizeResponse>
+                    handler) {
+        LOG.trace("Called async estimateRecallDataSize");
+        final EstimateRecallDataSizeRequest interceptedRequest =
+                EstimateRecallDataSizeConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                EstimateRecallDataSizeConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, EstimateRecallDataSizeResponse>
+                transformer = EstimateRecallDataSizeConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        EstimateRecallDataSizeRequest, EstimateRecallDataSizeResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                EstimateRecallDataSizeRequest, EstimateRecallDataSizeResponse>,
+                        java.util.concurrent.Future<EstimateRecallDataSizeResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    EstimateRecallDataSizeRequest, EstimateRecallDataSizeResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<EstimateReleaseDataSizeResponse> estimateReleaseDataSize(
+            EstimateReleaseDataSizeRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            EstimateReleaseDataSizeRequest, EstimateReleaseDataSizeResponse>
+                    handler) {
+        LOG.trace("Called async estimateReleaseDataSize");
+        final EstimateReleaseDataSizeRequest interceptedRequest =
+                EstimateReleaseDataSizeConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                EstimateReleaseDataSizeConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, EstimateReleaseDataSizeResponse>
+                transformer = EstimateReleaseDataSizeConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        EstimateReleaseDataSizeRequest, EstimateReleaseDataSizeResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                EstimateReleaseDataSizeRequest, EstimateReleaseDataSizeResponse>,
+                        java.util.concurrent.Future<EstimateReleaseDataSizeResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    EstimateReleaseDataSizeRequest, EstimateReleaseDataSizeResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -2277,6 +2450,42 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetLogAnalyticsObjectCollectionRuleRequest,
                     GetLogAnalyticsObjectCollectionRuleResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetLookupResponse> getLookup(
+            GetLookupRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetLookupRequest, GetLookupResponse>
+                    handler) {
+        LOG.trace("Called async getLookup");
+        final GetLookupRequest interceptedRequest = GetLookupConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetLookupConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetLookupResponse>
+                transformer = GetLookupConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetLookupRequest, GetLookupResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<GetLookupRequest, GetLookupResponse>,
+                        java.util.concurrent.Future<GetLookupResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetLookupRequest, GetLookupResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -3340,6 +3549,44 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListLookupsResponse> listLookups(
+            ListLookupsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListLookupsRequest, ListLookupsResponse>
+                    handler) {
+        LOG.trace("Called async listLookups");
+        final ListLookupsRequest interceptedRequest =
+                ListLookupsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListLookupsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListLookupsResponse>
+                transformer = ListLookupsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListLookupsRequest, ListLookupsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListLookupsRequest, ListLookupsResponse>,
+                        java.util.concurrent.Future<ListLookupsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListLookupsRequest, ListLookupsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListMetaSourceTypesResponse> listMetaSourceTypes(
             ListMetaSourceTypesRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -3568,6 +3815,45 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListQueryWorkRequestsRequest, ListQueryWorkRequestsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListRecalledDataResponse> listRecalledData(
+            ListRecalledDataRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListRecalledDataRequest, ListRecalledDataResponse>
+                    handler) {
+        LOG.trace("Called async listRecalledData");
+        final ListRecalledDataRequest interceptedRequest =
+                ListRecalledDataConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListRecalledDataConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListRecalledDataResponse>
+                transformer = ListRecalledDataConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListRecalledDataRequest, ListRecalledDataResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListRecalledDataRequest, ListRecalledDataResponse>,
+                        java.util.concurrent.Future<ListRecalledDataResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListRecalledDataRequest, ListRecalledDataResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -4152,6 +4438,44 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListWarningsResponse> listWarnings(
+            ListWarningsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListWarningsRequest, ListWarningsResponse>
+                    handler) {
+        LOG.trace("Called async listWarnings");
+        final ListWarningsRequest interceptedRequest =
+                ListWarningsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWarningsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListWarningsResponse>
+                transformer = ListWarningsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListWarningsRequest, ListWarningsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListWarningsRequest, ListWarningsResponse>,
+                        java.util.concurrent.Future<ListWarningsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListWarningsRequest, ListWarningsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListWorkRequestErrorsResponse> listWorkRequestErrors(
             ListWorkRequestErrorsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -4377,6 +4701,45 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ParseQueryRequest, ParseQueryResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<PauseScheduledTaskResponse> pauseScheduledTask(
+            PauseScheduledTaskRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            PauseScheduledTaskRequest, PauseScheduledTaskResponse>
+                    handler) {
+        LOG.trace("Called async pauseScheduledTask");
+        final PauseScheduledTaskRequest interceptedRequest =
+                PauseScheduledTaskConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                PauseScheduledTaskConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, PauseScheduledTaskResponse>
+                transformer = PauseScheduledTaskConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<PauseScheduledTaskRequest, PauseScheduledTaskResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                PauseScheduledTaskRequest, PauseScheduledTaskResponse>,
+                        java.util.concurrent.Future<PauseScheduledTaskResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    PauseScheduledTaskRequest, PauseScheduledTaskResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -4684,6 +5047,47 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ResumeScheduledTaskResponse> resumeScheduledTask(
+            ResumeScheduledTaskRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ResumeScheduledTaskRequest, ResumeScheduledTaskResponse>
+                    handler) {
+        LOG.trace("Called async resumeScheduledTask");
+        final ResumeScheduledTaskRequest interceptedRequest =
+                ResumeScheduledTaskConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ResumeScheduledTaskConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ResumeScheduledTaskResponse>
+                transformer = ResumeScheduledTaskConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ResumeScheduledTaskRequest, ResumeScheduledTaskResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ResumeScheduledTaskRequest, ResumeScheduledTaskResponse>,
+                        java.util.concurrent.Future<ResumeScheduledTaskResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ResumeScheduledTaskRequest, ResumeScheduledTaskResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<RunResponse> run(
             RunRequest request,
             final com.oracle.bmc.responses.AsyncHandler<RunRequest, RunResponse> handler) {
@@ -4754,6 +5158,46 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<SuppressWarningResponse> suppressWarning(
+            SuppressWarningRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            SuppressWarningRequest, SuppressWarningResponse>
+                    handler) {
+        LOG.trace("Called async suppressWarning");
+        final SuppressWarningRequest interceptedRequest =
+                SuppressWarningConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SuppressWarningConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, SuppressWarningResponse>
+                transformer = SuppressWarningConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<SuppressWarningRequest, SuppressWarningResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SuppressWarningRequest, SuppressWarningResponse>,
+                        java.util.concurrent.Future<SuppressWarningResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SuppressWarningRequest, SuppressWarningResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<TestParserResponse> testParser(
             TestParserRequest request,
             final com.oracle.bmc.responses.AsyncHandler<TestParserRequest, TestParserResponse>
@@ -4779,6 +5223,46 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     TestParserRequest, TestParserResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UnsuppressWarningResponse> unsuppressWarning(
+            UnsuppressWarningRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UnsuppressWarningRequest, UnsuppressWarningResponse>
+                    handler) {
+        LOG.trace("Called async unsuppressWarning");
+        final UnsuppressWarningRequest interceptedRequest =
+                UnsuppressWarningConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UnsuppressWarningConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UnsuppressWarningResponse>
+                transformer = UnsuppressWarningConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<UnsuppressWarningRequest, UnsuppressWarningResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UnsuppressWarningRequest, UnsuppressWarningResponse>,
+                        java.util.concurrent.Future<UnsuppressWarningResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UnsuppressWarningRequest, UnsuppressWarningResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -4961,6 +5445,97 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
                     futureSupplier) {
                 @Override
                 protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateLookupResponse> updateLookup(
+            UpdateLookupRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<UpdateLookupRequest, UpdateLookupResponse>
+                    handler) {
+        LOG.trace("Called async updateLookup");
+        final UpdateLookupRequest interceptedRequest =
+                UpdateLookupConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateLookupConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateLookupResponse>
+                transformer = UpdateLookupConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateLookupRequest, UpdateLookupResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateLookupRequest, UpdateLookupResponse>,
+                        java.util.concurrent.Future<UpdateLookupResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateLookupRequest, UpdateLookupResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateLookupDataResponse> updateLookupData(
+            UpdateLookupDataRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateLookupDataRequest, UpdateLookupDataResponse>
+                    handler) {
+        LOG.trace("Called async updateLookupData");
+        if (request.getRetryConfiguration() != null
+                || authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            request =
+                    com.oracle.bmc.retrier.Retriers.wrapBodyInputStreamIfNecessary(
+                            request, UpdateLookupDataRequest.builder());
+        }
+        final UpdateLookupDataRequest interceptedRequest =
+                UpdateLookupDataConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateLookupDataConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateLookupDataResponse>
+                transformer = UpdateLookupDataConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateLookupDataRequest, UpdateLookupDataResponse>
+                handlerToUse =
+                        new com.oracle.bmc.responses.internal.StreamClosingAsyncHandler<>(handler);
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateLookupDataRequest, UpdateLookupDataResponse>,
+                        java.util.concurrent.Future<UpdateLookupDataResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateLookupDataRequest, UpdateLookupDataResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {
+                    LOG.debug("Resetting stream");
+                    com.oracle.bmc.retrier.Retriers.tryResetStreamForRetry(
+                            interceptedRequest.getUpdateLookupFileBody(), true);
+                }
             };
         } else {
             return futureSupplier.apply(handlerToUse);

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsClient.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsClient.java
@@ -475,6 +475,69 @@ public class LogAnalyticsClient implements LogAnalytics {
     }
 
     @Override
+    public AppendLookupDataResponse appendLookupData(AppendLookupDataRequest request) {
+        LOG.trace("Called appendLookupData");
+        try {
+            if (request.getRetryConfiguration() != null
+                    || retryConfiguration != null
+                    || authenticationDetailsProvider
+                            instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+                request =
+                        com.oracle.bmc.retrier.Retriers.wrapBodyInputStreamIfNecessary(
+                                request, AppendLookupDataRequest.builder());
+            }
+            final AppendLookupDataRequest interceptedRequest =
+                    AppendLookupDataConverter.interceptRequest(request);
+            com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                    AppendLookupDataConverter.fromRequest(client, interceptedRequest);
+            com.google.common.base.Function<javax.ws.rs.core.Response, AppendLookupDataResponse>
+                    transformer = AppendLookupDataConverter.fromResponse();
+
+            final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                    com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                            interceptedRequest.getRetryConfiguration(), retryConfiguration);
+            com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+            return retrier.execute(
+                    interceptedRequest,
+                    retryRequest -> {
+                        final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                                new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                        authenticationDetailsProvider);
+                        return tokenRefreshRetrier.execute(
+                                retryRequest,
+                                retriedRequest -> {
+                                    try {
+                                        javax.ws.rs.core.Response response =
+                                                client.post(
+                                                        ib,
+                                                        retriedRequest.getAppendLookupFileBody(),
+                                                        retriedRequest);
+                                        return transformer.apply(response);
+                                    } catch (RuntimeException e) {
+                                        if (interceptedRequest.getRetryConfiguration() != null
+                                                || retryConfiguration != null
+                                                || (e instanceof com.oracle.bmc.model.BmcException
+                                                        && tokenRefreshRetrier
+                                                                .getRetryCondition()
+                                                                .shouldBeRetried(
+                                                                        (com.oracle.bmc.model
+                                                                                        .BmcException)
+                                                                                e))) {
+                                            com.oracle.bmc.retrier.Retriers.tryResetStreamForRetry(
+                                                    interceptedRequest.getAppendLookupFileBody(),
+                                                    true);
+                                        }
+                                        throw e; // rethrow
+                                    }
+                                });
+                    });
+        } finally {
+            com.oracle.bmc.io.internal.KeepOpenInputStream.closeStream(
+                    request.getAppendLookupFileBody());
+        }
+    }
+
+    @Override
     public BatchGetBasicInfoResponse batchGetBasicInfo(BatchGetBasicInfoRequest request) {
         LOG.trace("Called batchGetBasicInfo");
         final BatchGetBasicInfoRequest interceptedRequest =
@@ -1109,6 +1172,36 @@ public class LogAnalyticsClient implements LogAnalytics {
     }
 
     @Override
+    public DeleteLookupResponse deleteLookup(DeleteLookupRequest request) {
+        LOG.trace("Called deleteLookup");
+        final DeleteLookupRequest interceptedRequest =
+                DeleteLookupConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteLookupConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteLookupResponse>
+                transformer = DeleteLookupConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public DeleteParserResponse deleteParser(DeleteParserRequest request) {
         LOG.trace("Called deleteParser");
         final DeleteParserRequest interceptedRequest =
@@ -1370,6 +1463,72 @@ public class LogAnalyticsClient implements LogAnalytics {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getEstimatePurgeDataSizeDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public EstimateRecallDataSizeResponse estimateRecallDataSize(
+            EstimateRecallDataSizeRequest request) {
+        LOG.trace("Called estimateRecallDataSize");
+        final EstimateRecallDataSizeRequest interceptedRequest =
+                EstimateRecallDataSizeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                EstimateRecallDataSizeConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, EstimateRecallDataSizeResponse>
+                transformer = EstimateRecallDataSizeConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getEstimateRecallDataSizeDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public EstimateReleaseDataSizeResponse estimateReleaseDataSize(
+            EstimateReleaseDataSizeRequest request) {
+        LOG.trace("Called estimateReleaseDataSize");
+        final EstimateReleaseDataSizeRequest interceptedRequest =
+                EstimateReleaseDataSizeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                EstimateReleaseDataSizeConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, EstimateReleaseDataSizeResponse>
+                transformer = EstimateReleaseDataSizeConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getEstimateReleaseDataSizeDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -1898,6 +2057,33 @@ public class LogAnalyticsClient implements LogAnalytics {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, GetLogAnalyticsObjectCollectionRuleResponse>
                 transformer = GetLogAnalyticsObjectCollectionRuleConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetLookupResponse getLookup(GetLookupRequest request) {
+        LOG.trace("Called getLookup");
+        final GetLookupRequest interceptedRequest = GetLookupConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetLookupConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetLookupResponse> transformer =
+                GetLookupConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -2692,6 +2878,34 @@ public class LogAnalyticsClient implements LogAnalytics {
     }
 
     @Override
+    public ListLookupsResponse listLookups(ListLookupsRequest request) {
+        LOG.trace("Called listLookups");
+        final ListLookupsRequest interceptedRequest =
+                ListLookupsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListLookupsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListLookupsResponse>
+                transformer = ListLookupsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListMetaSourceTypesResponse listMetaSourceTypes(ListMetaSourceTypesRequest request) {
         LOG.trace("Called listMetaSourceTypes");
         final ListMetaSourceTypesRequest interceptedRequest =
@@ -2842,6 +3056,34 @@ public class LogAnalyticsClient implements LogAnalytics {
                 ListQueryWorkRequestsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListQueryWorkRequestsResponse>
                 transformer = ListQueryWorkRequestsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListRecalledDataResponse listRecalledData(ListRecalledDataRequest request) {
+        LOG.trace("Called listRecalledData");
+        final ListRecalledDataRequest interceptedRequest =
+                ListRecalledDataConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListRecalledDataConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListRecalledDataResponse>
+                transformer = ListRecalledDataConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -3265,6 +3507,34 @@ public class LogAnalyticsClient implements LogAnalytics {
     }
 
     @Override
+    public ListWarningsResponse listWarnings(ListWarningsRequest request) {
+        LOG.trace("Called listWarnings");
+        final ListWarningsRequest interceptedRequest =
+                ListWarningsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWarningsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListWarningsResponse>
+                transformer = ListWarningsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListWorkRequestErrorsResponse listWorkRequestErrors(
             ListWorkRequestErrorsRequest request) {
         LOG.trace("Called listWorkRequestErrors");
@@ -3435,6 +3705,35 @@ public class LogAnalyticsClient implements LogAnalytics {
                                                 ib,
                                                 retriedRequest.getParseQueryDetails(),
                                                 retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public PauseScheduledTaskResponse pauseScheduledTask(PauseScheduledTaskRequest request) {
+        LOG.trace("Called pauseScheduledTask");
+        final PauseScheduledTaskRequest interceptedRequest =
+                PauseScheduledTaskConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                PauseScheduledTaskConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, PauseScheduledTaskResponse>
+                transformer = PauseScheduledTaskConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });
@@ -3700,6 +3999,35 @@ public class LogAnalyticsClient implements LogAnalytics {
     }
 
     @Override
+    public ResumeScheduledTaskResponse resumeScheduledTask(ResumeScheduledTaskRequest request) {
+        LOG.trace("Called resumeScheduledTask");
+        final ResumeScheduledTaskRequest interceptedRequest =
+                ResumeScheduledTaskConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ResumeScheduledTaskConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ResumeScheduledTaskResponse>
+                transformer = ResumeScheduledTaskConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public RunResponse run(RunRequest request) {
         LOG.trace("Called run");
         final RunRequest interceptedRequest = RunConverter.interceptRequest(request);
@@ -3760,6 +4088,39 @@ public class LogAnalyticsClient implements LogAnalytics {
     }
 
     @Override
+    public SuppressWarningResponse suppressWarning(SuppressWarningRequest request) {
+        LOG.trace("Called suppressWarning");
+        final SuppressWarningRequest interceptedRequest =
+                SuppressWarningConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SuppressWarningConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, SuppressWarningResponse>
+                transformer = SuppressWarningConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getWarningReferenceDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public TestParserResponse testParser(TestParserRequest request) {
         LOG.trace("Called testParser");
         final TestParserRequest interceptedRequest = TestParserConverter.interceptRequest(request);
@@ -3785,6 +4146,39 @@ public class LogAnalyticsClient implements LogAnalytics {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getTestParserPayloadDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UnsuppressWarningResponse unsuppressWarning(UnsuppressWarningRequest request) {
+        LOG.trace("Called unsuppressWarning");
+        final UnsuppressWarningRequest interceptedRequest =
+                UnsuppressWarningConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UnsuppressWarningConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UnsuppressWarningResponse>
+                transformer = UnsuppressWarningConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getWarningReferenceDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -3928,6 +4322,102 @@ public class LogAnalyticsClient implements LogAnalytics {
                                 return transformer.apply(response);
                             });
                 });
+    }
+
+    @Override
+    public UpdateLookupResponse updateLookup(UpdateLookupRequest request) {
+        LOG.trace("Called updateLookup");
+        final UpdateLookupRequest interceptedRequest =
+                UpdateLookupConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateLookupConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateLookupResponse>
+                transformer = UpdateLookupConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateLookupMetadataDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateLookupDataResponse updateLookupData(UpdateLookupDataRequest request) {
+        LOG.trace("Called updateLookupData");
+        try {
+            if (request.getRetryConfiguration() != null
+                    || retryConfiguration != null
+                    || authenticationDetailsProvider
+                            instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+                request =
+                        com.oracle.bmc.retrier.Retriers.wrapBodyInputStreamIfNecessary(
+                                request, UpdateLookupDataRequest.builder());
+            }
+            final UpdateLookupDataRequest interceptedRequest =
+                    UpdateLookupDataConverter.interceptRequest(request);
+            com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                    UpdateLookupDataConverter.fromRequest(client, interceptedRequest);
+            com.google.common.base.Function<javax.ws.rs.core.Response, UpdateLookupDataResponse>
+                    transformer = UpdateLookupDataConverter.fromResponse();
+
+            final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                    com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                            interceptedRequest.getRetryConfiguration(), retryConfiguration);
+            com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+            return retrier.execute(
+                    interceptedRequest,
+                    retryRequest -> {
+                        final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                                new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                        authenticationDetailsProvider);
+                        return tokenRefreshRetrier.execute(
+                                retryRequest,
+                                retriedRequest -> {
+                                    try {
+                                        javax.ws.rs.core.Response response =
+                                                client.post(
+                                                        ib,
+                                                        retriedRequest.getUpdateLookupFileBody(),
+                                                        retriedRequest);
+                                        return transformer.apply(response);
+                                    } catch (RuntimeException e) {
+                                        if (interceptedRequest.getRetryConfiguration() != null
+                                                || retryConfiguration != null
+                                                || (e instanceof com.oracle.bmc.model.BmcException
+                                                        && tokenRefreshRetrier
+                                                                .getRetryCondition()
+                                                                .shouldBeRetried(
+                                                                        (com.oracle.bmc.model
+                                                                                        .BmcException)
+                                                                                e))) {
+                                            com.oracle.bmc.retrier.Retriers.tryResetStreamForRetry(
+                                                    interceptedRequest.getUpdateLookupFileBody(),
+                                                    true);
+                                        }
+                                        throw e; // rethrow
+                                    }
+                                });
+                    });
+        } finally {
+            com.oracle.bmc.io.internal.KeepOpenInputStream.closeStream(
+                    request.getUpdateLookupFileBody());
+        }
     }
 
     @Override

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsPaginators.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsPaginators.java
@@ -1451,6 +1451,116 @@ public class LogAnalyticsPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listLookups operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListLookupsResponse> listLookupsResponseIterator(
+            final ListLookupsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListLookupsRequest.Builder, ListLookupsRequest, ListLookupsResponse>(
+                new com.google.common.base.Supplier<ListLookupsRequest.Builder>() {
+                    @Override
+                    public ListLookupsRequest.Builder get() {
+                        return ListLookupsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListLookupsResponse, String>() {
+                    @Override
+                    public String apply(ListLookupsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListLookupsRequest.Builder>,
+                        ListLookupsRequest>() {
+                    @Override
+                    public ListLookupsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListLookupsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListLookupsRequest, ListLookupsResponse>() {
+                    @Override
+                    public ListLookupsResponse apply(ListLookupsRequest request) {
+                        return client.listLookups(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.loganalytics.model.LogAnalyticsLookup} objects
+     * contained in responses from the listLookups operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.loganalytics.model.LogAnalyticsLookup} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.loganalytics.model.LogAnalyticsLookup> listLookupsRecordIterator(
+            final ListLookupsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListLookupsRequest.Builder, ListLookupsRequest, ListLookupsResponse,
+                com.oracle.bmc.loganalytics.model.LogAnalyticsLookup>(
+                new com.google.common.base.Supplier<ListLookupsRequest.Builder>() {
+                    @Override
+                    public ListLookupsRequest.Builder get() {
+                        return ListLookupsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListLookupsResponse, String>() {
+                    @Override
+                    public String apply(ListLookupsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListLookupsRequest.Builder>,
+                        ListLookupsRequest>() {
+                    @Override
+                    public ListLookupsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListLookupsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListLookupsRequest, ListLookupsResponse>() {
+                    @Override
+                    public ListLookupsResponse apply(ListLookupsRequest request) {
+                        return client.listLookups(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListLookupsResponse,
+                        java.util.List<com.oracle.bmc.loganalytics.model.LogAnalyticsLookup>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.loganalytics.model.LogAnalyticsLookup>
+                            apply(ListLookupsResponse response) {
+                        return response.getLogAnalyticsLookupCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listMetaSourceTypes operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -2025,6 +2135,118 @@ public class LogAnalyticsPaginators {
                     public java.util.List<com.oracle.bmc.loganalytics.model.QueryWorkRequestSummary>
                             apply(ListQueryWorkRequestsResponse response) {
                         return response.getQueryWorkRequestCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listRecalledData operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListRecalledDataResponse> listRecalledDataResponseIterator(
+            final ListRecalledDataRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListRecalledDataRequest.Builder, ListRecalledDataRequest, ListRecalledDataResponse>(
+                new com.google.common.base.Supplier<ListRecalledDataRequest.Builder>() {
+                    @Override
+                    public ListRecalledDataRequest.Builder get() {
+                        return ListRecalledDataRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListRecalledDataResponse, String>() {
+                    @Override
+                    public String apply(ListRecalledDataResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListRecalledDataRequest.Builder>,
+                        ListRecalledDataRequest>() {
+                    @Override
+                    public ListRecalledDataRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListRecalledDataRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRecalledDataRequest, ListRecalledDataResponse>() {
+                    @Override
+                    public ListRecalledDataResponse apply(ListRecalledDataRequest request) {
+                        return client.listRecalledData(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.loganalytics.model.RecalledData} objects
+     * contained in responses from the listRecalledData operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.loganalytics.model.RecalledData} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.loganalytics.model.RecalledData> listRecalledDataRecordIterator(
+            final ListRecalledDataRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListRecalledDataRequest.Builder, ListRecalledDataRequest, ListRecalledDataResponse,
+                com.oracle.bmc.loganalytics.model.RecalledData>(
+                new com.google.common.base.Supplier<ListRecalledDataRequest.Builder>() {
+                    @Override
+                    public ListRecalledDataRequest.Builder get() {
+                        return ListRecalledDataRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListRecalledDataResponse, String>() {
+                    @Override
+                    public String apply(ListRecalledDataResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListRecalledDataRequest.Builder>,
+                        ListRecalledDataRequest>() {
+                    @Override
+                    public ListRecalledDataRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListRecalledDataRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRecalledDataRequest, ListRecalledDataResponse>() {
+                    @Override
+                    public ListRecalledDataResponse apply(ListRecalledDataRequest request) {
+                        return client.listRecalledData(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRecalledDataResponse,
+                        java.util.List<com.oracle.bmc.loganalytics.model.RecalledData>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.loganalytics.model.RecalledData> apply(
+                            ListRecalledDataResponse response) {
+                        return response.getRecalledDataCollection().getItems();
                     }
                 });
     }
@@ -3425,6 +3647,116 @@ public class LogAnalyticsPaginators {
                     public java.util.List<com.oracle.bmc.loganalytics.model.UploadSummary> apply(
                             ListUploadsResponse response) {
                         return response.getUploadCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listWarnings operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListWarningsResponse> listWarningsResponseIterator(
+            final ListWarningsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListWarningsRequest.Builder, ListWarningsRequest, ListWarningsResponse>(
+                new com.google.common.base.Supplier<ListWarningsRequest.Builder>() {
+                    @Override
+                    public ListWarningsRequest.Builder get() {
+                        return ListWarningsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWarningsResponse, String>() {
+                    @Override
+                    public String apply(ListWarningsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWarningsRequest.Builder>,
+                        ListWarningsRequest>() {
+                    @Override
+                    public ListWarningsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWarningsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListWarningsRequest, ListWarningsResponse>() {
+                    @Override
+                    public ListWarningsResponse apply(ListWarningsRequest request) {
+                        return client.listWarnings(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.loganalytics.model.LogAnalyticsWarning} objects
+     * contained in responses from the listWarnings operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.loganalytics.model.LogAnalyticsWarning} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.loganalytics.model.LogAnalyticsWarning>
+            listWarningsRecordIterator(final ListWarningsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListWarningsRequest.Builder, ListWarningsRequest, ListWarningsResponse,
+                com.oracle.bmc.loganalytics.model.LogAnalyticsWarning>(
+                new com.google.common.base.Supplier<ListWarningsRequest.Builder>() {
+                    @Override
+                    public ListWarningsRequest.Builder get() {
+                        return ListWarningsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWarningsResponse, String>() {
+                    @Override
+                    public String apply(ListWarningsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWarningsRequest.Builder>,
+                        ListWarningsRequest>() {
+                    @Override
+                    public ListWarningsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWarningsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListWarningsRequest, ListWarningsResponse>() {
+                    @Override
+                    public ListWarningsResponse apply(ListWarningsRequest request) {
+                        return client.listWarnings(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWarningsResponse,
+                        java.util.List<com.oracle.bmc.loganalytics.model.LogAnalyticsWarning>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.loganalytics.model.LogAnalyticsWarning>
+                            apply(ListWarningsResponse response) {
+                        return response.getLogAnalyticsWarningCollection().getItems();
                     }
                 });
     }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsWaiters.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsWaiters.java
@@ -233,16 +233,15 @@ public class LogAnalyticsWaiters {
      * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
      *
      * @param request the request to send
-     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
-     * @return a new {@code Waiter} instance
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
                     GetLogAnalyticsObjectCollectionRuleRequest,
                     GetLogAnalyticsObjectCollectionRuleResponse>
             forLogAnalyticsObjectCollectionRule(
                     GetLogAnalyticsObjectCollectionRuleRequest request,
-                    com.oracle.bmc.loganalytics.model.LogAnalyticsObjectCollectionRule
-                                    .LifecycleState...
+                    com.oracle.bmc.loganalytics.model.ObjectCollectionRuleLifecycleStates...
                             targetStates) {
         org.apache.commons.lang3.Validate.notEmpty(
                 targetStates, "At least one targetState must be provided");
@@ -267,8 +266,7 @@ public class LogAnalyticsWaiters {
                     GetLogAnalyticsObjectCollectionRuleResponse>
             forLogAnalyticsObjectCollectionRule(
                     GetLogAnalyticsObjectCollectionRuleRequest request,
-                    com.oracle.bmc.loganalytics.model.LogAnalyticsObjectCollectionRule
-                                    .LifecycleState
+                    com.oracle.bmc.loganalytics.model.ObjectCollectionRuleLifecycleStates
                             targetState,
                     com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
                     com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
@@ -287,7 +285,7 @@ public class LogAnalyticsWaiters {
      * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
      * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
      * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
-     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     * @return a new {@code Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
                     GetLogAnalyticsObjectCollectionRuleRequest,
@@ -296,13 +294,12 @@ public class LogAnalyticsWaiters {
                     GetLogAnalyticsObjectCollectionRuleRequest request,
                     com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
                     com.oracle.bmc.waiter.DelayStrategy delayStrategy,
-                    com.oracle.bmc.loganalytics.model.LogAnalyticsObjectCollectionRule
-                                    .LifecycleState...
+                    com.oracle.bmc.loganalytics.model.ObjectCollectionRuleLifecycleStates...
                             targetStates) {
         org.apache.commons.lang3.Validate.notEmpty(
-                targetStates, "At least one target state must be provided");
+                targetStates, "At least one targetState must be provided");
         org.apache.commons.lang3.Validate.noNullElements(
-                targetStates, "Null target states are not permitted");
+                targetStates, "Null targetState values are not permitted");
 
         return forLogAnalyticsObjectCollectionRule(
                 com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
@@ -317,12 +314,9 @@ public class LogAnalyticsWaiters {
             forLogAnalyticsObjectCollectionRule(
                     com.oracle.bmc.waiter.BmcGenericWaiter waiter,
                     final GetLogAnalyticsObjectCollectionRuleRequest request,
-                    final com.oracle.bmc.loganalytics.model.LogAnalyticsObjectCollectionRule
-                                    .LifecycleState...
+                    final com.oracle.bmc.loganalytics.model.ObjectCollectionRuleLifecycleStates...
                             targetStates) {
-        final java.util.Set<
-                        com.oracle.bmc.loganalytics.model.LogAnalyticsObjectCollectionRule
-                                .LifecycleState>
+        final java.util.Set<com.oracle.bmc.loganalytics.model.ObjectCollectionRuleLifecycleStates>
                 targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
 
         return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
@@ -349,8 +343,8 @@ public class LogAnalyticsWaiters {
                             }
                         },
                         targetStatesSet.contains(
-                                com.oracle.bmc.loganalytics.model.LogAnalyticsObjectCollectionRule
-                                        .LifecycleState.Deleted)),
+                                com.oracle.bmc.loganalytics.model
+                                        .ObjectCollectionRuleLifecycleStates.Deleted)),
                 request);
     }
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/AppendLookupDataConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/AppendLookupDataConverter.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class AppendLookupDataConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.AppendLookupDataRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.AppendLookupDataRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.AppendLookupDataRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notBlank(request.getLookupName(), "lookupName must not be blank");
+        Validate.notNull(request.getAppendLookupFileBody(), "appendLookupFileBody is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("lookups")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLookupName()))
+                        .path("actions")
+                        .path("appendData");
+
+        if (request.getIsForce() != null) {
+            target =
+                    target.queryParam(
+                            "isForce",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsForce()));
+        }
+
+        if (request.getCharEncoding() != null) {
+            target =
+                    target.queryParam(
+                            "charEncoding",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCharEncoding()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.AppendLookupDataResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.AppendLookupDataResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.AppendLookupDataResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.AppendLookupDataResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.AppendLookupDataResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.AppendLookupDataResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .AppendLookupDataResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.AppendLookupDataResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/DeleteLookupConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/DeleteLookupConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class DeleteLookupConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.DeleteLookupRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.DeleteLookupRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.DeleteLookupRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notBlank(request.getLookupName(), "lookupName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("lookups")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLookupName()));
+
+        if (request.getIsForce() != null) {
+            target =
+                    target.queryParam(
+                            "isForce",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsForce()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.DeleteLookupResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.DeleteLookupResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.DeleteLookupResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.DeleteLookupResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.DeleteLookupResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.DeleteLookupResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .DeleteLookupResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.DeleteLookupResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/EstimateRecallDataSizeConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/EstimateRecallDataSizeConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class EstimateRecallDataSizeConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.EstimateRecallDataSizeRequest
+            interceptRequest(
+                    com.oracle.bmc.loganalytics.requests.EstimateRecallDataSizeRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.EstimateRecallDataSizeRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notNull(
+                request.getEstimateRecallDataSizeDetails(),
+                "estimateRecallDataSizeDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("storage")
+                        .path("actions")
+                        .path("estimateRecallDataSize");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.EstimateRecallDataSizeResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.EstimateRecallDataSizeResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses
+                                        .EstimateRecallDataSizeResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses
+                                            .EstimateRecallDataSizeResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.EstimateRecallDataSizeResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        EstimateRecallDataSizeResult>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        EstimateRecallDataSizeResult.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                EstimateRecallDataSizeResult>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.EstimateRecallDataSizeResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .EstimateRecallDataSizeResponse.builder();
+
+                                builder.estimateRecallDataSizeResult(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.EstimateRecallDataSizeResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/EstimateReleaseDataSizeConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/EstimateReleaseDataSizeConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class EstimateReleaseDataSizeConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.EstimateReleaseDataSizeRequest
+            interceptRequest(
+                    com.oracle.bmc.loganalytics.requests.EstimateReleaseDataSizeRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.EstimateReleaseDataSizeRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notNull(
+                request.getEstimateReleaseDataSizeDetails(),
+                "estimateReleaseDataSizeDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("storage")
+                        .path("actions")
+                        .path("estimateReleaseDataSize");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.EstimateReleaseDataSizeResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.EstimateReleaseDataSizeResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses
+                                        .EstimateReleaseDataSizeResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses
+                                            .EstimateReleaseDataSizeResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.EstimateReleaseDataSizeResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        EstimateReleaseDataSizeResult>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        EstimateReleaseDataSizeResult.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                EstimateReleaseDataSizeResult>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses
+                                                .EstimateReleaseDataSizeResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .EstimateReleaseDataSizeResponse.builder();
+
+                                builder.estimateReleaseDataSizeResult(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses
+                                                .EstimateReleaseDataSizeResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/GetLookupConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/GetLookupConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class GetLookupConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.GetLookupRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.GetLookupRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.GetLookupRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notBlank(request.getLookupName(), "lookupName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("lookups")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLookupName()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.GetLookupResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.GetLookupResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.GetLookupResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.GetLookupResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.GetLookupResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        LogAnalyticsLookup>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        LogAnalyticsLookup.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<LogAnalyticsLookup>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.GetLookupResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .GetLookupResponse.builder();
+
+                                builder.logAnalyticsLookup(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.GetLookupResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListLookupsConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListLookupsConverter.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class ListLookupsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.ListLookupsRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.ListLookupsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.ListLookupsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notNull(request.getType(), "type is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("lookups");
+
+        if (request.getLookupDisplayText() != null) {
+            target =
+                    target.queryParam(
+                            "lookupDisplayText",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLookupDisplayText()));
+        }
+
+        target =
+                target.queryParam(
+                        "type",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getType().getValue()));
+
+        if (request.getIsSystem() != null) {
+            target =
+                    target.queryParam(
+                            "isSystem",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsSystem().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getStatus() != null) {
+            target =
+                    target.queryParam(
+                            "status",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getStatus().getValue()));
+        }
+
+        if (request.getIsHideSpecial() != null) {
+            target =
+                    target.queryParam(
+                            "isHideSpecial",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsHideSpecial()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.ListLookupsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.ListLookupsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.ListLookupsResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.ListLookupsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.ListLookupsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        LogAnalyticsLookupCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        LogAnalyticsLookupCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                LogAnalyticsLookupCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.ListLookupsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .ListLookupsResponse.builder();
+
+                                builder.logAnalyticsLookupCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.ListLookupsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListMetaSourceTypesConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListMetaSourceTypesConverter.java
@@ -59,7 +59,7 @@ public class ListMetaSourceTypesConverter {
                     target.queryParam(
                             "sortBy",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getSortBy()));
+                                    request.getSortBy().getValue()));
         }
 
         if (request.getSortOrder() != null) {

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListParserFunctionsConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListParserFunctionsConverter.java
@@ -67,7 +67,7 @@ public class ListParserFunctionsConverter {
                     target.queryParam(
                             "sortBy",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getSortBy()));
+                                    request.getSortBy().getValue()));
         }
 
         if (request.getSortOrder() != null) {

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListParserMetaPluginsConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListParserMetaPluginsConverter.java
@@ -60,7 +60,7 @@ public class ListParserMetaPluginsConverter {
                     target.queryParam(
                             "sortBy",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getSortBy()));
+                                    request.getSortBy().getValue()));
         }
 
         if (request.getSortOrder() != null) {

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListRecalledDataConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListRecalledDataConverter.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class ListRecalledDataConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.ListRecalledDataRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.ListRecalledDataRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.ListRecalledDataRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("storage")
+                        .path("recalledData");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getTimeDataStartedGreaterThanOrEqual() != null) {
+            target =
+                    target.queryParam(
+                            "timeDataStartedGreaterThanOrEqual",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeDataStartedGreaterThanOrEqual()));
+        }
+
+        if (request.getTimeDataEndedLessThan() != null) {
+            target =
+                    target.queryParam(
+                            "timeDataEndedLessThan",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeDataEndedLessThan()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.ListRecalledDataResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.ListRecalledDataResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.ListRecalledDataResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.ListRecalledDataResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.ListRecalledDataResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        RecalledDataCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        RecalledDataCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<RecalledDataCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.ListRecalledDataResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .ListRecalledDataResponse.builder();
+
+                                builder.recalledDataCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.ListRecalledDataResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListSourceLabelOperatorsConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListSourceLabelOperatorsConverter.java
@@ -60,7 +60,7 @@ public class ListSourceLabelOperatorsConverter {
                     target.queryParam(
                             "sortBy",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getSortBy()));
+                                    request.getSortBy().getValue()));
         }
 
         if (request.getSortOrder() != null) {

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListSourceMetaFunctionsConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListSourceMetaFunctionsConverter.java
@@ -60,7 +60,7 @@ public class ListSourceMetaFunctionsConverter {
                     target.queryParam(
                             "sortBy",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getSortBy()));
+                                    request.getSortBy().getValue()));
         }
 
         if (request.getSortOrder() != null) {

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListWarningsConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ListWarningsConverter.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class ListWarningsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.ListWarningsRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.ListWarningsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.ListWarningsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("warnings");
+
+        if (request.getWarningState() != null) {
+            target =
+                    target.queryParam(
+                            "warningState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getWarningState().getValue()));
+        }
+
+        if (request.getSourceName() != null) {
+            target =
+                    target.queryParam(
+                            "sourceName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSourceName()));
+        }
+
+        if (request.getSourcePattern() != null) {
+            target =
+                    target.queryParam(
+                            "sourcePattern",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSourcePattern()));
+        }
+
+        if (request.getWarningMessage() != null) {
+            target =
+                    target.queryParam(
+                            "warningMessage",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getWarningMessage()));
+        }
+
+        if (request.getEntityName() != null) {
+            target =
+                    target.queryParam(
+                            "entityName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEntityName()));
+        }
+
+        if (request.getEntityType() != null) {
+            target =
+                    target.queryParam(
+                            "entityType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEntityType()));
+        }
+
+        if (request.getWarningType() != null) {
+            target =
+                    target.queryParam(
+                            "warningType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getWarningType()));
+        }
+
+        if (request.getIsNoSource() != null) {
+            target =
+                    target.queryParam(
+                            "isNoSource",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsNoSource()));
+        }
+
+        if (request.getStartTime() != null) {
+            target =
+                    target.queryParam(
+                            "startTime",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getStartTime()));
+        }
+
+        if (request.getEndTime() != null) {
+            target =
+                    target.queryParam(
+                            "endTime",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndTime()));
+        }
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.ListWarningsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.ListWarningsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.ListWarningsResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.ListWarningsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.ListWarningsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        LogAnalyticsWarningCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        LogAnalyticsWarningCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                LogAnalyticsWarningCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.ListWarningsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .ListWarningsResponse.builder();
+
+                                builder.logAnalyticsWarningCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.ListWarningsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/PauseScheduledTaskConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/PauseScheduledTaskConverter.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class PauseScheduledTaskConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.PauseScheduledTaskRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.PauseScheduledTaskRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.PauseScheduledTaskRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notBlank(request.getScheduledTaskId(), "scheduledTaskId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("scheduledTasks")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getScheduledTaskId()))
+                        .path("actions")
+                        .path("pause");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.PauseScheduledTaskResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.PauseScheduledTaskResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses
+                                        .PauseScheduledTaskResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.PauseScheduledTaskResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.PauseScheduledTaskResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ScheduledTask>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ScheduledTask.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ScheduledTask> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.PauseScheduledTaskResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .PauseScheduledTaskResponse.builder();
+
+                                if (response.getStatusCode() != 304) {
+                                    builder.scheduledTask(response.getItem());
+                                    builder.isNotModified(false);
+                                } else {
+                                    builder.isNotModified(true);
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.PauseScheduledTaskResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ResumeScheduledTaskConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ResumeScheduledTaskConverter.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class ResumeScheduledTaskConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.ResumeScheduledTaskRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.ResumeScheduledTaskRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.ResumeScheduledTaskRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notBlank(request.getScheduledTaskId(), "scheduledTaskId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("scheduledTasks")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getScheduledTaskId()))
+                        .path("actions")
+                        .path("resume");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.ResumeScheduledTaskResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.ResumeScheduledTaskResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses
+                                        .ResumeScheduledTaskResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.ResumeScheduledTaskResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.ResumeScheduledTaskResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ScheduledTask>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ScheduledTask.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ScheduledTask> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.ResumeScheduledTaskResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .ResumeScheduledTaskResponse.builder();
+
+                                if (response.getStatusCode() != 304) {
+                                    builder.scheduledTask(response.getItem());
+                                    builder.isNotModified(false);
+                                } else {
+                                    builder.isNotModified(true);
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.ResumeScheduledTaskResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/SuppressWarningConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/SuppressWarningConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class SuppressWarningConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.SuppressWarningRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.SuppressWarningRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.SuppressWarningRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notNull(
+                request.getWarningReferenceDetails(), "warningReferenceDetails is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("warnings")
+                        .path("actions")
+                        .path("suppress");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.SuppressWarningResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.SuppressWarningResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.SuppressWarningResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.SuppressWarningResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.SuppressWarningResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.SuppressWarningResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .SuppressWarningResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.SuppressWarningResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UnsuppressWarningConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UnsuppressWarningConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class UnsuppressWarningConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.UnsuppressWarningRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.UnsuppressWarningRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.UnsuppressWarningRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notNull(
+                request.getWarningReferenceDetails(), "warningReferenceDetails is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("warnings")
+                        .path("actions")
+                        .path("unsuppress");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.UnsuppressWarningResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.UnsuppressWarningResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.UnsuppressWarningResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.UnsuppressWarningResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.UnsuppressWarningResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.UnsuppressWarningResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .UnsuppressWarningResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.UnsuppressWarningResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UpdateLookupConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UpdateLookupConverter.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class UpdateLookupConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.UpdateLookupRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.UpdateLookupRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.UpdateLookupRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notBlank(request.getLookupName(), "lookupName must not be blank");
+        Validate.notNull(
+                request.getUpdateLookupMetadataDetails(),
+                "updateLookupMetadataDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("lookups")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLookupName()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.UpdateLookupResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.UpdateLookupResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.UpdateLookupResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.UpdateLookupResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.UpdateLookupResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        LogAnalyticsLookup>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        LogAnalyticsLookup.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<LogAnalyticsLookup>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.UpdateLookupResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .UpdateLookupResponse.builder();
+
+                                builder.logAnalyticsLookup(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.UpdateLookupResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UpdateLookupDataConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UpdateLookupDataConverter.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class UpdateLookupDataConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.UpdateLookupDataRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.UpdateLookupDataRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.UpdateLookupDataRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notBlank(request.getLookupName(), "lookupName must not be blank");
+        Validate.notNull(request.getUpdateLookupFileBody(), "updateLookupFileBody is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("lookups")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLookupName()))
+                        .path("actions")
+                        .path("updateData");
+
+        if (request.getIsForce() != null) {
+            target =
+                    target.queryParam(
+                            "isForce",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsForce()));
+        }
+
+        if (request.getCharEncoding() != null) {
+            target =
+                    target.queryParam(
+                            "charEncoding",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCharEncoding()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.UpdateLookupDataResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.UpdateLookupDataResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.UpdateLookupDataResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.UpdateLookupDataResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.UpdateLookupDataResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.UpdateLookupDataResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .UpdateLookupDataResponse.builder();
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.UpdateLookupDataResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AbstractCommandDescriptor.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AbstractCommandDescriptor.java
@@ -74,8 +74,16 @@ package com.oracle.bmc.loganalytics.model;
         name = "FIELD_SUMMARY"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = MapCommandDescriptor.class,
+        name = "MAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = EventStatsCommandDescriptor.class,
         name = "EVENT_STATS"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = HighlightGroupsCommandDescriptor.class,
+        name = "HIGHLIGHT_GROUPS"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = WhereCommandDescriptor.class,
@@ -134,6 +142,10 @@ package com.oracle.bmc.loganalytics.model;
         name = "EXTRACT"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = NlpCommandDescriptor.class,
+        name = "NLP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = BottomCommandDescriptor.class,
         name = "BOTTOM"
     ),
@@ -164,6 +176,10 @@ package com.oracle.bmc.loganalytics.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = HeadCommandDescriptor.class,
         name = "HEAD"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateViewCommandDescriptor.class,
+        name = "CREATE_VIEW"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = AddFieldsCommandDescriptor.class,
@@ -259,6 +275,10 @@ public class AbstractCommandDescriptor {
         MultiSearch("MULTI_SEARCH"),
         Highlight("HIGHLIGHT"),
         HighlightRows("HIGHLIGHT_ROWS"),
+        HighlightGroups("HIGHLIGHT_GROUPS"),
+        CreateView("CREATE_VIEW"),
+        Map("MAP"),
+        Nlp("NLP"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AbstractField.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AbstractField.java
@@ -108,6 +108,13 @@ public class AbstractField {
     String filterQueryString;
 
     /**
+     * Field denoting field unit type.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("unitType")
+    String unitType;
+
+    /**
      * Field type classification.
      *
      **/

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AddEntityAssociationDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AddEntityAssociationDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Information about the associations to be added between log analytics entity and other existing entities.
+ * Information about the associations to be added between a source log analytics entity and other existing destination entities.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ArchivingConfiguration.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ArchivingConfiguration.java
@@ -73,7 +73,7 @@ public class ArchivingConfiguration {
     }
 
     /**
-     * Thi is the duration data in active storage before data is archived, as described in
+     * This is the duration data in active storage before data is archived, as described in
      * https://en.wikipedia.org/wiki/ISO_8601#Durations.
      * The largest supported unit is D, e.g. P365D (not P1Y) or P14D (not P2W).
      *
@@ -82,7 +82,7 @@ public class ArchivingConfiguration {
     String activeStorageDuration;
 
     /**
-     * The is the duration before archived data is deleted from object storage, as described in
+     * This is the duration before archived data is deleted from object storage, as described in
      * https://en.wikipedia.org/wiki/ISO_8601#Durations
      * The largest supported unit is D, e.g. P365D (not P1Y) or P14D (not P2W).
      *

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ChangeLogAnalyticsEntityCompartmentDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ChangeLogAnalyticsEntityCompartmentDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * log analytics entity compartment to be updated.
+ * Log analytics entity compartment to be updated.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ChangeLogAnalyticsObjectCollectionRuleCompartmentDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ChangeLogAnalyticsObjectCollectionRuleCompartmentDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * The new compartment this Object Collection Rule will be moved to.
+ * New compartment details.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -63,7 +63,7 @@ public class ChangeLogAnalyticsObjectCollectionRuleCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment into which the rule should be moved.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to which the rule have to be moved.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CharEncodingCollection.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CharEncodingCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * List of supported character encodings
+ * List of supported character encodings.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -61,7 +61,7 @@ public class CharEncodingCollection {
     }
 
     /**
-     * List of supported character encodings
+     * List of supported character encodings.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<String> items;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateLogAnalyticsEntityDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateLogAnalyticsEntityDetails.java
@@ -176,7 +176,7 @@ public class CreateLogAnalyticsEntityDetails {
     }
 
     /**
-     * Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+     * Log analytics entity name.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateLogAnalyticsObjectCollectionRuleDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateLogAnalyticsObjectCollectionRuleDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * The configuration details of an Object Storage based collection rule to enable automatic log collection.
+ * The configuration details of collection rule to enable automatic log collection from an object storage bucket.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -135,6 +135,15 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("overrides")
         private java.util.Map<String, java.util.List<PropertyOverride>> overrides;
 
@@ -182,6 +191,7 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
                             logSourceName,
                             entityId,
                             charEncoding,
+                            isEnabled,
                             overrides,
                             definedTags,
                             freeformTags);
@@ -204,6 +214,7 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
                             .logSourceName(o.getLogSourceName())
                             .entityId(o.getEntityId())
                             .charEncoding(o.getCharEncoding())
+                            .isEnabled(o.getIsEnabled())
                             .overrides(o.getOverrides())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
@@ -254,7 +265,6 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
 
     /**
      * The type of collection.
-     * Supported collection types: LIVE, HISTORIC, HISTORIC_LIVE
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("collectionType")
@@ -263,16 +273,16 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
     /**
      * The oldest time of the file in the bucket to consider for collection.
      * Accepted values are: BEGINNING or CURRENT_TIME or RFC3339 formatted datetime string.
-     * When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
+     * Use this for HISTORIC or HISTORIC_LIVE collection types. When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pollSince")
     String pollSince;
 
     /**
-     * The oldest time of the file in the bucket to consider for collection.
+     * The newest time of the file in the bucket to consider for collection.
      * Accepted values are: CURRENT_TIME or RFC3339 formatted datetime string.
-     * When collectionType is LIVE, specifying pollTill will result in error.
+     * Use this for HISTORIC collection type. When collectionType is LIVE or HISTORIC_LIVE, specifying pollTill will result in error.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pollTill")
@@ -298,13 +308,20 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
 
     /**
      * An optional character encoding to aid in detecting the character encoding of the contents of the objects while processing.
-     * It is recommended to set this value as ISO_8589_1 when configuring content of the objects having more numeric characters,
+     * It is recommended to set this value as ISO_8859_1 when configuring content of the objects having more numeric characters,
      * and very few alphabets.
      * For e.g. this applies when configuring VCN Flow Logs.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("charEncoding")
     String charEncoding;
+
+    /**
+     * Whether or not this rule is currently enabled.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
 
     /**
      * The override is used to modify some important configuration properties for objects matching a specific pattern inside the bucket.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateStandardTaskDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateStandardTaskDetails.java
@@ -162,6 +162,8 @@ public class CreateStandardTaskDetails extends CreateScheduledTaskDetails {
 
     /**
      * Schedules, typically a single schedule.
+     * Note there may only be a single schedule for SAVED_SEARCH and PURGE scheduled tasks.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("schedules")
     java.util.List<Schedule> schedules;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateViewCommandDescriptor.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateViewCommandDescriptor.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Command descriptor for querylanguage CREATEVIEW command.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateViewCommandDescriptor.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "name"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateViewCommandDescriptor extends AbstractCommandDescriptor {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayQueryString")
+        private String displayQueryString;
+
+        public Builder displayQueryString(String displayQueryString) {
+            this.displayQueryString = displayQueryString;
+            this.__explicitlySet__.add("displayQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("internalQueryString")
+        private String internalQueryString;
+
+        public Builder internalQueryString(String internalQueryString) {
+            this.internalQueryString = internalQueryString;
+            this.__explicitlySet__.add("internalQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("category")
+        private String category;
+
+        public Builder category(String category) {
+            this.category = category;
+            this.__explicitlySet__.add("category");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("referencedFields")
+        private java.util.List<AbstractField> referencedFields;
+
+        public Builder referencedFields(java.util.List<AbstractField> referencedFields) {
+            this.referencedFields = referencedFields;
+            this.__explicitlySet__.add("referencedFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("declaredFields")
+        private java.util.List<AbstractField> declaredFields;
+
+        public Builder declaredFields(java.util.List<AbstractField> declaredFields) {
+            this.declaredFields = declaredFields;
+            this.__explicitlySet__.add("declaredFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateViewCommandDescriptor build() {
+            CreateViewCommandDescriptor __instance__ =
+                    new CreateViewCommandDescriptor(
+                            displayQueryString,
+                            internalQueryString,
+                            category,
+                            referencedFields,
+                            declaredFields);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateViewCommandDescriptor o) {
+            Builder copiedBuilder =
+                    displayQueryString(o.getDisplayQueryString())
+                            .internalQueryString(o.getInternalQueryString())
+                            .category(o.getCategory())
+                            .referencedFields(o.getReferencedFields())
+                            .declaredFields(o.getDeclaredFields());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateViewCommandDescriptor(
+            String displayQueryString,
+            String internalQueryString,
+            String category,
+            java.util.List<AbstractField> referencedFields,
+            java.util.List<AbstractField> declaredFields) {
+        super(displayQueryString, internalQueryString, category, referencedFields, declaredFields);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EntityCloudType.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EntityCloudType.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Nature of log analytics entity type - whether it is a CLOUD or NON_CLOUD (on-premises) type.
+ * Log analytics entity type group. This can be CLOUD (OCI) or NON_CLOUD otherwise.
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EntityLifecycleStates.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EntityLifecycleStates.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Possible lifecycle states.
+ * Log analytics entity lifecycle state. Supported states are ACTIVE, DELETED
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EstimateRecallDataSizeDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EstimateRecallDataSizeDetails.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * This is the input used to estimate the size of data to be recalled
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EstimateRecallDataSizeDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EstimateRecallDataSizeDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+        private java.util.Date timeDataStarted;
+
+        public Builder timeDataStarted(java.util.Date timeDataStarted) {
+            this.timeDataStarted = timeDataStarted;
+            this.__explicitlySet__.add("timeDataStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+        private java.util.Date timeDataEnded;
+
+        public Builder timeDataEnded(java.util.Date timeDataEnded) {
+            this.timeDataEnded = timeDataEnded;
+            this.__explicitlySet__.add("timeDataEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EstimateRecallDataSizeDetails build() {
+            EstimateRecallDataSizeDetails __instance__ =
+                    new EstimateRecallDataSizeDetails(timeDataStarted, timeDataEnded);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EstimateRecallDataSizeDetails o) {
+            Builder copiedBuilder =
+                    timeDataStarted(o.getTimeDataStarted()).timeDataEnded(o.getTimeDataEnded());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * This is the start of the time range for the data to be recalled
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+    java.util.Date timeDataStarted;
+
+    /**
+     * This is the end of the time range for the data to be recalled
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+    java.util.Date timeDataEnded;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EstimateRecallDataSizeResult.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EstimateRecallDataSizeResult.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * This is the size and time range of data to be recalled
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EstimateRecallDataSizeResult.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EstimateRecallDataSizeResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+        private java.util.Date timeDataEnded;
+
+        public Builder timeDataEnded(java.util.Date timeDataEnded) {
+            this.timeDataEnded = timeDataEnded;
+            this.__explicitlySet__.add("timeDataEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+        private java.util.Date timeDataStarted;
+
+        public Builder timeDataStarted(java.util.Date timeDataStarted) {
+            this.timeDataStarted = timeDataStarted;
+            this.__explicitlySet__.add("timeDataStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+        private Long sizeInBytes;
+
+        public Builder sizeInBytes(Long sizeInBytes) {
+            this.sizeInBytes = sizeInBytes;
+            this.__explicitlySet__.add("sizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isOverlappingWithExistingRecalls")
+        private Boolean isOverlappingWithExistingRecalls;
+
+        public Builder isOverlappingWithExistingRecalls(Boolean isOverlappingWithExistingRecalls) {
+            this.isOverlappingWithExistingRecalls = isOverlappingWithExistingRecalls;
+            this.__explicitlySet__.add("isOverlappingWithExistingRecalls");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EstimateRecallDataSizeResult build() {
+            EstimateRecallDataSizeResult __instance__ =
+                    new EstimateRecallDataSizeResult(
+                            timeDataEnded,
+                            timeDataStarted,
+                            sizeInBytes,
+                            isOverlappingWithExistingRecalls);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EstimateRecallDataSizeResult o) {
+            Builder copiedBuilder =
+                    timeDataEnded(o.getTimeDataEnded())
+                            .timeDataStarted(o.getTimeDataStarted())
+                            .sizeInBytes(o.getSizeInBytes())
+                            .isOverlappingWithExistingRecalls(
+                                    o.getIsOverlappingWithExistingRecalls());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * This is the end of the time range of data to be recalled.  timeDataStarted and timeDataEnded delineate
+     * the time range of the archived data to be recalled.  They may not be exact the same as the
+     * parameters in the request input (EstimateRecallDataSizeDetails).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+    java.util.Date timeDataEnded;
+
+    /**
+     * This is the start of the time range of data to be recalled
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+    java.util.Date timeDataStarted;
+
+    /**
+     * This is the size in bytes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+    Long sizeInBytes;
+
+    /**
+     * This indicates if the time range of data to be recalled overlaps with existing recalled data
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isOverlappingWithExistingRecalls")
+    Boolean isOverlappingWithExistingRecalls;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EstimateReleaseDataSizeDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EstimateReleaseDataSizeDetails.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * This is the input used to estimate the size of data to be released
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EstimateReleaseDataSizeDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EstimateReleaseDataSizeDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+        private java.util.Date timeDataStarted;
+
+        public Builder timeDataStarted(java.util.Date timeDataStarted) {
+            this.timeDataStarted = timeDataStarted;
+            this.__explicitlySet__.add("timeDataStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+        private java.util.Date timeDataEnded;
+
+        public Builder timeDataEnded(java.util.Date timeDataEnded) {
+            this.timeDataEnded = timeDataEnded;
+            this.__explicitlySet__.add("timeDataEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EstimateReleaseDataSizeDetails build() {
+            EstimateReleaseDataSizeDetails __instance__ =
+                    new EstimateReleaseDataSizeDetails(timeDataStarted, timeDataEnded);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EstimateReleaseDataSizeDetails o) {
+            Builder copiedBuilder =
+                    timeDataStarted(o.getTimeDataStarted()).timeDataEnded(o.getTimeDataEnded());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * This is the start of the time range for the data to be released
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+    java.util.Date timeDataStarted;
+
+    /**
+     * This is the end of the time range for the data to be released
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+    java.util.Date timeDataEnded;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EstimateReleaseDataSizeResult.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EstimateReleaseDataSizeResult.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * This is the size and time range of data to be released
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EstimateReleaseDataSizeResult.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EstimateReleaseDataSizeResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+        private java.util.Date timeDataEnded;
+
+        public Builder timeDataEnded(java.util.Date timeDataEnded) {
+            this.timeDataEnded = timeDataEnded;
+            this.__explicitlySet__.add("timeDataEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+        private java.util.Date timeDataStarted;
+
+        public Builder timeDataStarted(java.util.Date timeDataStarted) {
+            this.timeDataStarted = timeDataStarted;
+            this.__explicitlySet__.add("timeDataStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+        private Long sizeInBytes;
+
+        public Builder sizeInBytes(Long sizeInBytes) {
+            this.sizeInBytes = sizeInBytes;
+            this.__explicitlySet__.add("sizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EstimateReleaseDataSizeResult build() {
+            EstimateReleaseDataSizeResult __instance__ =
+                    new EstimateReleaseDataSizeResult(timeDataEnded, timeDataStarted, sizeInBytes);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EstimateReleaseDataSizeResult o) {
+            Builder copiedBuilder =
+                    timeDataEnded(o.getTimeDataEnded())
+                            .timeDataStarted(o.getTimeDataStarted())
+                            .sizeInBytes(o.getSizeInBytes());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * This is the end of the time range of data to be released.  timeDataStarted and timeDataEnded delineate
+     * the time range of the recalled data to be released.  They may not be exact the same as the
+     * parameters in the request input (EstimateReleaseDataSizeDetails).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+    java.util.Date timeDataEnded;
+
+    /**
+     * This is the start of the time range of data to be released
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+    java.util.Date timeDataStarted;
+
+    /**
+     * This is the size in bytes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+    Long sizeInBytes;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EventType.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/EventType.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * The event type.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = EventType.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EventType {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("eventTypeName")
+        private String eventTypeName;
+
+        public Builder eventTypeName(String eventTypeName) {
+            this.eventTypeName = eventTypeName;
+            this.__explicitlySet__.add("eventTypeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("specVersion")
+        private String specVersion;
+
+        public Builder specVersion(String specVersion) {
+            this.specVersion = specVersion;
+            this.__explicitlySet__.add("specVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSystem")
+        private Boolean isSystem;
+
+        public Builder isSystem(Boolean isSystem) {
+            this.isSystem = isSystem;
+            this.__explicitlySet__.add("isSystem");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EventType build() {
+            EventType __instance__ = new EventType(eventTypeName, specVersion, isEnabled, isSystem);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EventType o) {
+            Builder copiedBuilder =
+                    eventTypeName(o.getEventTypeName())
+                            .specVersion(o.getSpecVersion())
+                            .isEnabled(o.getIsEnabled())
+                            .isSystem(o.getIsSystem());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the event type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("eventTypeName")
+    String eventTypeName;
+
+    /**
+     * The version.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("specVersion")
+    String specVersion;
+
+    /**
+     * A flag indicating whether or not the event type is enabled.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
+
+    /**
+     * A flag indicating whether or not the event type is user defined.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSystem")
+    Boolean isSystem;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/Field.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/Field.java
@@ -112,6 +112,15 @@ public class Field extends AbstractField {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("unitType")
+        private String unitType;
+
+        public Builder unitType(String unitType) {
+            this.unitType = unitType;
+            this.__explicitlySet__.add("unitType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -126,7 +135,8 @@ public class Field extends AbstractField {
                             isGroupable,
                             isDuration,
                             alias,
-                            filterQueryString);
+                            filterQueryString,
+                            unitType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -142,7 +152,8 @@ public class Field extends AbstractField {
                             .isGroupable(o.getIsGroupable())
                             .isDuration(o.getIsDuration())
                             .alias(o.getAlias())
-                            .filterQueryString(o.getFilterQueryString());
+                            .filterQueryString(o.getFilterQueryString())
+                            .unitType(o.getUnitType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -166,7 +177,8 @@ public class Field extends AbstractField {
             Boolean isGroupable,
             Boolean isDuration,
             String alias,
-            String filterQueryString) {
+            String filterQueryString,
+            String unitType) {
         super(
                 displayName,
                 isDeclared,
@@ -176,7 +188,8 @@ public class Field extends AbstractField {
                 isGroupable,
                 isDuration,
                 alias,
-                filterQueryString);
+                filterQueryString,
+                unitType);
     }
 
     @com.fasterxml.jackson.annotation.JsonIgnore

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/FieldsAddRemoveField.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/FieldsAddRemoveField.java
@@ -114,6 +114,15 @@ public class FieldsAddRemoveField extends AbstractField {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("unitType")
+        private String unitType;
+
+        public Builder unitType(String unitType) {
+            this.unitType = unitType;
+            this.__explicitlySet__.add("unitType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("operation")
         private Operation operation;
 
@@ -138,6 +147,7 @@ public class FieldsAddRemoveField extends AbstractField {
                             isDuration,
                             alias,
                             filterQueryString,
+                            unitType,
                             operation);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -155,6 +165,7 @@ public class FieldsAddRemoveField extends AbstractField {
                             .isDuration(o.getIsDuration())
                             .alias(o.getAlias())
                             .filterQueryString(o.getFilterQueryString())
+                            .unitType(o.getUnitType())
                             .operation(o.getOperation());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -180,6 +191,7 @@ public class FieldsAddRemoveField extends AbstractField {
             Boolean isDuration,
             String alias,
             String filterQueryString,
+            String unitType,
             Operation operation) {
         super(
                 displayName,
@@ -190,7 +202,8 @@ public class FieldsAddRemoveField extends AbstractField {
                 isGroupable,
                 isDuration,
                 alias,
-                filterQueryString);
+                filterQueryString,
+                unitType);
         this.operation = operation;
     }
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/FunctionField.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/FunctionField.java
@@ -112,6 +112,15 @@ public class FunctionField extends AbstractField {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("unitType")
+        private String unitType;
+
+        public Builder unitType(String unitType) {
+            this.unitType = unitType;
+            this.__explicitlySet__.add("unitType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("function")
         private String function;
 
@@ -145,6 +154,7 @@ public class FunctionField extends AbstractField {
                             isDuration,
                             alias,
                             filterQueryString,
+                            unitType,
                             function,
                             arguments);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -163,6 +173,7 @@ public class FunctionField extends AbstractField {
                             .isDuration(o.getIsDuration())
                             .alias(o.getAlias())
                             .filterQueryString(o.getFilterQueryString())
+                            .unitType(o.getUnitType())
                             .function(o.getFunction())
                             .arguments(o.getArguments());
 
@@ -189,6 +200,7 @@ public class FunctionField extends AbstractField {
             Boolean isDuration,
             String alias,
             String filterQueryString,
+            String unitType,
             String function,
             java.util.List<Argument> arguments) {
         super(
@@ -200,7 +212,8 @@ public class FunctionField extends AbstractField {
                 isGroupable,
                 isDuration,
                 alias,
-                filterQueryString);
+                filterQueryString,
+                unitType);
         this.function = function;
         this.arguments = arguments;
     }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/HighlightGroupsCommandDescriptor.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/HighlightGroupsCommandDescriptor.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Command descriptor for querylanguage HIGHLIGHTGROUPS command.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = HighlightGroupsCommandDescriptor.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "name"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class HighlightGroupsCommandDescriptor extends AbstractCommandDescriptor {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayQueryString")
+        private String displayQueryString;
+
+        public Builder displayQueryString(String displayQueryString) {
+            this.displayQueryString = displayQueryString;
+            this.__explicitlySet__.add("displayQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("internalQueryString")
+        private String internalQueryString;
+
+        public Builder internalQueryString(String internalQueryString) {
+            this.internalQueryString = internalQueryString;
+            this.__explicitlySet__.add("internalQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("category")
+        private String category;
+
+        public Builder category(String category) {
+            this.category = category;
+            this.__explicitlySet__.add("category");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("referencedFields")
+        private java.util.List<AbstractField> referencedFields;
+
+        public Builder referencedFields(java.util.List<AbstractField> referencedFields) {
+            this.referencedFields = referencedFields;
+            this.__explicitlySet__.add("referencedFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("declaredFields")
+        private java.util.List<AbstractField> declaredFields;
+
+        public Builder declaredFields(java.util.List<AbstractField> declaredFields) {
+            this.declaredFields = declaredFields;
+            this.__explicitlySet__.add("declaredFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("color")
+        private String color;
+
+        public Builder color(String color) {
+            this.color = color;
+            this.__explicitlySet__.add("color");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("priority")
+        private String priority;
+
+        public Builder priority(String priority) {
+            this.priority = priority;
+            this.__explicitlySet__.add("priority");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fields")
+        private java.util.List<String> fields;
+
+        public Builder fields(java.util.List<String> fields) {
+            this.fields = fields;
+            this.__explicitlySet__.add("fields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keywords")
+        private java.util.List<String> keywords;
+
+        public Builder keywords(java.util.List<String> keywords) {
+            this.keywords = keywords;
+            this.__explicitlySet__.add("keywords");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subQueries")
+        private java.util.List<ParseQueryOutput> subQueries;
+
+        public Builder subQueries(java.util.List<ParseQueryOutput> subQueries) {
+            this.subQueries = subQueries;
+            this.__explicitlySet__.add("subQueries");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public HighlightGroupsCommandDescriptor build() {
+            HighlightGroupsCommandDescriptor __instance__ =
+                    new HighlightGroupsCommandDescriptor(
+                            displayQueryString,
+                            internalQueryString,
+                            category,
+                            referencedFields,
+                            declaredFields,
+                            color,
+                            priority,
+                            fields,
+                            keywords,
+                            subQueries);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(HighlightGroupsCommandDescriptor o) {
+            Builder copiedBuilder =
+                    displayQueryString(o.getDisplayQueryString())
+                            .internalQueryString(o.getInternalQueryString())
+                            .category(o.getCategory())
+                            .referencedFields(o.getReferencedFields())
+                            .declaredFields(o.getDeclaredFields())
+                            .color(o.getColor())
+                            .priority(o.getPriority())
+                            .fields(o.getFields())
+                            .keywords(o.getKeywords())
+                            .subQueries(o.getSubQueries());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public HighlightGroupsCommandDescriptor(
+            String displayQueryString,
+            String internalQueryString,
+            String category,
+            java.util.List<AbstractField> referencedFields,
+            java.util.List<AbstractField> declaredFields,
+            String color,
+            String priority,
+            java.util.List<String> fields,
+            java.util.List<String> keywords,
+            java.util.List<ParseQueryOutput> subQueries) {
+        super(displayQueryString, internalQueryString, category, referencedFields, declaredFields);
+        this.color = color;
+        this.priority = priority;
+        this.fields = fields;
+        this.keywords = keywords;
+        this.subQueries = subQueries;
+    }
+
+    /**
+     * User specified color to highlight matches with if found.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("color")
+    String color;
+
+    /**
+     * User specified priority assigned to highlighted matches if found.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("priority")
+    String priority;
+
+    /**
+     * List of fields to search for terms or phrases to highlight.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fields")
+    java.util.List<String> fields;
+
+    /**
+     * List of terms or phrases to highlight if found.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("keywords")
+    java.util.List<String> keywords;
+
+    /**
+     * List of subQueries specified as highlightgroups command arguments
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subQueries")
+    java.util.List<ParseQueryOutput> subQueries;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/HighlightRowsCommandDescriptor.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/HighlightRowsCommandDescriptor.java
@@ -78,6 +78,15 @@ public class HighlightRowsCommandDescriptor extends AbstractCommandDescriptor {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("color")
+        private String color;
+
+        public Builder color(String color) {
+            this.color = color;
+            this.__explicitlySet__.add("color");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("keywords")
         private java.util.List<String> keywords;
 
@@ -98,6 +107,7 @@ public class HighlightRowsCommandDescriptor extends AbstractCommandDescriptor {
                             category,
                             referencedFields,
                             declaredFields,
+                            color,
                             keywords);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -111,6 +121,7 @@ public class HighlightRowsCommandDescriptor extends AbstractCommandDescriptor {
                             .category(o.getCategory())
                             .referencedFields(o.getReferencedFields())
                             .declaredFields(o.getDeclaredFields())
+                            .color(o.getColor())
                             .keywords(o.getKeywords());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -132,10 +143,19 @@ public class HighlightRowsCommandDescriptor extends AbstractCommandDescriptor {
             String category,
             java.util.List<AbstractField> referencedFields,
             java.util.List<AbstractField> declaredFields,
+            String color,
             java.util.List<String> keywords) {
         super(displayQueryString, internalQueryString, category, referencedFields, declaredFields);
+        this.color = color;
         this.keywords = keywords;
     }
+
+    /**
+     * User specified color to highlight matches with if found.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("color")
+    String color;
 
     /**
      * List of terms or phrases to find to mark the result row as highlighted.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsConfigWorkRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsConfigWorkRequest.java
@@ -169,6 +169,9 @@ public class LogAnalyticsConfigWorkRequest {
     public enum OperationType {
         CreateAssociations("CREATE_ASSOCIATIONS"),
         DeleteAssociations("DELETE_ASSOCIATIONS"),
+        AppendLookupData("APPEND_LOOKUP_DATA"),
+        UpdateLookupData("UPDATE_LOOKUP_DATA"),
+        DeleteLookup("DELETE_LOOKUP"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsConfigWorkRequestPayload.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsConfigWorkRequestPayload.java
@@ -53,12 +53,22 @@ public class LogAnalyticsConfigWorkRequestPayload {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lookupReferenceString")
+        private String lookupReferenceString;
+
+        public Builder lookupReferenceString(String lookupReferenceString) {
+            this.lookupReferenceString = lookupReferenceString;
+            this.__explicitlySet__.add("lookupReferenceString");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public LogAnalyticsConfigWorkRequestPayload build() {
             LogAnalyticsConfigWorkRequestPayload __instance__ =
-                    new LogAnalyticsConfigWorkRequestPayload(sourceName, entityId, lookupReference);
+                    new LogAnalyticsConfigWorkRequestPayload(
+                            sourceName, entityId, lookupReference, lookupReferenceString);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -68,7 +78,8 @@ public class LogAnalyticsConfigWorkRequestPayload {
             Builder copiedBuilder =
                     sourceName(o.getSourceName())
                             .entityId(o.getEntityId())
-                            .lookupReference(o.getLookupReference());
+                            .lookupReference(o.getLookupReference())
+                            .lookupReferenceString(o.getLookupReferenceString());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -99,6 +110,12 @@ public class LogAnalyticsConfigWorkRequestPayload {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lookupReference")
     Long lookupReference;
+
+    /**
+     * lookupReference
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lookupReferenceString")
+    String lookupReferenceString;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsConfigWorkRequestSummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsConfigWorkRequestSummary.java
@@ -147,6 +147,9 @@ public class LogAnalyticsConfigWorkRequestSummary {
     public enum OperationType {
         CreateAssociations("CREATE_ASSOCIATIONS"),
         DeleteAssociations("DELETE_ASSOCIATIONS"),
+        AppendLookupData("APPEND_LOOKUP_DATA"),
+        UpdateLookupData("UPDATE_LOOKUP_DATA"),
+        DeleteLookup("DELETE_LOOKUP"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsEntity.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsEntity.java
@@ -283,7 +283,7 @@ public class LogAnalyticsEntity {
     String id;
 
     /**
-     * Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+     * Log analytics entity name.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsEntitySummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsEntitySummary.java
@@ -239,7 +239,7 @@ public class LogAnalyticsEntitySummary {
     String id;
 
     /**
-     * Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+     * Log analytics entity name.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsEntityType.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsEntityType.java
@@ -180,7 +180,7 @@ public class LogAnalyticsEntityType {
     String category;
 
     /**
-     * Nature of log analytics entity type.
+     * Log analytics entity type group. That can be CLOUD (OCI) or NON_CLOUD otherwise.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("cloudType")
@@ -194,7 +194,7 @@ public class LogAnalyticsEntityType {
     java.util.List<EntityTypeProperty> properties;
 
     /**
-     * The current state of the log analytics entity.
+     * The current lifecycle state of the log analytics entity.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsEntityTypeSummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsEntityTypeSummary.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Summary of an log analytics entity type.
+ * Summary of a log analytics entity type.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -152,14 +152,14 @@ public class LogAnalyticsEntityTypeSummary {
     String category;
 
     /**
-     * Nature of log analytics entity type.
+     * Log analytics entity type group. This can be CLOUD (OCI) or NON_CLOUD otherwise.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("cloudType")
     EntityCloudType cloudType;
 
     /**
-     * The current state of the log analytics entity
+     * The current lifecycle state of the log analytics entity type.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsLookup.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsLookup.java
@@ -80,6 +80,24 @@ public class LogAnalyticsLookup {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lookupReferenceString")
+        private String lookupReferenceString;
+
+        public Builder lookupReferenceString(String lookupReferenceString) {
+            this.lookupReferenceString = lookupReferenceString;
+            this.__explicitlySet__.add("lookupReferenceString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private Type type;
+
+        public Builder type(Type type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("name")
         private String name;
 
@@ -155,6 +173,8 @@ public class LogAnalyticsLookup {
                             editVersion,
                             fields,
                             lookupReference,
+                            lookupReferenceString,
+                            type,
                             name,
                             isBuiltIn,
                             isHidden,
@@ -175,6 +195,8 @@ public class LogAnalyticsLookup {
                             .editVersion(o.getEditVersion())
                             .fields(o.getFields())
                             .lookupReference(o.getLookupReference())
+                            .lookupReferenceString(o.getLookupReferenceString())
+                            .type(o.getType())
                             .name(o.getName())
                             .isBuiltIn(o.getIsBuiltIn())
                             .isHidden(o.getIsHidden())
@@ -226,10 +248,66 @@ public class LogAnalyticsLookup {
     java.util.List<LookupField> fields;
 
     /**
-     * lookupReference
+     * The lookup reference as an integer.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lookupReference")
     Long lookupReference;
+
+    /**
+     * The lookup reference as a string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lookupReferenceString")
+    String lookupReferenceString;
+    /**
+     * The lookup type.  Valid values are LOOKUP or DICTIONARY.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Type {
+        Lookup("Lookup"),
+        Dictionary("Dictionary"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Type> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Type v : Type.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Type create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Type', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The lookup type.  Valid values are LOOKUP or DICTIONARY.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    Type type;
 
     /**
      * iname

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsLookupCollection.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsLookupCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * LogAnalytics Lookup Collection
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LogAnalyticsLookupCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LogAnalyticsLookupCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<LogAnalyticsLookup> items;
+
+        public Builder items(java.util.List<LogAnalyticsLookup> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LogAnalyticsLookupCollection build() {
+            LogAnalyticsLookupCollection __instance__ = new LogAnalyticsLookupCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LogAnalyticsLookupCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * list of fields
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<LogAnalyticsLookup> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsLookupFields.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsLookupFields.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * LogAnalyticsLookupFields
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LogAnalyticsLookupFields.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LogAnalyticsLookupFields {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("commonFieldName")
+        private String commonFieldName;
+
+        public Builder commonFieldName(String commonFieldName) {
+            this.commonFieldName = commonFieldName;
+            this.__explicitlySet__.add("commonFieldName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("defaultMatchValue")
+        private String defaultMatchValue;
+
+        public Builder defaultMatchValue(String defaultMatchValue) {
+            this.defaultMatchValue = defaultMatchValue;
+            this.__explicitlySet__.add("defaultMatchValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCommonField")
+        private Boolean isCommonField;
+
+        public Builder isCommonField(Boolean isCommonField) {
+            this.isCommonField = isCommonField;
+            this.__explicitlySet__.add("isCommonField");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("matchOperator")
+        private String matchOperator;
+
+        public Builder matchOperator(String matchOperator) {
+            this.matchOperator = matchOperator;
+            this.__explicitlySet__.add("matchOperator");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("position")
+        private Long position;
+
+        public Builder position(Long position) {
+            this.position = position;
+            this.__explicitlySet__.add("position");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LogAnalyticsLookupFields build() {
+            LogAnalyticsLookupFields __instance__ =
+                    new LogAnalyticsLookupFields(
+                            commonFieldName,
+                            defaultMatchValue,
+                            displayName,
+                            isCommonField,
+                            matchOperator,
+                            name,
+                            position);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LogAnalyticsLookupFields o) {
+            Builder copiedBuilder =
+                    commonFieldName(o.getCommonFieldName())
+                            .defaultMatchValue(o.getDefaultMatchValue())
+                            .displayName(o.getDisplayName())
+                            .isCommonField(o.getIsCommonField())
+                            .matchOperator(o.getMatchOperator())
+                            .name(o.getName())
+                            .position(o.getPosition());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The common field name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("commonFieldName")
+    String commonFieldName;
+
+    /**
+     * The default match value.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultMatchValue")
+    String defaultMatchValue;
+
+    /**
+     * The display name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * A flag indicating whether or not the field is a common field.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCommonField")
+    Boolean isCommonField;
+
+    /**
+     * The match operator.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("matchOperator")
+    String matchOperator;
+
+    /**
+     * The field name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The position.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("position")
+    Long position;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRule.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRule.java
@@ -155,9 +155,9 @@ public class LogAnalyticsObjectCollectionRule {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-        private LifecycleState lifecycleState;
+        private ObjectCollectionRuleLifecycleStates lifecycleState;
 
-        public Builder lifecycleState(LifecycleState lifecycleState) {
+        public Builder lifecycleState(ObjectCollectionRuleLifecycleStates lifecycleState) {
             this.lifecycleState = lifecycleState;
             this.__explicitlySet__.add("lifecycleState");
             return this;
@@ -187,6 +187,15 @@ public class LogAnalyticsObjectCollectionRule {
         public Builder timeUpdated(java.util.Date timeUpdated) {
             this.timeUpdated = timeUpdated;
             this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
             return this;
         }
 
@@ -233,6 +242,7 @@ public class LogAnalyticsObjectCollectionRule {
                             lifecycleDetails,
                             timeCreated,
                             timeUpdated,
+                            isEnabled,
                             definedTags,
                             freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -260,6 +270,7 @@ public class LogAnalyticsObjectCollectionRule {
                             .lifecycleDetails(o.getLifecycleDetails())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
+                            .isEnabled(o.getIsEnabled())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -314,8 +325,7 @@ public class LogAnalyticsObjectCollectionRule {
     String osBucketName;
 
     /**
-     * The type of collection.
-     * Supported collection types: LIVE, HISTORIC, HISTORIC_LIVE
+     * The type of log collection.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("collectionType")
@@ -324,16 +334,16 @@ public class LogAnalyticsObjectCollectionRule {
     /**
      * The oldest time of the file in the bucket to consider for collection.
      * Accepted values are: BEGINNING or CURRENT_TIME or RFC3339 formatted datetime string.
-     * When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
+     * Use this for HISTORIC or HISTORIC_LIVE collection types. When collectionType is LIVE, specifying pollSince value other than CURRENT_TIME will result in error.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pollSince")
     String pollSince;
 
     /**
-     * The oldest time of the file in the bucket to consider for collection.
+     * The newest time of the file in the bucket to consider for collection.
      * Accepted values are: CURRENT_TIME or RFC3339 formatted datetime string.
-     * When collectionType is LIVE, specifying pollTill will result in error.
+     * Use this for HISTORIC collection type. When collectionType is LIVE or HISTORIC_LIVE, specifying pollTill will result in error.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pollTill")
@@ -359,7 +369,7 @@ public class LogAnalyticsObjectCollectionRule {
 
     /**
      * An optional character encoding to aid in detecting the character encoding of the contents of the objects while processing.
-     * It is recommended to set this value as ISO_8589_1 when configuring content of the objects having more numeric characters,
+     * It is recommended to set this value as ISO_8859_1 when configuring content of the objects having more numeric characters,
      * and very few alphabets.
      * For e.g. this applies when configuring VCN Flow Logs.
      *
@@ -375,59 +385,13 @@ public class LogAnalyticsObjectCollectionRule {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("overrides")
     java.util.Map<String, java.util.List<PropertyOverride>> overrides;
-    /**
-     * The current state of the rule.
-     *
-     **/
-    @lombok.extern.slf4j.Slf4j
-    public enum LifecycleState {
-        Active("ACTIVE"),
-        Deleted("DELETED"),
 
-        /**
-         * This value is used if a service returns a value for this enum that is not recognized by this
-         * version of the SDK.
-         */
-        UnknownEnumValue(null);
-
-        private final String value;
-        private static java.util.Map<String, LifecycleState> map;
-
-        static {
-            map = new java.util.HashMap<>();
-            for (LifecycleState v : LifecycleState.values()) {
-                if (v != UnknownEnumValue) {
-                    map.put(v.getValue(), v);
-                }
-            }
-        }
-
-        LifecycleState(String value) {
-            this.value = value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonValue
-        public String getValue() {
-            return value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonCreator
-        public static LifecycleState create(String key) {
-            if (map.containsKey(key)) {
-                return map.get(key);
-            }
-            LOG.warn(
-                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
-                    key);
-            return UnknownEnumValue;
-        }
-    };
     /**
      * The current state of the rule.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-    LifecycleState lifecycleState;
+    ObjectCollectionRuleLifecycleStates lifecycleState;
 
     /**
      * A detailed status of the life cycle state.
@@ -446,6 +410,13 @@ public class LogAnalyticsObjectCollectionRule {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     java.util.Date timeUpdated;
+
+    /**
+     * Whether or not this rule is currently enabled.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRuleCollection.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRuleCollection.java
@@ -62,7 +62,7 @@ public class LogAnalyticsObjectCollectionRuleCollection {
     }
 
     /**
-     * list of LogAnalyticsObjectCollectionRuleSummary objects.
+     * List of LogAnalyticsObjectCollectionRuleSummary objects.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<LogAnalyticsObjectCollectionRuleSummary> items;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRuleSummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRuleSummary.java
@@ -91,10 +91,9 @@ public class LogAnalyticsObjectCollectionRuleSummary {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-        private LogAnalyticsObjectCollectionRule.LifecycleState lifecycleState;
+        private ObjectCollectionRuleLifecycleStates lifecycleState;
 
-        public Builder lifecycleState(
-                LogAnalyticsObjectCollectionRule.LifecycleState lifecycleState) {
+        public Builder lifecycleState(ObjectCollectionRuleLifecycleStates lifecycleState) {
             this.lifecycleState = lifecycleState;
             this.__explicitlySet__.add("lifecycleState");
             return this;
@@ -124,6 +123,15 @@ public class LogAnalyticsObjectCollectionRuleSummary {
         public Builder timeUpdated(java.util.Date timeUpdated) {
             this.timeUpdated = timeUpdated;
             this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
             return this;
         }
 
@@ -163,6 +171,7 @@ public class LogAnalyticsObjectCollectionRuleSummary {
                             lifecycleDetails,
                             timeCreated,
                             timeUpdated,
+                            isEnabled,
                             definedTags,
                             freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -183,6 +192,7 @@ public class LogAnalyticsObjectCollectionRuleSummary {
                             .lifecycleDetails(o.getLifecycleDetails())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
+                            .isEnabled(o.getIsEnabled())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -237,8 +247,7 @@ public class LogAnalyticsObjectCollectionRuleSummary {
     String osBucketName;
 
     /**
-     * The type of collection.
-     * Supported collection types: LIVE, HISTORIC, HISTORIC_LIVE
+     * The type of log collection.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("collectionType")
@@ -249,7 +258,7 @@ public class LogAnalyticsObjectCollectionRuleSummary {
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-    LogAnalyticsObjectCollectionRule.LifecycleState lifecycleState;
+    ObjectCollectionRuleLifecycleStates lifecycleState;
 
     /**
      * A detailed status of the life cycle state.
@@ -268,6 +277,13 @@ public class LogAnalyticsObjectCollectionRuleSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     java.util.Date timeUpdated;
+
+    /**
+     * Whether or not this rule is currently enabled.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsSource.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsSource.java
@@ -348,6 +348,15 @@ public class LogAnalyticsSource {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("eventTypes")
+        private java.util.List<EventType> eventTypes;
+
+        public Builder eventTypes(java.util.List<EventType> eventTypes) {
+            this.eventTypes = eventTypes;
+            this.__explicitlySet__.add("eventTypes");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -388,7 +397,8 @@ public class LogAnalyticsSource {
                             entityTypes,
                             isTimezoneOverride,
                             userParsers,
-                            timeUpdated);
+                            timeUpdated,
+                            eventTypes);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -430,7 +440,8 @@ public class LogAnalyticsSource {
                             .entityTypes(o.getEntityTypes())
                             .isTimezoneOverride(o.getIsTimezoneOverride())
                             .userParsers(o.getUserParsers())
-                            .timeUpdated(o.getTimeUpdated());
+                            .timeUpdated(o.getTimeUpdated())
+                            .eventTypes(o.getEventTypes());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -653,6 +664,12 @@ public class LogAnalyticsSource {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     java.util.Date timeUpdated;
+
+    /**
+     * An array of event types.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("eventTypes")
+    java.util.List<EventType> eventTypes;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsWarning.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsWarning.java
@@ -1,0 +1,502 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * LogAnalyticsWarning
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LogAnalyticsWarning.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LogAnalyticsWarning {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("agentId")
+        private String agentId;
+
+        public Builder agentId(String agentId) {
+            this.agentId = agentId;
+            this.__explicitlySet__.add("agentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("hostName")
+        private String hostName;
+
+        public Builder hostName(String hostName) {
+            this.hostName = hostName;
+            this.__explicitlySet__.add("hostName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ruleDisplayName")
+        private String ruleDisplayName;
+
+        public Builder ruleDisplayName(String ruleDisplayName) {
+            this.ruleDisplayName = ruleDisplayName;
+            this.__explicitlySet__.add("ruleDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceName")
+        private String sourceName;
+
+        public Builder sourceName(String sourceName) {
+            this.sourceName = sourceName;
+            this.__explicitlySet__.add("sourceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceDisplayName")
+        private String sourceDisplayName;
+
+        public Builder sourceDisplayName(String sourceDisplayName) {
+            this.sourceDisplayName = sourceDisplayName;
+            this.__explicitlySet__.add("sourceDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("entityName")
+        private String entityName;
+
+        public Builder entityName(String entityName) {
+            this.entityName = entityName;
+            this.__explicitlySet__.add("entityName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCollected")
+        private java.util.Date timeCollected;
+
+        public Builder timeCollected(java.util.Date timeCollected) {
+            this.timeCollected = timeCollected;
+            this.__explicitlySet__.add("timeCollected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("warningId")
+        private String warningId;
+
+        public Builder warningId(String warningId) {
+            this.warningId = warningId;
+            this.__explicitlySet__.add("warningId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeOfInitialWarning")
+        private java.util.Date timeOfInitialWarning;
+
+        public Builder timeOfInitialWarning(java.util.Date timeOfInitialWarning) {
+            this.timeOfInitialWarning = timeOfInitialWarning;
+            this.__explicitlySet__.add("timeOfInitialWarning");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isActive")
+        private Boolean isActive;
+
+        public Builder isActive(Boolean isActive) {
+            this.isActive = isActive;
+            this.__explicitlySet__.add("isActive");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isSuppressed")
+        private Boolean isSuppressed;
+
+        public Builder isSuppressed(Boolean isSuppressed) {
+            this.isSuppressed = isSuppressed;
+            this.__explicitlySet__.add("isSuppressed");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeOfLatestWarning")
+        private java.util.Date timeOfLatestWarning;
+
+        public Builder timeOfLatestWarning(java.util.Date timeOfLatestWarning) {
+            this.timeOfLatestWarning = timeOfLatestWarning;
+            this.__explicitlySet__.add("timeOfLatestWarning");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("warningLevel")
+        private String warningLevel;
+
+        public Builder warningLevel(String warningLevel) {
+            this.warningLevel = warningLevel;
+            this.__explicitlySet__.add("warningLevel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("warningMessage")
+        private String warningMessage;
+
+        public Builder warningMessage(String warningMessage) {
+            this.warningMessage = warningMessage;
+            this.__explicitlySet__.add("warningMessage");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("patternId")
+        private String patternId;
+
+        public Builder patternId(String patternId) {
+            this.patternId = patternId;
+            this.__explicitlySet__.add("patternId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("patternText")
+        private String patternText;
+
+        public Builder patternText(String patternText) {
+            this.patternText = patternText;
+            this.__explicitlySet__.add("patternText");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("ruleId")
+        private String ruleId;
+
+        public Builder ruleId(String ruleId) {
+            this.ruleId = ruleId;
+            this.__explicitlySet__.add("ruleId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
+        private String sourceId;
+
+        public Builder sourceId(String sourceId) {
+            this.sourceId = sourceId;
+            this.__explicitlySet__.add("sourceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("suppressedBy")
+        private String suppressedBy;
+
+        public Builder suppressedBy(String suppressedBy) {
+            this.suppressedBy = suppressedBy;
+            this.__explicitlySet__.add("suppressedBy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("entityId")
+        private String entityId;
+
+        public Builder entityId(String entityId) {
+            this.entityId = entityId;
+            this.__explicitlySet__.add("entityId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("entityType")
+        private String entityType;
+
+        public Builder entityType(String entityType) {
+            this.entityType = entityType;
+            this.__explicitlySet__.add("entityType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("entityTypeDisplayName")
+        private String entityTypeDisplayName;
+
+        public Builder entityTypeDisplayName(String entityTypeDisplayName) {
+            this.entityTypeDisplayName = entityTypeDisplayName;
+            this.__explicitlySet__.add("entityTypeDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("typeDisplayName")
+        private String typeDisplayName;
+
+        public Builder typeDisplayName(String typeDisplayName) {
+            this.typeDisplayName = typeDisplayName;
+            this.__explicitlySet__.add("typeDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("typeName")
+        private String typeName;
+
+        public Builder typeName(String typeName) {
+            this.typeName = typeName;
+            this.__explicitlySet__.add("typeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("severity")
+        private Integer severity;
+
+        public Builder severity(Integer severity) {
+            this.severity = severity;
+            this.__explicitlySet__.add("severity");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LogAnalyticsWarning build() {
+            LogAnalyticsWarning __instance__ =
+                    new LogAnalyticsWarning(
+                            agentId,
+                            hostName,
+                            ruleDisplayName,
+                            sourceName,
+                            compartmentId,
+                            sourceDisplayName,
+                            entityName,
+                            timeCollected,
+                            warningId,
+                            timeOfInitialWarning,
+                            isActive,
+                            isSuppressed,
+                            timeOfLatestWarning,
+                            warningLevel,
+                            warningMessage,
+                            patternId,
+                            patternText,
+                            ruleId,
+                            sourceId,
+                            suppressedBy,
+                            entityId,
+                            entityType,
+                            entityTypeDisplayName,
+                            typeDisplayName,
+                            typeName,
+                            severity);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LogAnalyticsWarning o) {
+            Builder copiedBuilder =
+                    agentId(o.getAgentId())
+                            .hostName(o.getHostName())
+                            .ruleDisplayName(o.getRuleDisplayName())
+                            .sourceName(o.getSourceName())
+                            .compartmentId(o.getCompartmentId())
+                            .sourceDisplayName(o.getSourceDisplayName())
+                            .entityName(o.getEntityName())
+                            .timeCollected(o.getTimeCollected())
+                            .warningId(o.getWarningId())
+                            .timeOfInitialWarning(o.getTimeOfInitialWarning())
+                            .isActive(o.getIsActive())
+                            .isSuppressed(o.getIsSuppressed())
+                            .timeOfLatestWarning(o.getTimeOfLatestWarning())
+                            .warningLevel(o.getWarningLevel())
+                            .warningMessage(o.getWarningMessage())
+                            .patternId(o.getPatternId())
+                            .patternText(o.getPatternText())
+                            .ruleId(o.getRuleId())
+                            .sourceId(o.getSourceId())
+                            .suppressedBy(o.getSuppressedBy())
+                            .entityId(o.getEntityId())
+                            .entityType(o.getEntityType())
+                            .entityTypeDisplayName(o.getEntityTypeDisplayName())
+                            .typeDisplayName(o.getTypeDisplayName())
+                            .typeName(o.getTypeName())
+                            .severity(o.getSeverity());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique identifier of the agent associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("agentId")
+    String agentId;
+
+    /**
+     * The host containing the agent associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostName")
+    String hostName;
+
+    /**
+     * The display name of the rule which triggered the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ruleDisplayName")
+    String ruleDisplayName;
+
+    /**
+     * The name of the source associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceName")
+    String sourceName;
+
+    /**
+     * The entity compartment ID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The display name of the source associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceDisplayName")
+    String sourceDisplayName;
+
+    /**
+     * The name of the entity associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("entityName")
+    String entityName;
+
+    /**
+     * The time at which the warning was most recently collected
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCollected")
+    java.util.Date timeCollected;
+
+    /**
+     * The unique identifier of the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("warningId")
+    String warningId;
+
+    /**
+     * The date at which the warning was initially triggered
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeOfInitialWarning")
+    java.util.Date timeOfInitialWarning;
+
+    /**
+     * A flag indicating if the warning is currently active
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isActive")
+    Boolean isActive;
+
+    /**
+     * A flag indicating if the warning is currently suppressed
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSuppressed")
+    Boolean isSuppressed;
+
+    /**
+     * The most recent date on which the warning was triggered
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeOfLatestWarning")
+    java.util.Date timeOfLatestWarning;
+
+    /**
+     * The warning level - either pattern, rule, or source.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("warningLevel")
+    String warningLevel;
+
+    /**
+     * A description of the warning intended for the consumer of the warning.  It will
+     * usually detail the cause of the warning, may suggest a remedy, and can contain any
+     * other relevant information the consumer might find useful
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("warningMessage")
+    String warningMessage;
+
+    /**
+     * The unique identifier of the warning pattern
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patternId")
+    String patternId;
+
+    /**
+     * The text of the pattern used by the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patternText")
+    String patternText;
+
+    /**
+     * The unique identifier of the rule associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ruleId")
+    String ruleId;
+
+    /**
+     * The unique identifier of the source associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
+    String sourceId;
+
+    /**
+     * The user who suppressed the warning, or empty if the warning is not suppressed
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("suppressedBy")
+    String suppressedBy;
+
+    /**
+     * The unique identifier of the entity associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("entityId")
+    String entityId;
+
+    /**
+     * The type of the entity associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("entityType")
+    String entityType;
+
+    /**
+     * The display name of the entity type associated with the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("entityTypeDisplayName")
+    String entityTypeDisplayName;
+
+    /**
+     * The display name of the warning type
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("typeDisplayName")
+    String typeDisplayName;
+
+    /**
+     * The internal name of the warning
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("typeName")
+    String typeName;
+
+    /**
+     * The warning severity
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("severity")
+    Integer severity;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsWarningCollection.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsWarningCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * A collection of warnings.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LogAnalyticsWarningCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LogAnalyticsWarningCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<LogAnalyticsWarning> items;
+
+        public Builder items(java.util.List<LogAnalyticsWarning> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LogAnalyticsWarningCollection build() {
+            LogAnalyticsWarningCollection __instance__ = new LogAnalyticsWarningCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LogAnalyticsWarningCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A collection of LogAnalyticsWarnings
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<LogAnalyticsWarning> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/MapCommandDescriptor.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/MapCommandDescriptor.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Command descriptor for querylanguage MAP command.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = MapCommandDescriptor.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "name"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MapCommandDescriptor extends AbstractCommandDescriptor {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayQueryString")
+        private String displayQueryString;
+
+        public Builder displayQueryString(String displayQueryString) {
+            this.displayQueryString = displayQueryString;
+            this.__explicitlySet__.add("displayQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("internalQueryString")
+        private String internalQueryString;
+
+        public Builder internalQueryString(String internalQueryString) {
+            this.internalQueryString = internalQueryString;
+            this.__explicitlySet__.add("internalQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("category")
+        private String category;
+
+        public Builder category(String category) {
+            this.category = category;
+            this.__explicitlySet__.add("category");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("referencedFields")
+        private java.util.List<AbstractField> referencedFields;
+
+        public Builder referencedFields(java.util.List<AbstractField> referencedFields) {
+            this.referencedFields = referencedFields;
+            this.__explicitlySet__.add("referencedFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("declaredFields")
+        private java.util.List<AbstractField> declaredFields;
+
+        public Builder declaredFields(java.util.List<AbstractField> declaredFields) {
+            this.declaredFields = declaredFields;
+            this.__explicitlySet__.add("declaredFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MapCommandDescriptor build() {
+            MapCommandDescriptor __instance__ =
+                    new MapCommandDescriptor(
+                            displayQueryString,
+                            internalQueryString,
+                            category,
+                            referencedFields,
+                            declaredFields);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MapCommandDescriptor o) {
+            Builder copiedBuilder =
+                    displayQueryString(o.getDisplayQueryString())
+                            .internalQueryString(o.getInternalQueryString())
+                            .category(o.getCategory())
+                            .referencedFields(o.getReferencedFields())
+                            .declaredFields(o.getDeclaredFields());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public MapCommandDescriptor(
+            String displayQueryString,
+            String internalQueryString,
+            String category,
+            java.util.List<AbstractField> referencedFields,
+            java.util.List<AbstractField> declaredFields) {
+        super(displayQueryString, internalQueryString, category, referencedFields, declaredFields);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/MetricExtraction.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/MetricExtraction.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Specify metric extraction for SAVED_SEARCH scheduled task execution
+ * to post to OCI Monitoring.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = MetricExtraction.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MetricExtraction {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metricName")
+        private String metricName;
+
+        public Builder metricName(String metricName) {
+            this.metricName = metricName;
+            this.__explicitlySet__.add("metricName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceGroup")
+        private String resourceGroup;
+
+        public Builder resourceGroup(String resourceGroup) {
+            this.resourceGroup = resourceGroup;
+            this.__explicitlySet__.add("resourceGroup");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MetricExtraction build() {
+            MetricExtraction __instance__ =
+                    new MetricExtraction(compartmentId, namespace, metricName, resourceGroup);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MetricExtraction o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .namespace(o.getNamespace())
+                            .metricName(o.getMetricName())
+                            .resourceGroup(o.getResourceGroup());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The compartment OCID (/iaas/Content/General/Concepts/identifiers.htm) of the extracted metric.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The namespace of the extracted metric.
+     * A valid value starts with an alphabetical character and includes only
+     * alphanumeric characters and underscores (_).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    /**
+     * The metric name of the extracted metric.
+     * A valid value starts with an alphabetical character and includes only
+     * alphanumeric characters, periods (.), underscores (_), hyphens (-), and dollar signs ($).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metricName")
+    String metricName;
+
+    /**
+     * The resourceGroup of the extracted metric.
+     * A valid value starts with an alphabetical character and includes only
+     * alphanumeric characters, periods (.), underscores (_), hyphens (-), and dollar signs ($).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceGroup")
+    String resourceGroup;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/NlpCommandDescriptor.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/NlpCommandDescriptor.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Command descriptor for querylanguage NLP command.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = NlpCommandDescriptor.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "name"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NlpCommandDescriptor extends AbstractCommandDescriptor {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayQueryString")
+        private String displayQueryString;
+
+        public Builder displayQueryString(String displayQueryString) {
+            this.displayQueryString = displayQueryString;
+            this.__explicitlySet__.add("displayQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("internalQueryString")
+        private String internalQueryString;
+
+        public Builder internalQueryString(String internalQueryString) {
+            this.internalQueryString = internalQueryString;
+            this.__explicitlySet__.add("internalQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("category")
+        private String category;
+
+        public Builder category(String category) {
+            this.category = category;
+            this.__explicitlySet__.add("category");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("referencedFields")
+        private java.util.List<AbstractField> referencedFields;
+
+        public Builder referencedFields(java.util.List<AbstractField> referencedFields) {
+            this.referencedFields = referencedFields;
+            this.__explicitlySet__.add("referencedFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("declaredFields")
+        private java.util.List<AbstractField> declaredFields;
+
+        public Builder declaredFields(java.util.List<AbstractField> declaredFields) {
+            this.declaredFields = declaredFields;
+            this.__explicitlySet__.add("declaredFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NlpCommandDescriptor build() {
+            NlpCommandDescriptor __instance__ =
+                    new NlpCommandDescriptor(
+                            displayQueryString,
+                            internalQueryString,
+                            category,
+                            referencedFields,
+                            declaredFields);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NlpCommandDescriptor o) {
+            Builder copiedBuilder =
+                    displayQueryString(o.getDisplayQueryString())
+                            .internalQueryString(o.getInternalQueryString())
+                            .category(o.getCategory())
+                            .referencedFields(o.getReferencedFields())
+                            .declaredFields(o.getDeclaredFields());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public NlpCommandDescriptor(
+            String displayQueryString,
+            String internalQueryString,
+            String category,
+            java.util.List<AbstractField> referencedFields,
+            java.util.List<AbstractField> declaredFields) {
+        super(displayQueryString, internalQueryString, category, referencedFields, declaredFields);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ObjectCollectionRuleLifecycleStates.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ObjectCollectionRuleLifecycleStates.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Possible object collection rule life cycle states.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public enum ObjectCollectionRuleLifecycleStates {
+    Active("ACTIVE"),
+    Deleted("DELETED"),
+    Inactive("INACTIVE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, ObjectCollectionRuleLifecycleStates> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (ObjectCollectionRuleLifecycleStates v : ObjectCollectionRuleLifecycleStates.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    ObjectCollectionRuleLifecycleStates(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static ObjectCollectionRuleLifecycleStates create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'ObjectCollectionRuleLifecycleStates', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ParsedContent.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ParsedContent.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Parsed Content
+ * Parsed representation of the log file.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -117,37 +117,37 @@ public class ParsedContent {
     }
 
     /**
-     * Field names
+     * List of field names.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fieldNames")
     java.util.List<String> fieldNames;
 
     /**
-     * Display names for fields
+     * List of field display names.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fieldDisplayNames")
     java.util.List<String> fieldDisplayNames;
 
     /**
-     * Parsed field values
+     * Parsed field values.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parsedFieldValues")
     java.util.List<ParsedField> parsedFieldValues;
 
     /**
-     * Sample log entries picked up from the given file for validation
+     * Sample log entries picked up from the given file for validation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logContent")
     String logContent;
 
     /**
-     * Sample Size taken for validation
+     * Sample Size taken for validation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sampleSize")
     Integer sampleSize;
 
     /**
-     * Match Status
+     * Match Status.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("matchStatus")
     String matchStatus;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ParsedField.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ParsedField.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Parsed field response
+ * Parsed field response.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -68,13 +68,13 @@ public class ParsedField {
     }
 
     /**
-     * Sample log entries picked up from the given file for validation
+     * Sample log entries picked up from the given file for validation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logContent")
     String logContent;
 
     /**
-     * Field Values
+     * List of field Values.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fieldValues")
     java.util.List<String> fieldValues;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/PropertyOverride.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/PropertyOverride.java
@@ -94,7 +94,7 @@ public class PropertyOverride {
     }
 
     /**
-     * Match Type. Accepted values are: contains
+     * Match Type. Accepted values are: contains.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("matchType")
@@ -114,7 +114,7 @@ public class PropertyOverride {
     String propertyName;
 
     /**
-     * Value.
+     * Value of the property.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("propertyValue")
     String propertyValue;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/RecalledData.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/RecalledData.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * This is the information about recalled data
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = RecalledData.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RecalledData {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+        private java.util.Date timeDataEnded;
+
+        public Builder timeDataEnded(java.util.Date timeDataEnded) {
+            this.timeDataEnded = timeDataEnded;
+            this.__explicitlySet__.add("timeDataEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+        private java.util.Date timeDataStarted;
+
+        public Builder timeDataStarted(java.util.Date timeDataStarted) {
+            this.timeDataStarted = timeDataStarted;
+            this.__explicitlySet__.add("timeDataStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("recallCount")
+        private Integer recallCount;
+
+        public Builder recallCount(Integer recallCount) {
+            this.recallCount = recallCount;
+            this.__explicitlySet__.add("recallCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("storageUsageInBytes")
+        private Long storageUsageInBytes;
+
+        public Builder storageUsageInBytes(Long storageUsageInBytes) {
+            this.storageUsageInBytes = storageUsageInBytes;
+            this.__explicitlySet__.add("storageUsageInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RecalledData build() {
+            RecalledData __instance__ =
+                    new RecalledData(
+                            timeDataEnded,
+                            timeDataStarted,
+                            timeStarted,
+                            status,
+                            recallCount,
+                            storageUsageInBytes);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RecalledData o) {
+            Builder copiedBuilder =
+                    timeDataEnded(o.getTimeDataEnded())
+                            .timeDataStarted(o.getTimeDataStarted())
+                            .timeStarted(o.getTimeStarted())
+                            .status(o.getStatus())
+                            .recallCount(o.getRecallCount())
+                            .storageUsageInBytes(o.getStorageUsageInBytes());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * This is the end of the time range of the related data
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataEnded")
+    java.util.Date timeDataEnded;
+
+    /**
+     * This is the start of the time range of the related data
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDataStarted")
+    java.util.Date timeDataStarted;
+
+    /**
+     * This is the time when the first recall operation was started for this RecalledData
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+    java.util.Date timeStarted;
+    /**
+     * This is the status of the recall
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Status {
+        Recalled("RECALLED"),
+        Pending("PENDING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Status> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Status v : Status.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Status(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Status create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Status', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * This is the status of the recall
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    Status status;
+
+    /**
+     * This is the number of recall operations for this recall.  Note one RecalledData can be merged from the results
+     * of several recall operations if the time duration of the results of the recall operations overlap.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("recallCount")
+    Integer recallCount;
+
+    /**
+     * This is the size in bytes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("storageUsageInBytes")
+    Long storageUsageInBytes;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/RecalledDataCollection.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/RecalledDataCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * This is the list of recalled data
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RecalledDataCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RecalledDataCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<RecalledData> items;
+
+        public Builder items(java.util.List<RecalledData> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RecalledDataCollection build() {
+            RecalledDataCollection __instance__ = new RecalledDataCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RecalledDataCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * This is the array of recalled data
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<RecalledData> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/RemoveEntityAssociationsDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/RemoveEntityAssociationsDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Information about the associations to be deleted between entity and other existing entities.
+ * Information about the associations to be deleted between source entity and other existing destination entities.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ScheduledTask.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ScheduledTask.java
@@ -16,195 +16,26 @@ package com.oracle.bmc.loganalytics.model;
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
-@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
 @lombok.Value
-@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ScheduledTask.Builder.class)
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind",
+    defaultImpl = ScheduledTask.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = StandardTask.class,
+        name = "STANDARD"
+    )
+})
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-@lombok.Builder(builderClassName = "Builder", toBuilder = true)
 public class ScheduledTask {
-    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
-    @lombok.experimental.Accessors(fluent = true)
-    public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("id")
-        private String id;
-
-        public Builder id(String id) {
-            this.id = id;
-            this.__explicitlySet__.add("id");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
-        private String displayName;
-
-        public Builder displayName(String displayName) {
-            this.displayName = displayName;
-            this.__explicitlySet__.add("displayName");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("taskType")
-        private TaskType taskType;
-
-        public Builder taskType(TaskType taskType) {
-            this.taskType = taskType;
-            this.__explicitlySet__.add("taskType");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("schedules")
-        private java.util.List<Schedule> schedules;
-
-        public Builder schedules(java.util.List<Schedule> schedules) {
-            this.schedules = schedules;
-            this.__explicitlySet__.add("schedules");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("action")
-        private Action action;
-
-        public Builder action(Action action) {
-            this.action = action;
-            this.__explicitlySet__.add("action");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("taskStatus")
-        private TaskStatus taskStatus;
-
-        public Builder taskStatus(TaskStatus taskStatus) {
-            this.taskStatus = taskStatus;
-            this.__explicitlySet__.add("taskStatus");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("workRequestId")
-        private String workRequestId;
-
-        public Builder workRequestId(String workRequestId) {
-            this.workRequestId = workRequestId;
-            this.__explicitlySet__.add("workRequestId");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("numOccurrences")
-        private Long numOccurrences;
-
-        public Builder numOccurrences(Long numOccurrences) {
-            this.numOccurrences = numOccurrences;
-            this.__explicitlySet__.add("numOccurrences");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
-        private String compartmentId;
-
-        public Builder compartmentId(String compartmentId) {
-            this.compartmentId = compartmentId;
-            this.__explicitlySet__.add("compartmentId");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
-        private java.util.Date timeCreated;
-
-        public Builder timeCreated(java.util.Date timeCreated) {
-            this.timeCreated = timeCreated;
-            this.__explicitlySet__.add("timeCreated");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
-        private java.util.Date timeUpdated;
-
-        public Builder timeUpdated(java.util.Date timeUpdated) {
-            this.timeUpdated = timeUpdated;
-            this.__explicitlySet__.add("timeUpdated");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-        private LifecycleState lifecycleState;
-
-        public Builder lifecycleState(LifecycleState lifecycleState) {
-            this.lifecycleState = lifecycleState;
-            this.__explicitlySet__.add("lifecycleState");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
-        private java.util.Map<String, String> freeformTags;
-
-        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
-            this.freeformTags = freeformTags;
-            this.__explicitlySet__.add("freeformTags");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
-        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
-
-        public Builder definedTags(
-                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
-            this.definedTags = definedTags;
-            this.__explicitlySet__.add("definedTags");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonIgnore
-        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
-
-        public ScheduledTask build() {
-            ScheduledTask __instance__ =
-                    new ScheduledTask(
-                            id,
-                            displayName,
-                            taskType,
-                            schedules,
-                            action,
-                            taskStatus,
-                            workRequestId,
-                            numOccurrences,
-                            compartmentId,
-                            timeCreated,
-                            timeUpdated,
-                            lifecycleState,
-                            freeformTags,
-                            definedTags);
-            __instance__.__explicitlySet__.addAll(__explicitlySet__);
-            return __instance__;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonIgnore
-        public Builder copy(ScheduledTask o) {
-            Builder copiedBuilder =
-                    id(o.getId())
-                            .displayName(o.getDisplayName())
-                            .taskType(o.getTaskType())
-                            .schedules(o.getSchedules())
-                            .action(o.getAction())
-                            .taskStatus(o.getTaskStatus())
-                            .workRequestId(o.getWorkRequestId())
-                            .numOccurrences(o.getNumOccurrences())
-                            .compartmentId(o.getCompartmentId())
-                            .timeCreated(o.getTimeCreated())
-                            .timeUpdated(o.getTimeUpdated())
-                            .lifecycleState(o.getLifecycleState())
-                            .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
-
-            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
-            return copiedBuilder;
-        }
-    }
-
-    /**
-     * Create a new builder.
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the data plane resource.
@@ -390,6 +221,49 @@ public class ScheduledTask {
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
-    @com.fasterxml.jackson.annotation.JsonIgnore
-    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+    /**
+     * Discriminator.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Kind {
+        Acceleration("ACCELERATION"),
+        Standard("STANDARD"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Kind> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Kind v : Kind.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Kind(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Kind create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Kind', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
 }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ScheduledTaskSummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ScheduledTaskSummary.java
@@ -126,6 +126,24 @@ public class ScheduledTaskSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lastExecutionStatus")
+        private LastExecutionStatus lastExecutionStatus;
+
+        public Builder lastExecutionStatus(LastExecutionStatus lastExecutionStatus) {
+            this.lastExecutionStatus = lastExecutionStatus;
+            this.__explicitlySet__.add("lastExecutionStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastExecuted")
+        private java.util.Date timeLastExecuted;
+
+        public Builder timeLastExecuted(java.util.Date timeLastExecuted) {
+            this.timeLastExecuted = timeLastExecuted;
+            this.__explicitlySet__.add("timeLastExecuted");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -142,7 +160,9 @@ public class ScheduledTaskSummary {
                             workRequestId,
                             displayName,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            lastExecutionStatus,
+                            timeLastExecuted);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -160,7 +180,9 @@ public class ScheduledTaskSummary {
                             .workRequestId(o.getWorkRequestId())
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .lastExecutionStatus(o.getLastExecutionStatus())
+                            .timeLastExecuted(o.getTimeLastExecuted());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -297,6 +319,63 @@ public class ScheduledTaskSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+    /**
+     * The most recent task execution status.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LastExecutionStatus {
+        Failed("FAILED"),
+        Succeeded("SUCCEEDED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LastExecutionStatus> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LastExecutionStatus v : LastExecutionStatus.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LastExecutionStatus(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LastExecutionStatus create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LastExecutionStatus', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The most recent task execution status.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastExecutionStatus")
+    LastExecutionStatus lastExecutionStatus;
+
+    /**
+     * The date and time the scheduled task last executed, in the format defined by RFC3339.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastExecuted")
+    java.util.Date timeLastExecuted;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/SortField.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/SortField.java
@@ -112,6 +112,15 @@ public class SortField extends AbstractField {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("unitType")
+        private String unitType;
+
+        public Builder unitType(String unitType) {
+            this.unitType = unitType;
+            this.__explicitlySet__.add("unitType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("direction")
         private Direction direction;
 
@@ -136,6 +145,7 @@ public class SortField extends AbstractField {
                             isDuration,
                             alias,
                             filterQueryString,
+                            unitType,
                             direction);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -153,6 +163,7 @@ public class SortField extends AbstractField {
                             .isDuration(o.getIsDuration())
                             .alias(o.getAlias())
                             .filterQueryString(o.getFilterQueryString())
+                            .unitType(o.getUnitType())
                             .direction(o.getDirection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -178,6 +189,7 @@ public class SortField extends AbstractField {
             Boolean isDuration,
             String alias,
             String filterQueryString,
+            String unitType,
             Direction direction) {
         super(
                 displayName,
@@ -188,7 +200,8 @@ public class SortField extends AbstractField {
                 isGroupable,
                 isDuration,
                 alias,
-                filterQueryString);
+                filterQueryString,
+                unitType);
         this.direction = direction;
     }
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/SourceMappingResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/SourceMappingResponse.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Response object containing match status and parsed representation of log data
+ * Response object containing match status and parsed representation of log data.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -61,7 +61,7 @@ public class SourceMappingResponse {
     }
 
     /**
-     * Parsed representation of the log file
+     * Parsed representation of the log file.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parsedResponse")
     java.util.List<ParsedContent> parsedResponse;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/StandardTask.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/StandardTask.java
@@ -1,0 +1,334 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Log analytics scheduled task resource.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = StandardTask.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class StandardTask extends ScheduledTask {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("taskType")
+        private TaskType taskType;
+
+        public Builder taskType(TaskType taskType) {
+            this.taskType = taskType;
+            this.__explicitlySet__.add("taskType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schedules")
+        private java.util.List<Schedule> schedules;
+
+        public Builder schedules(java.util.List<Schedule> schedules) {
+            this.schedules = schedules;
+            this.__explicitlySet__.add("schedules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("action")
+        private Action action;
+
+        public Builder action(Action action) {
+            this.action = action;
+            this.__explicitlySet__.add("action");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("taskStatus")
+        private TaskStatus taskStatus;
+
+        public Builder taskStatus(TaskStatus taskStatus) {
+            this.taskStatus = taskStatus;
+            this.__explicitlySet__.add("taskStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("workRequestId")
+        private String workRequestId;
+
+        public Builder workRequestId(String workRequestId) {
+            this.workRequestId = workRequestId;
+            this.__explicitlySet__.add("workRequestId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("numOccurrences")
+        private Long numOccurrences;
+
+        public Builder numOccurrences(Long numOccurrences) {
+            this.numOccurrences = numOccurrences;
+            this.__explicitlySet__.add("numOccurrences");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lastExecutionStatus")
+        private LastExecutionStatus lastExecutionStatus;
+
+        public Builder lastExecutionStatus(LastExecutionStatus lastExecutionStatus) {
+            this.lastExecutionStatus = lastExecutionStatus;
+            this.__explicitlySet__.add("lastExecutionStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastExecuted")
+        private java.util.Date timeLastExecuted;
+
+        public Builder timeLastExecuted(java.util.Date timeLastExecuted) {
+            this.timeLastExecuted = timeLastExecuted;
+            this.__explicitlySet__.add("timeLastExecuted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public StandardTask build() {
+            StandardTask __instance__ =
+                    new StandardTask(
+                            id,
+                            displayName,
+                            taskType,
+                            schedules,
+                            action,
+                            taskStatus,
+                            workRequestId,
+                            numOccurrences,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags,
+                            lastExecutionStatus,
+                            timeLastExecuted);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(StandardTask o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .taskType(o.getTaskType())
+                            .schedules(o.getSchedules())
+                            .action(o.getAction())
+                            .taskStatus(o.getTaskStatus())
+                            .workRequestId(o.getWorkRequestId())
+                            .numOccurrences(o.getNumOccurrences())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .lastExecutionStatus(o.getLastExecutionStatus())
+                            .timeLastExecuted(o.getTimeLastExecuted());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public StandardTask(
+            String id,
+            String displayName,
+            TaskType taskType,
+            java.util.List<Schedule> schedules,
+            Action action,
+            TaskStatus taskStatus,
+            String workRequestId,
+            Long numOccurrences,
+            String compartmentId,
+            java.util.Date timeCreated,
+            java.util.Date timeUpdated,
+            LifecycleState lifecycleState,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            LastExecutionStatus lastExecutionStatus,
+            java.util.Date timeLastExecuted) {
+        super(
+                id,
+                displayName,
+                taskType,
+                schedules,
+                action,
+                taskStatus,
+                workRequestId,
+                numOccurrences,
+                compartmentId,
+                timeCreated,
+                timeUpdated,
+                lifecycleState,
+                freeformTags,
+                definedTags);
+        this.lastExecutionStatus = lastExecutionStatus;
+        this.timeLastExecuted = timeLastExecuted;
+    }
+
+    /**
+     * The most recent task execution status.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LastExecutionStatus {
+        Failed("FAILED"),
+        Succeeded("SUCCEEDED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LastExecutionStatus> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LastExecutionStatus v : LastExecutionStatus.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LastExecutionStatus(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LastExecutionStatus create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LastExecutionStatus', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The most recent task execution status.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastExecutionStatus")
+    LastExecutionStatus lastExecutionStatus;
+
+    /**
+     * The date and time the scheduled task last executed, in the format defined by RFC3339.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastExecuted")
+    java.util.Date timeLastExecuted;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/StreamAction.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/StreamAction.java
@@ -39,18 +39,28 @@ public class StreamAction extends Action {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("metricExtraction")
+        private MetricExtraction metricExtraction;
+
+        public Builder metricExtraction(MetricExtraction metricExtraction) {
+            this.metricExtraction = metricExtraction;
+            this.__explicitlySet__.add("metricExtraction");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public StreamAction build() {
-            StreamAction __instance__ = new StreamAction(savedSearchId);
+            StreamAction __instance__ = new StreamAction(savedSearchId, metricExtraction);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(StreamAction o) {
-            Builder copiedBuilder = savedSearchId(o.getSavedSearchId());
+            Builder copiedBuilder =
+                    savedSearchId(o.getSavedSearchId()).metricExtraction(o.getMetricExtraction());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -65,9 +75,10 @@ public class StreamAction extends Action {
     }
 
     @Deprecated
-    public StreamAction(String savedSearchId) {
+    public StreamAction(String savedSearchId, MetricExtraction metricExtraction) {
         super();
         this.savedSearchId = savedSearchId;
+        this.metricExtraction = metricExtraction;
     }
 
     /**
@@ -75,6 +86,9 @@ public class StreamAction extends Action {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("savedSearchId")
     String savedSearchId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("metricExtraction")
+    MetricExtraction metricExtraction;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateLogAnalyticsEntityDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateLogAnalyticsEntityDetails.java
@@ -132,7 +132,7 @@ public class UpdateLogAnalyticsEntityDetails {
     }
 
     /**
-     * Log analytics entity name. The name must be unique, within the tenancy, and cannot be changed.
+     * Log analytics entity name.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateLogAnalyticsObjectCollectionRuleDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateLogAnalyticsObjectCollectionRuleDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * To update the attributes of an Object Storage based collection rule.
+ * Configuration of the collection rule to be updated.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -72,6 +72,15 @@ public class UpdateLogAnalyticsObjectCollectionRuleDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("overrides")
         private java.util.Map<String, java.util.List<PropertyOverride>> overrides;
 
@@ -112,6 +121,7 @@ public class UpdateLogAnalyticsObjectCollectionRuleDetails {
                             logSourceName,
                             entityId,
                             charEncoding,
+                            isEnabled,
                             overrides,
                             definedTags,
                             freeformTags);
@@ -127,6 +137,7 @@ public class UpdateLogAnalyticsObjectCollectionRuleDetails {
                             .logSourceName(o.getLogSourceName())
                             .entityId(o.getEntityId())
                             .charEncoding(o.getCharEncoding())
+                            .isEnabled(o.getIsEnabled())
                             .overrides(o.getOverrides())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
@@ -171,13 +182,20 @@ public class UpdateLogAnalyticsObjectCollectionRuleDetails {
 
     /**
      * An optional character encoding to aid in detecting the character encoding of the contents of the objects while processing.
-     * It is recommended to set this value as ISO_8589_1 when configuring content of the objects having more numeric characters,
+     * It is recommended to set this value as ISO_8859_1 when configuring content of the objects having more numeric characters,
      * and very few alphabets.
      * For e.g. this applies when configuring VCN Flow Logs.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("charEncoding")
     String charEncoding;
+
+    /**
+     * Whether or not this rule is currently enabled.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
 
     /**
      * Use this to override some property values which are defined at bucket level to the scope of object.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateLookupMetadataDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateLookupMetadataDetails.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * UpdateLookupMetadataDetails
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateLookupMetadataDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateLookupMetadataDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("defaultMatchValue")
+        private String defaultMatchValue;
+
+        public Builder defaultMatchValue(String defaultMatchValue) {
+            this.defaultMatchValue = defaultMatchValue;
+            this.__explicitlySet__.add("defaultMatchValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fields")
+        private java.util.List<LogAnalyticsLookupFields> fields;
+
+        public Builder fields(java.util.List<LogAnalyticsLookupFields> fields) {
+            this.fields = fields;
+            this.__explicitlySet__.add("fields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxMatches")
+        private Long maxMatches;
+
+        public Builder maxMatches(Long maxMatches) {
+            this.maxMatches = maxMatches;
+            this.__explicitlySet__.add("maxMatches");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateLookupMetadataDetails build() {
+            UpdateLookupMetadataDetails __instance__ =
+                    new UpdateLookupMetadataDetails(
+                            defaultMatchValue, description, fields, maxMatches);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateLookupMetadataDetails o) {
+            Builder copiedBuilder =
+                    defaultMatchValue(o.getDefaultMatchValue())
+                            .description(o.getDescription())
+                            .fields(o.getFields())
+                            .maxMatches(o.getMaxMatches());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The default match value.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultMatchValue")
+    String defaultMatchValue;
+
+    /**
+     * The lookup description.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The lookup fields.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("fields")
+    java.util.List<LogAnalyticsLookupFields> fields;
+
+    /**
+     * The maximum number of matches.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxMatches")
+    Long maxMatches;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateScheduledTaskDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateScheduledTaskDetails.java
@@ -16,84 +16,26 @@ package com.oracle.bmc.loganalytics.model;
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
-@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
-@lombok.Value
-@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
-    builder = UpdateScheduledTaskDetails.Builder.class
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
 )
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind",
+    defaultImpl = UpdateScheduledTaskDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateStandardTaskDetails.class,
+        name = "STANDARD"
+    )
+})
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-@lombok.Builder(builderClassName = "Builder", toBuilder = true)
 public class UpdateScheduledTaskDetails {
-    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
-    @lombok.experimental.Accessors(fluent = true)
-    public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
-        private String displayName;
-
-        public Builder displayName(String displayName) {
-            this.displayName = displayName;
-            this.__explicitlySet__.add("displayName");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
-        private java.util.Map<String, String> freeformTags;
-
-        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
-            this.freeformTags = freeformTags;
-            this.__explicitlySet__.add("freeformTags");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
-        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
-
-        public Builder definedTags(
-                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
-            this.definedTags = definedTags;
-            this.__explicitlySet__.add("definedTags");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("schedules")
-        private java.util.List<Schedule> schedules;
-
-        public Builder schedules(java.util.List<Schedule> schedules) {
-            this.schedules = schedules;
-            this.__explicitlySet__.add("schedules");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonIgnore
-        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
-
-        public UpdateScheduledTaskDetails build() {
-            UpdateScheduledTaskDetails __instance__ =
-                    new UpdateScheduledTaskDetails(
-                            displayName, freeformTags, definedTags, schedules);
-            __instance__.__explicitlySet__.addAll(__explicitlySet__);
-            return __instance__;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonIgnore
-        public Builder copy(UpdateScheduledTaskDetails o) {
-            Builder copiedBuilder =
-                    displayName(o.getDisplayName())
-                            .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags())
-                            .schedules(o.getSchedules());
-
-            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
-            return copiedBuilder;
-        }
-    }
-
-    /**
-     * Create a new builder.
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
 
     /**
      * A user-friendly name that is changeable and that does not have to be unique.
@@ -122,12 +64,46 @@ public class UpdateScheduledTaskDetails {
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * Schedules may be updated for task types SAVED_SEARCH and PURGE
+     * Schedules may be updated for task types SAVED_SEARCH and PURGE.
+     * Note there may only be a single schedule for SAVED_SEARCH and PURGE scheduled tasks.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("schedules")
     java.util.List<Schedule> schedules;
 
-    @com.fasterxml.jackson.annotation.JsonIgnore
-    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+    /**
+     * Discriminator.
+     **/
+    public enum Kind {
+        Acceleration("ACCELERATION"),
+        Standard("STANDARD"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Kind> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Kind v : Kind.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Kind(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Kind create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Kind: " + key);
+        }
+    };
 }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateStandardTaskDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateStandardTaskDetails.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * The details for updating a schedule task.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateStandardTaskDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateStandardTaskDetails extends UpdateScheduledTaskDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("schedules")
+        private java.util.List<Schedule> schedules;
+
+        public Builder schedules(java.util.List<Schedule> schedules) {
+            this.schedules = schedules;
+            this.__explicitlySet__.add("schedules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("action")
+        private Action action;
+
+        public Builder action(Action action) {
+            this.action = action;
+            this.__explicitlySet__.add("action");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateStandardTaskDetails build() {
+            UpdateStandardTaskDetails __instance__ =
+                    new UpdateStandardTaskDetails(
+                            displayName, freeformTags, definedTags, schedules, action);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateStandardTaskDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .schedules(o.getSchedules())
+                            .action(o.getAction());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateStandardTaskDetails(
+            String displayName,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.List<Schedule> schedules,
+            Action action) {
+        super(displayName, freeformTags, definedTags, schedules);
+        this.action = action;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("action")
+    Action action;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/Upload.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/Upload.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Upload is a container that can be used to optionally put all the relevant and related on-demand upload based log files.
+ * Upload is a container that can be used to put all the relevant and related on-demand upload based log files together.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -129,37 +129,37 @@ public class Upload {
     }
 
     /**
-     * Unique internal identifier to refer to the upload container
+     * Unique internal identifier to refer the upload container.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("reference")
     String reference;
 
     /**
-     * The name of the upload container
+     * The name of the upload container.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * The time when this upload container is created. An RFC3339 formatted datetime string
+     * The time when this upload container is created. An RFC3339 formatted datetime string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
 
     /**
-     * The latest time when this upload container is modified. An RFC3339 formatted datetime string
+     * The latest time when this upload container is modified. An RFC3339 formatted datetime string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     java.util.Date timeUpdated;
 
     /**
-     * This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string
+     * This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeEarliestLogEntry")
     java.util.Date timeEarliestLogEntry;
 
     /**
-     * This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string
+     * This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeLatestLogEntry")
     java.util.Date timeLatestLogEntry;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadFileStatus.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadFileStatus.java
@@ -68,13 +68,13 @@ public class UploadFileStatus {
     }
 
     /**
-     * Name of the file
+     * Name of the file.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fileName")
     String fileName;
 
     /**
-     * Is Valid flag
+     * Is Valid flag.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isValid")
     Boolean isValid;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadFileSummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadFileSummary.java
@@ -218,7 +218,7 @@ public class UploadFileSummary {
     }
 
     /**
-     * Unique internal identifier to refer to upload file
+     * Unique internal identifier to refer upload file.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("reference")
     String reference;
@@ -288,37 +288,37 @@ public class UploadFileSummary {
     java.math.BigDecimal totalChunks;
 
     /**
-     * Number of chunks processed
+     * Number of chunks processed.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("chunksConsumed")
     java.math.BigDecimal chunksConsumed;
 
     /**
-     * Number of chunks processed successfully
+     * Number of chunks processed successfully.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("chunksSuccess")
     java.math.BigDecimal chunksSuccess;
 
     /**
-     * Number of chunks failed processing
+     * Number of chunks failed processing.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("chunksFail")
     java.math.BigDecimal chunksFail;
 
     /**
-     * The time when this file processing started
+     * The time when this file processing started.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
     java.util.Date timeStarted;
 
     /**
-     * Name of the log source used for processing this file
+     * Name of the log source used for processing this file.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceName")
     String sourceName;
 
     /**
-     * Name of the entity type
+     * Name of the entity type.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("entityType")
     String entityType;
@@ -330,7 +330,7 @@ public class UploadFileSummary {
     String entityName;
 
     /**
-     * Log namespace associated with the file.
+     * (Deprecated) Name of the log namespace associated with the file.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logNamespace")
     String logNamespace;
@@ -342,13 +342,13 @@ public class UploadFileSummary {
     String logGroupId;
 
     /**
-     * Log group name associated with the file.
+     * Name of the log group associated with the file.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logGroupName")
     String logGroupName;
 
     /**
-     * The details about upload processing failure
+     * The details about upload processing failure.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("failureDetails")
     String failureDetails;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadSummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadSummary.java
@@ -128,37 +128,37 @@ public class UploadSummary {
     }
 
     /**
-     * Unique internal identifier to refer to the upload container
+     * Unique internal identifier to refer the upload container.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("reference")
     String reference;
 
     /**
-     * The name of the upload container
+     * The name of the upload container.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * The time when this upload container is created. An RFC3339 formatted datetime string
+     * The time when this upload container is created. An RFC3339 formatted datetime string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
 
     /**
-     * The latest time when this upload container is modified. An RFC3339 formatted datetime string
+     * The latest time when this upload container is modified. An RFC3339 formatted datetime string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     java.util.Date timeUpdated;
 
     /**
-     * This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string
+     * This time represents the earliest time of the log entry in this container. An RFC3339 formatted datetime string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeEarliestLogEntry")
     java.util.Date timeEarliestLogEntry;
 
     /**
-     * This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string
+     * This time represents the latest time of the log entry in this container. An RFC3339 formatted datetime string.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeLatestLogEntry")
     java.util.Date timeLatestLogEntry;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadWarningCollection.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadWarningCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loganalytics.model;
 
 /**
- * Collection of UploadFileSummary objects.
+ * Collection of UploadWarningSummary objects.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadWarningSummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UploadWarningSummary.java
@@ -93,25 +93,25 @@ public class UploadWarningSummary {
     }
 
     /**
-     * Unique internal identifier to refer to upload warning
+     * Unique internal identifier to refer upload warning.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("reference")
     String reference;
 
     /**
-     * Status of the upload. Ex - Failed
+     * Status of the upload. Ex - Failed.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("status")
     String status;
 
     /**
-     * The time when the upload processing started
+     * The time when the upload processing started.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
     java.util.Date timeStarted;
 
     /**
-     * The details about upload processing failure
+     * The details about upload processing failure.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("errorMessage")
     String errorMessage;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/WarningReferenceDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/WarningReferenceDetails.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * A list of LogAnalyticsWarning references.  Used as input to APIs which operate on a
+ * list.  For example, the suppress warning API accepts a list of warning references
+ * and will suppress all warnings in the input list.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WarningReferenceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WarningReferenceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("warningReferences")
+        private java.util.List<String> warningReferences;
+
+        public Builder warningReferences(java.util.List<String> warningReferences) {
+            this.warningReferences = warningReferences;
+            this.__explicitlySet__.add("warningReferences");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WarningReferenceDetails build() {
+            WarningReferenceDetails __instance__ = new WarningReferenceDetails(warningReferences);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WarningReferenceDetails o) {
+            Builder copiedBuilder = warningReferences(o.getWarningReferences());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A list of LogAnalyticsWarning references.  Used as input to APIs which operate on a
+     * list.  For example, the suppress warning API accepts a list of warning references
+     * and will suppress all warnings in the input list.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("warningReferences")
+    java.util.List<String> warningReferences;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/AddEntityAssociationRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/AddEntityAssociationRequest.java
@@ -27,7 +27,7 @@ public class AddEntityAssociationRequest
     private String logAnalyticsEntityId;
 
     /**
-     * This parameter specifies the entity OCIDs with which associations are to be created. Specify destination OCIDs as comma separated string.
+     * This parameter specifies the destination entity OCIDs with which associations are to be created.
      */
     private AddEntityAssociationDetails addEntityAssociationDetails;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/AppendLookupDataRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/AppendLookupDataRequest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/AppendLookupDataExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use AppendLookupDataRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class AppendLookupDataRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.io.InputStream> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * The name of the lookup to operate on.
+     */
+    private String lookupName;
+
+    /**
+     * The file to append.
+     */
+    private java.io.InputStream appendLookupFileBody;
+
+    /**
+     * is force
+     */
+    private Boolean isForce;
+
+    /**
+     * Character Encoding
+     */
+    private String charEncoding;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public java.io.InputStream getBody$() {
+        return appendLookupFileBody;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    AppendLookupDataRequest, java.io.InputStream> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AppendLookupDataRequest o) {
+            namespaceName(o.getNamespaceName());
+            lookupName(o.getLookupName());
+            appendLookupFileBody(o.getAppendLookupFileBody());
+            isForce(o.getIsForce());
+            charEncoding(o.getCharEncoding());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of AppendLookupDataRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of AppendLookupDataRequest
+         */
+        public AppendLookupDataRequest build() {
+            AppendLookupDataRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(java.io.InputStream body) {
+            appendLookupFileBody(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ChangeLogAnalyticsObjectCollectionRuleCompartmentRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ChangeLogAnalyticsObjectCollectionRuleCompartmentRequest.java
@@ -22,7 +22,7 @@ public class ChangeLogAnalyticsObjectCollectionRuleCompartmentRequest
     private String namespaceName;
 
     /**
-     * The Logging Analytics Object Collection Rule [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
+     * The Logging Analytics Object Collection Rule [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String logAnalyticsObjectCollectionRuleId;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteLogAnalyticsObjectCollectionRuleRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteLogAnalyticsObjectCollectionRuleRequest.java
@@ -21,7 +21,7 @@ public class DeleteLogAnalyticsObjectCollectionRuleRequest
     private String namespaceName;
 
     /**
-     * The Logging Analytics Object Collection Rule [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
+     * The Logging Analytics Object Collection Rule [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String logAnalyticsObjectCollectionRuleId;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteLookupRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteLookupRequest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/DeleteLookupExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteLookupRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteLookupRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * The name of the lookup to operate on.
+     */
+    private String lookupName;
+
+    /**
+     * is force
+     */
+    private Boolean isForce;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteLookupRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteLookupRequest o) {
+            namespaceName(o.getNamespaceName());
+            lookupName(o.getLookupName());
+            isForce(o.getIsForce());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteLookupRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteLookupRequest
+         */
+        public DeleteLookupRequest build() {
+            DeleteLookupRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteUploadFileRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteUploadFileRequest.java
@@ -20,12 +20,12 @@ public class DeleteUploadFileRequest extends com.oracle.bmc.requests.BmcRequest<
     private String namespaceName;
 
     /**
-     * Unique internal identifier to refer to upload container
+     * Unique internal identifier to refer upload container.
      */
     private String uploadReference;
 
     /**
-     * Unique internal identifier to refer to upload file
+     * Unique internal identifier to refer upload file.
      */
     private String fileReference;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteUploadRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteUploadRequest.java
@@ -20,7 +20,7 @@ public class DeleteUploadRequest extends com.oracle.bmc.requests.BmcRequest<java
     private String namespaceName;
 
     /**
-     * Unique internal identifier to refer to upload container
+     * Unique internal identifier to refer upload container.
      */
     private String uploadReference;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteUploadWarningRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/DeleteUploadWarningRequest.java
@@ -20,12 +20,12 @@ public class DeleteUploadWarningRequest extends com.oracle.bmc.requests.BmcReque
     private String namespaceName;
 
     /**
-     * Unique internal identifier to refer to upload container
+     * Unique internal identifier to refer upload container.
      */
     private String uploadReference;
 
     /**
-     * Unique internal identifier to refer to upload warning
+     * Unique internal identifier to refer upload warning.
      */
     private String warningReference;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/EstimateRecallDataSizeRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/EstimateRecallDataSizeRequest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/EstimateRecallDataSizeExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use EstimateRecallDataSizeRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class EstimateRecallDataSizeRequest
+        extends com.oracle.bmc.requests.BmcRequest<EstimateRecallDataSizeDetails> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * This is the input to estimate the size of data to be recalled.
+     */
+    private EstimateRecallDataSizeDetails estimateRecallDataSizeDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public EstimateRecallDataSizeDetails getBody$() {
+        return estimateRecallDataSizeDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    EstimateRecallDataSizeRequest, EstimateRecallDataSizeDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(EstimateRecallDataSizeRequest o) {
+            namespaceName(o.getNamespaceName());
+            estimateRecallDataSizeDetails(o.getEstimateRecallDataSizeDetails());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of EstimateRecallDataSizeRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of EstimateRecallDataSizeRequest
+         */
+        public EstimateRecallDataSizeRequest build() {
+            EstimateRecallDataSizeRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(EstimateRecallDataSizeDetails body) {
+            estimateRecallDataSizeDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/EstimateReleaseDataSizeRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/EstimateReleaseDataSizeRequest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/EstimateReleaseDataSizeExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use EstimateReleaseDataSizeRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class EstimateReleaseDataSizeRequest
+        extends com.oracle.bmc.requests.BmcRequest<EstimateReleaseDataSizeDetails> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * This is the input to estimate the size of recalled data to be released.
+     */
+    private EstimateReleaseDataSizeDetails estimateReleaseDataSizeDetails;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public EstimateReleaseDataSizeDetails getBody$() {
+        return estimateReleaseDataSizeDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    EstimateReleaseDataSizeRequest, EstimateReleaseDataSizeDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(EstimateReleaseDataSizeRequest o) {
+            namespaceName(o.getNamespaceName());
+            estimateReleaseDataSizeDetails(o.getEstimateReleaseDataSizeDetails());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of EstimateReleaseDataSizeRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of EstimateReleaseDataSizeRequest
+         */
+        public EstimateReleaseDataSizeRequest build() {
+            EstimateReleaseDataSizeRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(EstimateReleaseDataSizeDetails body) {
+            estimateReleaseDataSizeDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetLogAnalyticsObjectCollectionRuleRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetLogAnalyticsObjectCollectionRuleRequest.java
@@ -21,7 +21,7 @@ public class GetLogAnalyticsObjectCollectionRuleRequest
     private String namespaceName;
 
     /**
-     * The Logging Analytics Object Collection Rule [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
+     * The Logging Analytics Object Collection Rule [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String logAnalyticsObjectCollectionRuleId;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetLookupRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetLookupRequest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/GetLookupExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetLookupRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetLookupRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * The name of the lookup to operate on.
+     */
+    private String lookupName;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetLookupRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetLookupRequest o) {
+            namespaceName(o.getNamespaceName());
+            lookupName(o.getLookupName());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetLookupRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetLookupRequest
+         */
+        public GetLookupRequest build() {
+            GetLookupRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetUploadRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetUploadRequest.java
@@ -20,7 +20,7 @@ public class GetUploadRequest extends com.oracle.bmc.requests.BmcRequest<java.la
     private String namespaceName;
 
     /**
-     * Unique internal identifier to refer to upload container
+     * Unique internal identifier to refer upload container.
      */
     private String uploadReference;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListLookupsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListLookupsRequest.java
@@ -1,0 +1,325 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ListLookupsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListLookupsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListLookupsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * type - possible values are Lookup or Dictionary
+     */
+    private Type type;
+
+    /**
+     * type - possible values are Lookup or Dictionary
+     **/
+    public enum Type {
+        Lookup("Lookup"),
+        Dictionary("Dictionary"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Type> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Type v : Type.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Type create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Type: " + key);
+        }
+    };
+    /**
+     * Search by lookup display name or description.
+     */
+    private String lookupDisplayText;
+
+    /**
+     * Is system param of value (all, custom, sourceUsing)
+     *
+     */
+    private IsSystem isSystem;
+
+    /**
+     * Is system param of value (all, custom, sourceUsing)
+     *
+     **/
+    public enum IsSystem {
+        All("ALL"),
+        Custom("CUSTOM"),
+        BuiltIn("BUILT_IN"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, IsSystem> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (IsSystem v : IsSystem.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        IsSystem(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static IsSystem create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid IsSystem: " + key);
+        }
+    };
+    /**
+     * sort by field
+     */
+    private SortBy sortBy;
+
+    /**
+     * sort by field
+     **/
+    public enum SortBy {
+        DisplayName("displayName"),
+        Status("status"),
+        Type("type"),
+        UpdatedTime("updatedTime"),
+        CreationType("creationType"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The lookup status used for filtering when fetching a list of lookups.
+     */
+    private Status status;
+
+    /**
+     * The lookup status used for filtering when fetching a list of lookups.
+     **/
+    public enum Status {
+        All("ALL"),
+        Succesful("SUCCESFUL"),
+        Failed("FAILED"),
+        Inprogress("INPROGRESS"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Status> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Status v : Status.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Status(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Status create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Status: " + key);
+        }
+    };
+    /**
+     * is include items
+     */
+    private Boolean isHideSpecial;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListLookupsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListLookupsRequest o) {
+            namespaceName(o.getNamespaceName());
+            type(o.getType());
+            lookupDisplayText(o.getLookupDisplayText());
+            isSystem(o.getIsSystem());
+            sortBy(o.getSortBy());
+            status(o.getStatus());
+            isHideSpecial(o.getIsHideSpecial());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListLookupsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListLookupsRequest
+         */
+        public ListLookupsRequest build() {
+            ListLookupsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListMetaSourceTypesRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListMetaSourceTypesRequest.java
@@ -32,8 +32,42 @@ public class ListMetaSourceTypesRequest extends com.oracle.bmc.requests.BmcReque
     /**
      * sort by field
      */
-    private String sortBy;
+    private SortBy sortBy;
 
+    /**
+     * sort by field
+     **/
+    public enum SortBy {
+        Name("name"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
     /**
      * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
      *

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListParserFunctionsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListParserFunctionsRequest.java
@@ -37,8 +37,42 @@ public class ListParserFunctionsRequest extends com.oracle.bmc.requests.BmcReque
     /**
      * sort by field
      */
-    private String sortBy;
+    private SortBy sortBy;
 
+    /**
+     * sort by field
+     **/
+    public enum SortBy {
+        Name("name"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
     /**
      * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
      *

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListParserMetaPluginsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListParserMetaPluginsRequest.java
@@ -33,8 +33,42 @@ public class ListParserMetaPluginsRequest
     /**
      * sort by field
      */
-    private String sortBy;
+    private SortBy sortBy;
 
+    /**
+     * sort by field
+     **/
+    public enum SortBy {
+        Name("name"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
     /**
      * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
      *

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListRecalledDataRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListRecalledDataRequest.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ListRecalledDataExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListRecalledDataRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListRecalledDataRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * This is the query parameter of which field to sort by. Only one sort order may be provided. Default order for timeDataStarted
+     * is descending. If no value is specified timeDataStarted is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * This is the query parameter of which field to sort by. Only one sort order may be provided. Default order for timeDataStarted
+     * is descending. If no value is specified timeDataStarted is default.
+     *
+     **/
+    public enum SortBy {
+        TimeStarted("timeStarted"),
+        TimeDataStarted("timeDataStarted"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * This is the start of the time range for recalled data
+     */
+    private java.util.Date timeDataStartedGreaterThanOrEqual;
+
+    /**
+     * This is the end of the time range for recalled data
+     */
+    private java.util.Date timeDataEndedLessThan;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListRecalledDataRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListRecalledDataRequest o) {
+            namespaceName(o.getNamespaceName());
+            opcRequestId(o.getOpcRequestId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            timeDataStartedGreaterThanOrEqual(o.getTimeDataStartedGreaterThanOrEqual());
+            timeDataEndedLessThan(o.getTimeDataEndedLessThan());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListRecalledDataRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListRecalledDataRequest
+         */
+        public ListRecalledDataRequest build() {
+            ListRecalledDataRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListSourceLabelOperatorsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListSourceLabelOperatorsRequest.java
@@ -33,8 +33,42 @@ public class ListSourceLabelOperatorsRequest
     /**
      * sort by field
      */
-    private String sortBy;
+    private SortBy sortBy;
 
+    /**
+     * sort by field
+     **/
+    public enum SortBy {
+        Name("name"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
     /**
      * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
      *

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListSourceMetaFunctionsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListSourceMetaFunctionsRequest.java
@@ -33,8 +33,42 @@ public class ListSourceMetaFunctionsRequest
     /**
      * sort by field
      */
-    private String sortBy;
+    private SortBy sortBy;
 
+    /**
+     * sort by field
+     **/
+    public enum SortBy {
+        Name("name"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
     /**
      * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
      *

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListSourcesRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListSourcesRequest.java
@@ -30,7 +30,7 @@ public class ListSourcesRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String entityType;
 
     /**
-     * search by source display name or description
+     * Search by source display name or description.
      */
     private String sourceDisplayText;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListUploadFilesRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListUploadFilesRequest.java
@@ -20,7 +20,7 @@ public class ListUploadFilesRequest extends com.oracle.bmc.requests.BmcRequest<j
     private String namespaceName;
 
     /**
-     * Unique internal identifier to refer to upload container
+     * Unique internal identifier to refer upload container.
      */
     private String uploadReference;
 
@@ -77,21 +77,26 @@ public class ListUploadFilesRequest extends com.oracle.bmc.requests.BmcRequest<j
         }
     };
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending.
+     * The field to sort by. Only one sort order may be provided. Default order for timeStarted is descending.
+     * timeCreated, fileName and logGroup are deprecated. Instead use timestarted, name, logGroup accordingly.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending.
+     * The field to sort by. Only one sort order may be provided. Default order for timeStarted is descending.
+     * timeCreated, fileName and logGroup are deprecated. Instead use timestarted, name, logGroup accordingly.
      *
      **/
     public enum SortBy {
+        TimeStarted("timeStarted"),
+        Name("name"),
+        LogGroupName("logGroupName"),
+        SourceName("sourceName"),
+        Status("status"),
         TimeCreated("timeCreated"),
         FileName("fileName"),
         LogGroup("logGroup"),
-        SourceName("sourceName"),
-        Status("status"),
         ;
 
         private final String value;
@@ -122,17 +127,17 @@ public class ListUploadFilesRequest extends com.oracle.bmc.requests.BmcRequest<j
         }
     };
     /**
-     * Search string used to filtering uploads based on file name, log group name and log source name.
+     * This can be used to filter upload files based on the file, log group and log source names.
      */
     private String searchStr;
 
     /**
-     * Upload Status.
+     * Upload File processing state.
      */
     private java.util.List<Status> status;
 
     /**
-     * Upload Status.
+     * Upload File processing state.
      **/
     public enum Status {
         InProgress("IN_PROGRESS"),

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListUploadWarningsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListUploadWarningsRequest.java
@@ -20,7 +20,7 @@ public class ListUploadWarningsRequest extends com.oracle.bmc.requests.BmcReques
     private String namespaceName;
 
     /**
-     * Unique internal identifier to refer to upload container
+     * Unique internal identifier to refer upload container.
      */
     private String uploadReference;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListWarningsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ListWarningsRequest.java
@@ -1,0 +1,298 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ListWarningsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWarningsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListWarningsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * The ID of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * The warning state used for filtering.  A value of SUPPRESSED will return only
+     * suppressed warnings, a value of UNSUPPRESSED will return only unsuppressed
+     * warnings, and a value of ALL will return all warnings regardless of their
+     * suppression state.  Default is UNSUPPRESSED.
+     *
+     */
+    private WarningState warningState;
+
+    /**
+     * The warning state used for filtering.  A value of SUPPRESSED will return only
+     * suppressed warnings, a value of UNSUPPRESSED will return only unsuppressed
+     * warnings, and a value of ALL will return all warnings regardless of their
+     * suppression state.  Default is UNSUPPRESSED.
+     *
+     **/
+    public enum WarningState {
+        All("ALL"),
+        Suppressed("SUPPRESSED"),
+        Unsuppressed("UNSUPPRESSED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, WarningState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (WarningState v : WarningState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        WarningState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static WarningState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid WarningState: " + key);
+        }
+    };
+    /**
+     * sourceName
+     */
+    private String sourceName;
+
+    /**
+     * sourcePattern
+     */
+    private String sourcePattern;
+
+    /**
+     * warning message query parameter
+     */
+    private String warningMessage;
+
+    /**
+     * entityName
+     */
+    private String entityName;
+
+    /**
+     * entity type name
+     */
+    private String entityType;
+
+    /**
+     * The warning type query parameter.
+     */
+    private String warningType;
+
+    /**
+     * isNoSource
+     */
+    private Boolean isNoSource;
+
+    /**
+     * The warning start date query parameter.
+     */
+    private String startTime;
+
+    /**
+     * The warning end date query parameter.
+     */
+    private String endTime;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The attribute used to sort the returned warnings
+     */
+    private SortBy sortBy;
+
+    /**
+     * The attribute used to sort the returned warnings
+     **/
+    public enum SortBy {
+        EntityType("EntityType"),
+        SourceName("SourceName"),
+        PatternText("PatternText"),
+        FirstReported("FirstReported"),
+        WarningMessage("WarningMessage"),
+        Host("Host"),
+        EntityName("EntityName"),
+        InitialWarningDate("InitialWarningDate"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListWarningsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWarningsRequest o) {
+            namespaceName(o.getNamespaceName());
+            compartmentId(o.getCompartmentId());
+            warningState(o.getWarningState());
+            sourceName(o.getSourceName());
+            sourcePattern(o.getSourcePattern());
+            warningMessage(o.getWarningMessage());
+            entityName(o.getEntityName());
+            entityType(o.getEntityType());
+            warningType(o.getWarningType());
+            isNoSource(o.getIsNoSource());
+            startTime(o.getStartTime());
+            endTime(o.getEndTime());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListWarningsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListWarningsRequest
+         */
+        public ListWarningsRequest build() {
+            ListWarningsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/PauseScheduledTaskRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/PauseScheduledTaskRequest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/PauseScheduledTaskExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use PauseScheduledTaskRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class PauseScheduledTaskRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * Unique scheduledTask id returned from task create.
+     * If invalid will lead to a 404 not found.
+     *
+     */
+    private String scheduledTaskId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    PauseScheduledTaskRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(PauseScheduledTaskRequest o) {
+            namespaceName(o.getNamespaceName());
+            scheduledTaskId(o.getScheduledTaskId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of PauseScheduledTaskRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of PauseScheduledTaskRequest
+         */
+        public PauseScheduledTaskRequest build() {
+            PauseScheduledTaskRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/RemoveEntityAssociationsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/RemoveEntityAssociationsRequest.java
@@ -27,7 +27,7 @@ public class RemoveEntityAssociationsRequest
     private String logAnalyticsEntityId;
 
     /**
-     * This parameter specifies the entity OCIDs with which associations are to be deleted. Specify destination OCIDs as comma separated string.
+     * This parameter specifies the entity OCIDs with which associations are to be deleted.
      */
     private RemoveEntityAssociationsDetails removeEntityAssociationsDetails;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ResumeScheduledTaskRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ResumeScheduledTaskRequest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/ResumeScheduledTaskExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ResumeScheduledTaskRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ResumeScheduledTaskRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * Unique scheduledTask id returned from task create.
+     * If invalid will lead to a 404 not found.
+     *
+     */
+    private String scheduledTaskId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ResumeScheduledTaskRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ResumeScheduledTaskRequest o) {
+            namespaceName(o.getNamespaceName());
+            scheduledTaskId(o.getScheduledTaskId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ResumeScheduledTaskRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ResumeScheduledTaskRequest
+         */
+        public ResumeScheduledTaskRequest build() {
+            ResumeScheduledTaskRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/SuppressWarningRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/SuppressWarningRequest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/SuppressWarningExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SuppressWarningRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class SuppressWarningRequest
+        extends com.oracle.bmc.requests.BmcRequest<WarningReferenceDetails> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * list of agent warning references to suppress
+     */
+    private WarningReferenceDetails warningReferenceDetails;
+
+    /**
+     * The ID of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public WarningReferenceDetails getBody$() {
+        return warningReferenceDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SuppressWarningRequest, WarningReferenceDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SuppressWarningRequest o) {
+            namespaceName(o.getNamespaceName());
+            warningReferenceDetails(o.getWarningReferenceDetails());
+            compartmentId(o.getCompartmentId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SuppressWarningRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SuppressWarningRequest
+         */
+        public SuppressWarningRequest build() {
+            SuppressWarningRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(WarningReferenceDetails body) {
+            warningReferenceDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UnsuppressWarningRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UnsuppressWarningRequest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/UnsuppressWarningExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UnsuppressWarningRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UnsuppressWarningRequest
+        extends com.oracle.bmc.requests.BmcRequest<WarningReferenceDetails> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * warnings list
+     */
+    private WarningReferenceDetails warningReferenceDetails;
+
+    /**
+     * The ID of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public WarningReferenceDetails getBody$() {
+        return warningReferenceDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UnsuppressWarningRequest, WarningReferenceDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UnsuppressWarningRequest o) {
+            namespaceName(o.getNamespaceName());
+            warningReferenceDetails(o.getWarningReferenceDetails());
+            compartmentId(o.getCompartmentId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UnsuppressWarningRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UnsuppressWarningRequest
+         */
+        public UnsuppressWarningRequest build() {
+            UnsuppressWarningRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(WarningReferenceDetails body) {
+            warningReferenceDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLogAnalyticsEntityRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLogAnalyticsEntityRequest.java
@@ -27,7 +27,7 @@ public class UpdateLogAnalyticsEntityRequest
     private String logAnalyticsEntityId;
 
     /**
-     * The information to be updated.
+     * Log analytics entity information to be updated.
      */
     private UpdateLogAnalyticsEntityDetails updateLogAnalyticsEntityDetails;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLogAnalyticsObjectCollectionRuleRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLogAnalyticsObjectCollectionRuleRequest.java
@@ -21,7 +21,7 @@ public class UpdateLogAnalyticsObjectCollectionRuleRequest
     private String namespaceName;
 
     /**
-     * The Logging Analytics Object Collection Rule [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm)
+     * The Logging Analytics Object Collection Rule [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String logAnalyticsObjectCollectionRuleId;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLookupDataRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLookupDataRequest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/UpdateLookupDataExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateLookupDataRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateLookupDataRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.io.InputStream> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * The name of the lookup to operate on.
+     */
+    private String lookupName;
+
+    /**
+     * The file to use for the lookup update.
+     */
+    private java.io.InputStream updateLookupFileBody;
+
+    /**
+     * is force
+     */
+    private Boolean isForce;
+
+    /**
+     * Character Encoding
+     */
+    private String charEncoding;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public java.io.InputStream getBody$() {
+        return updateLookupFileBody;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateLookupDataRequest, java.io.InputStream> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateLookupDataRequest o) {
+            namespaceName(o.getNamespaceName());
+            lookupName(o.getLookupName());
+            updateLookupFileBody(o.getUpdateLookupFileBody());
+            isForce(o.getIsForce());
+            charEncoding(o.getCharEncoding());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateLookupDataRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateLookupDataRequest
+         */
+        public UpdateLookupDataRequest build() {
+            UpdateLookupDataRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(java.io.InputStream body) {
+            updateLookupFileBody(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLookupRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLookupRequest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/UpdateLookupExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateLookupRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateLookupRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateLookupMetadataDetails> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * The name of the lookup to operate on.
+     */
+    private String lookupName;
+
+    /**
+     * The information required to update a lookup.
+     */
+    private UpdateLookupMetadataDetails updateLookupMetadataDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateLookupMetadataDetails getBody$() {
+        return updateLookupMetadataDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateLookupRequest, UpdateLookupMetadataDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateLookupRequest o) {
+            namespaceName(o.getNamespaceName());
+            lookupName(o.getLookupName());
+            updateLookupMetadataDetails(o.getUpdateLookupMetadataDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateLookupRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateLookupRequest
+         */
+        public UpdateLookupRequest build() {
+            UpdateLookupRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateLookupMetadataDetails body) {
+            updateLookupMetadataDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UploadLogFileRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UploadLogFileRequest.java
@@ -61,7 +61,9 @@ public class UploadLogFileRequest extends com.oracle.bmc.requests.BmcRequest<jav
     private String timezone;
 
     /**
-     * Character Encoding
+     * Character encoding to be used to detect the encoding type of file(s) being uploaded.
+     * When this property is not specified, system detected character encoding will be used.
+     *
      */
     private String charEncoding;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ValidateFileRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ValidateFileRequest.java
@@ -20,7 +20,7 @@ public class ValidateFileRequest extends com.oracle.bmc.requests.BmcRequest<java
     private String namespaceName;
 
     /**
-     * Location of the log file
+     * Location of the log file.
      */
     private String objectLocation;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ValidateSourceMappingRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ValidateSourceMappingRequest.java
@@ -21,7 +21,7 @@ public class ValidateSourceMappingRequest
     private String namespaceName;
 
     /**
-     * Location of the log file
+     * Location of the log file.
      */
     private String objectLocation;
 

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/AppendLookupDataResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/AppendLookupDataResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class AppendLookupDataResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AppendLookupDataResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/DeleteLookupResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/DeleteLookupResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteLookupResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteLookupResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/EstimateRecallDataSizeResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/EstimateRecallDataSizeResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class EstimateRecallDataSizeResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned EstimateRecallDataSizeResult instance.
+     */
+    private EstimateRecallDataSizeResult estimateRecallDataSizeResult;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(EstimateRecallDataSizeResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            estimateRecallDataSizeResult(o.getEstimateRecallDataSizeResult());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/EstimateReleaseDataSizeResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/EstimateReleaseDataSizeResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class EstimateReleaseDataSizeResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned EstimateReleaseDataSizeResult instance.
+     */
+    private EstimateReleaseDataSizeResult estimateReleaseDataSizeResult;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(EstimateReleaseDataSizeResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            estimateReleaseDataSizeResult(o.getEstimateReleaseDataSizeResult());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/GetLookupResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/GetLookupResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetLookupResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned LogAnalyticsLookup instance.
+     */
+    private LogAnalyticsLookup logAnalyticsLookup;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetLookupResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            logAnalyticsLookup(o.getLogAnalyticsLookup());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/ListLookupsResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/ListLookupsResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListLookupsResponse {
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then additional items may be available on the previous page of the list. Include this value as the `page` parameter for the
+     * subsequent request to get the previous batch of items.
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then additional items may be available on the next page of the list. Include this value as the `page` parameter for the
+     * subsequent request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned LogAnalyticsLookupCollection instance.
+     */
+    private LogAnalyticsLookupCollection logAnalyticsLookupCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListLookupsResponse o) {
+            opcPrevPage(o.getOpcPrevPage());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            logAnalyticsLookupCollection(o.getLogAnalyticsLookupCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/ListRecalledDataResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/ListRecalledDataResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListRecalledDataResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then additional items may be available on the next page of the list. Include this value as the `page` parameter for the
+     * subsequent request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then additional items may be available on the previous page of the list. Include this value as the `page` parameter for the
+     * subsequent request to get the previous batch of items.
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * The returned RecalledDataCollection instance.
+     */
+    private RecalledDataCollection recalledDataCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListRecalledDataResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            opcPrevPage(o.getOpcPrevPage());
+            recalledDataCollection(o.getRecalledDataCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/ListWarningsResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/ListWarningsResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListWarningsResponse {
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then additional items may be available on the previous page of the list. Include this value as the `page` parameter for the
+     * subsequent request to get the previous batch of items.
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then additional items may be available on the next page of the list. Include this value as the `page` parameter for the
+     * subsequent request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned LogAnalyticsWarningCollection instance.
+     */
+    private LogAnalyticsWarningCollection logAnalyticsWarningCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWarningsResponse o) {
+            opcPrevPage(o.getOpcPrevPage());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            logAnalyticsWarningCollection(o.getLogAnalyticsWarningCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/PauseScheduledTaskResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/PauseScheduledTaskResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class PauseScheduledTaskResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned ScheduledTask instance, or null if {@link #isNotModified()} is true.
+     */
+    private ScheduledTask scheduledTask;
+
+    /**
+     * Flag to indicate whether or not the object was modified.  If this is true,
+     * the getter for the object itself will return null.  Callers should check this
+     * if they specified one of the request params that might result in a conditional
+     * response (like 'if-match'/'if-none-match').
+     */
+    private boolean isNotModified;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(PauseScheduledTaskResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            scheduledTask(o.getScheduledTask());
+            isNotModified(o.isNotModified());
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/ResumeScheduledTaskResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/ResumeScheduledTaskResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ResumeScheduledTaskResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned ScheduledTask instance, or null if {@link #isNotModified()} is true.
+     */
+    private ScheduledTask scheduledTask;
+
+    /**
+     * Flag to indicate whether or not the object was modified.  If this is true,
+     * the getter for the object itself will return null.  Callers should check this
+     * if they specified one of the request params that might result in a conditional
+     * response (like 'if-match'/'if-none-match').
+     */
+    private boolean isNotModified;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ResumeScheduledTaskResponse o) {
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            scheduledTask(o.getScheduledTask());
+            isNotModified(o.isNotModified());
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/SuppressWarningResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/SuppressWarningResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class SuppressWarningResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SuppressWarningResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/UnsuppressWarningResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/UnsuppressWarningResponse.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UnsuppressWarningResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UnsuppressWarningResponse o) {
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/UpdateLookupDataResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/UpdateLookupDataResponse.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateLookupDataResponse {
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateLookupDataResponse o) {
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/UpdateLookupResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/UpdateLookupResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateLookupResponse {
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned LogAnalyticsLookup instance.
+     */
+    private LogAnalyticsLookup logAnalyticsLookup;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateLookupResponse o) {
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            logAnalyticsLookup(o.getLogAnalyticsLookup());
+
+            return this;
+        }
+    }
+}

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/DashxApisAsyncClient.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/DashxApisAsyncClient.java
@@ -32,7 +32,7 @@ public class DashxApisAsyncClient implements DashxApisAsync {
                     .serviceName("DASHXAPIS")
                     .serviceEndpointPrefix("")
                     .serviceEndpointTemplate(
-                            "https://managementdashboards.{region}.oci.{secondLevelDomain}")
+                            "https://managementdashboard.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/DashxApisClient.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/DashxApisClient.java
@@ -19,7 +19,7 @@ public class DashxApisClient implements DashxApis {
                     .serviceName("DASHXAPIS")
                     .serviceEndpointPrefix("")
                     .serviceEndpointTemplate(
-                            "https://managementdashboards.{region}.oci.{secondLevelDomain}")
+                            "https://managementdashboard.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/src/main/java/com/oracle/bmc/sch/model/FunctionsTargetDetails.java
+++ b/bmc-sch/src/main/java/com/oracle/bmc/sch/model/FunctionsTargetDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.sch.model;
 
 /**
- * The function target.
+ * The function used for the Functions target.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-sch/src/main/java/com/oracle/bmc/sch/model/LoggingAnalyticsTargetDetails.java
+++ b/bmc-sch/src/main/java/com/oracle/bmc/sch/model/LoggingAnalyticsTargetDetails.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.sch.model;
+
+/**
+ * The log group used for the Logging Analytics target.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200909")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LoggingAnalyticsTargetDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LoggingAnalyticsTargetDetails extends TargetDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("logGroupId")
+        private String logGroupId;
+
+        public Builder logGroupId(String logGroupId) {
+            this.logGroupId = logGroupId;
+            this.__explicitlySet__.add("logGroupId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LoggingAnalyticsTargetDetails build() {
+            LoggingAnalyticsTargetDetails __instance__ =
+                    new LoggingAnalyticsTargetDetails(logGroupId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LoggingAnalyticsTargetDetails o) {
+            Builder copiedBuilder = logGroupId(o.getLogGroupId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public LoggingAnalyticsTargetDetails(String logGroupId) {
+        super();
+        this.logGroupId = logGroupId;
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the Logging Analytics log group.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("logGroupId")
+    String logGroupId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-sch/src/main/java/com/oracle/bmc/sch/model/MonitoringTargetDetails.java
+++ b/bmc-sch/src/main/java/com/oracle/bmc/sch/model/MonitoringTargetDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.sch.model;
 
 /**
- * The monitoring target.
+ * The metric and metric namespace used for the Monitoring target.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-sch/src/main/java/com/oracle/bmc/sch/model/NotificationsTargetDetails.java
+++ b/bmc-sch/src/main/java/com/oracle/bmc/sch/model/NotificationsTargetDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.sch.model;
 
 /**
- * The notifications target.
+ * The topic used for the Notifications target.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-sch/src/main/java/com/oracle/bmc/sch/model/ObjectStorageTargetDetails.java
+++ b/bmc-sch/src/main/java/com/oracle/bmc/sch/model/ObjectStorageTargetDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.sch.model;
 
 /**
- * The object storage target.
+ * The bucket used for the Object Storage target.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -60,12 +60,35 @@ public class ObjectStorageTargetDetails extends TargetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("batchRolloverSizeInMBs")
+        private Integer batchRolloverSizeInMBs;
+
+        public Builder batchRolloverSizeInMBs(Integer batchRolloverSizeInMBs) {
+            this.batchRolloverSizeInMBs = batchRolloverSizeInMBs;
+            this.__explicitlySet__.add("batchRolloverSizeInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("batchRolloverTimeInMs")
+        private Integer batchRolloverTimeInMs;
+
+        public Builder batchRolloverTimeInMs(Integer batchRolloverTimeInMs) {
+            this.batchRolloverTimeInMs = batchRolloverTimeInMs;
+            this.__explicitlySet__.add("batchRolloverTimeInMs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ObjectStorageTargetDetails build() {
             ObjectStorageTargetDetails __instance__ =
-                    new ObjectStorageTargetDetails(namespace, bucketName, objectNamePrefix);
+                    new ObjectStorageTargetDetails(
+                            namespace,
+                            bucketName,
+                            objectNamePrefix,
+                            batchRolloverSizeInMBs,
+                            batchRolloverTimeInMs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -75,7 +98,9 @@ public class ObjectStorageTargetDetails extends TargetDetails {
             Builder copiedBuilder =
                     namespace(o.getNamespace())
                             .bucketName(o.getBucketName())
-                            .objectNamePrefix(o.getObjectNamePrefix());
+                            .objectNamePrefix(o.getObjectNamePrefix())
+                            .batchRolloverSizeInMBs(o.getBatchRolloverSizeInMBs())
+                            .batchRolloverTimeInMs(o.getBatchRolloverTimeInMs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -91,11 +116,17 @@ public class ObjectStorageTargetDetails extends TargetDetails {
 
     @Deprecated
     public ObjectStorageTargetDetails(
-            String namespace, String bucketName, String objectNamePrefix) {
+            String namespace,
+            String bucketName,
+            String objectNamePrefix,
+            Integer batchRolloverSizeInMBs,
+            Integer batchRolloverTimeInMs) {
         super();
         this.namespace = namespace;
         this.bucketName = bucketName;
         this.objectNamePrefix = objectNamePrefix;
+        this.batchRolloverSizeInMBs = batchRolloverSizeInMBs;
+        this.batchRolloverTimeInMs = batchRolloverTimeInMs;
     }
 
     /**
@@ -118,6 +149,20 @@ public class ObjectStorageTargetDetails extends TargetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("objectNamePrefix")
     String objectNamePrefix;
+
+    /**
+     * The batch rollover size in megabytes.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("batchRolloverSizeInMBs")
+    Integer batchRolloverSizeInMBs;
+
+    /**
+     * The batch rollover time in milliseconds.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("batchRolloverTimeInMs")
+    Integer batchRolloverTimeInMs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-sch/src/main/java/com/oracle/bmc/sch/model/StreamingTargetDetails.java
+++ b/bmc-sch/src/main/java/com/oracle/bmc/sch/model/StreamingTargetDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.sch.model;
 
 /**
- * The streaming target.
+ * The stream used for the Streaming target.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-sch/src/main/java/com/oracle/bmc/sch/model/TargetDetails.java
+++ b/bmc-sch/src/main/java/com/oracle/bmc/sch/model/TargetDetails.java
@@ -49,6 +49,10 @@ package com.oracle.bmc.sch.model;
         name = "functions"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = LoggingAnalyticsTargetDetails.class,
+        name = "loggingAnalytics"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = StreamingTargetDetails.class,
         name = "streaming"
     )
@@ -62,11 +66,12 @@ public class TargetDetails {
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Kind {
-        Streaming("streaming"),
-        ObjectStorage("objectStorage"),
-        Monitoring("monitoring"),
         Functions("functions"),
+        LoggingAnalytics("loggingAnalytics"),
+        Monitoring("monitoring"),
         Notifications("notifications"),
+        ObjectStorage("objectStorage"),
+        Streaming("streaming"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.29.0</version>
+  <version>1.30.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for Logging Analytics as a target in the Service Connector Hub service

- Support for lookups, agent collection warnings, task commands, and data archive/recall in the Logging Analytics service



### Fixed

- Fixed a bug in the endpoint used for the Management Dashboard service



### Breaking Changes

- Parameter `sortBy` in requests `ListMetaSourceTypesRequest`, `ListParserFunctionsRequest`, `ListParserMetaPluginsRequest`, `ListSourceLabelOperatorsRequest`, `ListSourceMetaFunctionsRequest` has changed its datatype from `String` to `SortBy` enum in the Logging Analytics service

- Parameter `lifecycleState` in `LogAnalyticsObjectCollectionRule` has changed its datatype from `LogAnalyticsObjectCollectionRule.LifecycleState` to `ObjectCollectionRuleLifecycleStates` in the Logging Analytics Service

- Methods `builder()`, `toBuilder()`, and `get__explicitlySet__()` has been removed from `UpdateScheduledTaskDetails` in the Logging Analytics Service

- Methods `builder()`, `toBuilder()`, and `get__explicitlySet__()` has been removed from `ScheduledTask` in the Logging Analytics Service