### PR TITLE
Releasing version 1.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.32.1 - 2021-02-16
+### Added
+- Support for scan DNS names and zone ids on database system, cloud VM cluster, and autonomous Exadata infrastructure responses in the Database service
+- Support for specifying ACL rules to limit ingress into public load balancers in the Integration service
+- Support for Cloud at Customer as a source type in the Application Migration service
+- Support for selective migration of specific resources in the Application Migration service
+
 ## 1.32.0 - 2021-02-09
 ### Added
 - Support for the Database Management service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.13</version>
+      <version>${apache-httpcomponents.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -33,10 +33,18 @@
       <version>${resteasy.version}</version>
     </dependency>
 
+    <!-- Resteasy-JaxRs transitive dependencies that are resolved to a newer version to fix
+        known security vulnerabilities -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${apache-httpcomponents.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/AuthorizationDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/AuthorizationDetails.java
@@ -31,6 +31,10 @@ package com.oracle.bmc.applicationmigration.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OccAuthorizationDetails.class,
+        name = "OCC"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = InternalAuthorizationDetails.class,
         name = "INTERNAL_COMPUTE"
     ),

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/ConfigurationField.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/ConfigurationField.java
@@ -74,6 +74,15 @@ public class ConfigurationField {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceList")
+        private java.util.List<ResourceField> resourceList;
+
+        public Builder resourceList(java.util.List<ResourceField> resourceList) {
+            this.resourceList = resourceList;
+            this.__explicitlySet__.add("resourceList");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isRequired")
         private Boolean isRequired;
 
@@ -98,7 +107,14 @@ public class ConfigurationField {
         public ConfigurationField build() {
             ConfigurationField __instance__ =
                     new ConfigurationField(
-                            name, group, type, value, description, isRequired, isMutable);
+                            name,
+                            group,
+                            type,
+                            value,
+                            description,
+                            resourceList,
+                            isRequired,
+                            isMutable);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -111,6 +127,7 @@ public class ConfigurationField {
                             .type(o.getType())
                             .value(o.getValue())
                             .description(o.getDescription())
+                            .resourceList(o.getResourceList())
                             .isRequired(o.getIsRequired())
                             .isMutable(o.getIsMutable());
 
@@ -155,6 +172,13 @@ public class ConfigurationField {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
+
+    /**
+     * A list of resources associated with a specific configuration object.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceList")
+    java.util.List<ResourceField> resourceList;
 
     /**
      * Indicates whether or not the field is required (defaults to `true`).

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/CreateMigrationDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/CreateMigrationDetails.java
@@ -100,6 +100,15 @@ public class CreateMigrationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isSelectiveMigration")
+        private Boolean isSelectiveMigration;
+
+        public Builder isSelectiveMigration(Boolean isSelectiveMigration) {
+            this.isSelectiveMigration = isSelectiveMigration;
+            this.__explicitlySet__.add("isSelectiveMigration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("serviceConfig")
         private java.util.Map<String, ConfigurationField> serviceConfig;
 
@@ -151,6 +160,7 @@ public class CreateMigrationDetails {
                             applicationName,
                             discoveryDetails,
                             preCreatedTargetDatabaseType,
+                            isSelectiveMigration,
                             serviceConfig,
                             applicationConfig,
                             freeformTags,
@@ -169,6 +179,7 @@ public class CreateMigrationDetails {
                             .applicationName(o.getApplicationName())
                             .discoveryDetails(o.getDiscoveryDetails())
                             .preCreatedTargetDatabaseType(o.getPreCreatedTargetDatabaseType())
+                            .isSelectiveMigration(o.getIsSelectiveMigration())
                             .serviceConfig(o.getServiceConfig())
                             .applicationConfig(o.getApplicationConfig())
                             .freeformTags(o.getFreeformTags())
@@ -227,6 +238,13 @@ public class CreateMigrationDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("preCreatedTargetDatabaseType")
     TargetDatabaseTypes preCreatedTargetDatabaseType;
+
+    /**
+     * If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSelectiveMigration")
+    Boolean isSelectiveMigration;
 
     /**
      * Configuration required to migrate the application. In addition to the key and value, additional fields are provided

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/Migration.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/Migration.java
@@ -113,6 +113,15 @@ public class Migration {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isSelectiveMigration")
+        private Boolean isSelectiveMigration;
+
+        public Builder isSelectiveMigration(Boolean isSelectiveMigration) {
+            this.isSelectiveMigration = isSelectiveMigration;
+            this.__explicitlySet__.add("isSelectiveMigration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("serviceConfig")
         private java.util.Map<String, ConfigurationField> serviceConfig;
 
@@ -193,6 +202,7 @@ public class Migration {
                             applicationName,
                             applicationType,
                             preCreatedTargetDatabaseType,
+                            isSelectiveMigration,
                             serviceConfig,
                             applicationConfig,
                             lifecycleState,
@@ -216,6 +226,7 @@ public class Migration {
                             .applicationName(o.getApplicationName())
                             .applicationType(o.getApplicationType())
                             .preCreatedTargetDatabaseType(o.getPreCreatedTargetDatabaseType())
+                            .isSelectiveMigration(o.getIsSelectiveMigration())
                             .serviceConfig(o.getServiceConfig())
                             .applicationConfig(o.getApplicationConfig())
                             .lifecycleState(o.getLifecycleState())
@@ -292,6 +303,13 @@ public class Migration {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("preCreatedTargetDatabaseType")
     TargetDatabaseTypes preCreatedTargetDatabaseType;
+
+    /**
+     * If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSelectiveMigration")
+    Boolean isSelectiveMigration;
 
     /**
      * Configuration required to migrate the application. In addition to the key and value, additional fields are provided

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OccAuthorizationDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OccAuthorizationDetails.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.applicationmigration.model;
+
+/**
+ * Credentials to access Oracle Cloud @ Customer, which is the source environment from which you want to migrate the application.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OccAuthorizationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OccAuthorizationDetails extends AuthorizationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("username")
+        private String username;
+
+        public Builder username(String username) {
+            this.username = username;
+            this.__explicitlySet__.add("username");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("password")
+        private String password;
+
+        public Builder password(String password) {
+            this.password = password;
+            this.__explicitlySet__.add("password");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OccAuthorizationDetails build() {
+            OccAuthorizationDetails __instance__ = new OccAuthorizationDetails(username, password);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OccAuthorizationDetails o) {
+            Builder copiedBuilder = username(o.getUsername()).password(o.getPassword());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OccAuthorizationDetails(String username, String password) {
+        super();
+        this.username = username;
+        this.password = password;
+    }
+
+    /**
+     * User with Compute Operations role in Oracle Cloud @ Customer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    String username;
+
+    /**
+     * Password for this user.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("password")
+    String password;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OccSourceDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/OccSourceDetails.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.applicationmigration.model;
+
+/**
+ * Details about the Oracle Cloud @ Customer account, the source environment from which you want to migrate the application.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = OccSourceDetails.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OccSourceDetails extends SourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("computeAccount")
+        private String computeAccount;
+
+        public Builder computeAccount(String computeAccount) {
+            this.computeAccount = computeAccount;
+            this.__explicitlySet__.add("computeAccount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OccSourceDetails build() {
+            OccSourceDetails __instance__ = new OccSourceDetails(computeAccount);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OccSourceDetails o) {
+            Builder copiedBuilder = computeAccount(o.getComputeAccount());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OccSourceDetails(String computeAccount) {
+        super();
+        this.computeAccount = computeAccount;
+    }
+
+    /**
+     * If you are using a Oracle Cloud @ Customer account with Identity Cloud Service (IDCS), enter the service instance ID.
+     * For example, if Compute-567890123 is the account name of your Oracle Cloud @ Customer Compute service entitlement,
+     * then enter 567890123.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("computeAccount")
+    String computeAccount;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/ResourceField.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/ResourceField.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.applicationmigration.model;
+
+/**
+ * Resource object that can be used to pass details about any list of resources associated with Migrations. The List of resources are added to ConfigurationField to add the capability to pass lists of resources of any type and group.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20191031")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ResourceField.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ResourceField {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("group")
+        private String group;
+
+        public Builder group(String group) {
+            this.group = group;
+            this.__explicitlySet__.add("group");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private String type;
+
+        public Builder type(String type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            this.__explicitlySet__.add("value");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ResourceField build() {
+            ResourceField __instance__ = new ResourceField(name, group, type, value);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ResourceField o) {
+            Builder copiedBuilder =
+                    name(o.getName()).group(o.getGroup()).type(o.getType()).value(o.getValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The display name of the resource field.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The name of the group to which this field belongs to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("group")
+    String group;
+
+    /**
+     * The type of the resource field.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    String type;
+
+    /**
+     * The value of the field.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    String value;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceDetails.java
@@ -12,6 +12,8 @@ package com.oracle.bmc.applicationmigration.model;
  * <p>
  * Specify `INTERNAL_COMPUTE` if you have a traditional Oracle Cloud Infrastructure - Classic account and you want to migrate Oracle
  * Process Cloud Service or Oracle Integration Cloud Service applications.
+ * <p>
+ * Specify `OCC` if you have an Oracle Cloud @ Customer account.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -35,6 +37,10 @@ package com.oracle.bmc.applicationmigration.model;
     defaultImpl = SourceDetails.class
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OccSourceDetails.class,
+        name = "OCC"
+    ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = InternalSourceDetails.class,
         name = "INTERNAL_COMPUTE"

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceTypes.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/SourceTypes.java
@@ -12,6 +12,7 @@ package com.oracle.bmc.applicationmigration.model;
 public enum SourceTypes {
     Ocic("OCIC"),
     InternalCompute("INTERNAL_COMPUTE"),
+    Occ("OCC"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/UpdateMigrationDetails.java
+++ b/bmc-applicationmigration/src/main/java/com/oracle/bmc/applicationmigration/model/UpdateMigrationDetails.java
@@ -58,6 +58,15 @@ public class UpdateMigrationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isSelectiveMigration")
+        private Boolean isSelectiveMigration;
+
+        public Builder isSelectiveMigration(Boolean isSelectiveMigration) {
+            this.isSelectiveMigration = isSelectiveMigration;
+            this.__explicitlySet__.add("isSelectiveMigration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("serviceConfig")
         private java.util.Map<String, ConfigurationField> serviceConfig;
 
@@ -105,6 +114,7 @@ public class UpdateMigrationDetails {
                             displayName,
                             description,
                             discoveryDetails,
+                            isSelectiveMigration,
                             serviceConfig,
                             applicationConfig,
                             freeformTags,
@@ -119,6 +129,7 @@ public class UpdateMigrationDetails {
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
                             .discoveryDetails(o.getDiscoveryDetails())
+                            .isSelectiveMigration(o.getIsSelectiveMigration())
                             .serviceConfig(o.getServiceConfig())
                             .applicationConfig(o.getApplicationConfig())
                             .freeformTags(o.getFreeformTags())
@@ -150,6 +161,13 @@ public class UpdateMigrationDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("discoveryDetails")
     DiscoveryDetails discoveryDetails;
+
+    /**
+     * If set to `true`, Application Migration migrates the application resources selectively depending on the source.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSelectiveMigration")
+    Boolean isSelectiveMigration;
 
     /**
      * Configuration required to migrate the application. In addition to the key and value, additional fields are provided

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,408 +19,408 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/ClientRuntime.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/ClientRuntime.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This class provides client info that will be sent to the servers as part of each request.
@@ -38,6 +39,8 @@ public class ClientRuntime {
      */
     @Getter private final String clientInfo;
 
+    private static final String ENV_VAR_USER_AGENT = "OCI_SDK_APPEND_USER_AGENT";
+
     private ClientRuntime() {
         String os = System.getProperty("os.name");
         String osVersion = System.getProperty("os.version");
@@ -45,6 +48,10 @@ public class ClientRuntime {
         String javaVmName = System.getProperty("java.vm.name");
         String javaVmVersion = System.getProperty("java.vm.version");
         String sdkVersion = sdkVersion();
+
+        String userAgentFromEnvVar = System.getenv(ENV_VAR_USER_AGENT);
+        String ociSdkAppendUserAgent =
+                StringUtils.isBlank(userAgentFromEnvVar) ? "" : " " + userAgentFromEnvVar.trim();
 
         final String clientInfoFormat = "Oracle-JavaSDK/%s";
         clientInfo = String.format(clientInfoFormat, sdkVersion);
@@ -56,7 +63,7 @@ public class ClientRuntime {
             additionalUserAgentFromClient = "";
         }
 
-        final String agentFormat = "%s (%s/%s; Java/%s; %s/%s)%s";
+        final String agentFormat = "%s (%s/%s; Java/%s; %s/%s)%s%s";
         userAgent =
                 String.format(
                         agentFormat,
@@ -66,7 +73,8 @@ public class ClientRuntime {
                         javaVersion,
                         javaVmName,
                         javaVmVersion,
-                        additionalUserAgentFromClient);
+                        additionalUserAgentFromClient,
+                        ociSdkAppendUserAgent);
         LOG.info("Using SDK: {}", clientInfo);
         LOG.info("User agent set to: {}", userAgent);
     }

--- a/bmc-common/src/test/java/com/oracle/bmc/ClientRuntimeTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/ClientRuntimeTest.java
@@ -6,14 +6,60 @@ package com.oracle.bmc;
 
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertTrue;
 
 public class ClientRuntimeTest {
+
+    private static void setEnvironmentVariable(Map<String, String> newEnvMap) throws Exception {
+        try {
+            Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");
+            Field theEnvironmentField = processEnvironmentClass.getDeclaredField("theEnvironment");
+            theEnvironmentField.setAccessible(true);
+            Map<String, String> env = (Map<String, String>) theEnvironmentField.get(null);
+            env.putAll(newEnvMap);
+            Field theCaseInsensitiveEnvironmentField =
+                    processEnvironmentClass.getDeclaredField("theCaseInsensitiveEnvironment");
+            theCaseInsensitiveEnvironmentField.setAccessible(true);
+            Map<String, String> caseSensitiveEnvMap =
+                    (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
+            caseSensitiveEnvMap.putAll(newEnvMap);
+        } catch (NoSuchFieldException e) {
+            Class[] classes = Collections.class.getDeclaredClasses();
+            Map<String, String> env = System.getenv();
+            for (Class cl : classes) {
+                if ("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
+                    Field field = cl.getDeclaredField("m");
+                    field.setAccessible(true);
+                    Object obj = field.get(env);
+                    Map<String, String> map = (Map<String, String>) obj;
+                    map.clear();
+                    map.putAll(newEnvMap);
+                }
+            }
+        }
+    }
+
+    // This test checks the values of all the parameters used to form the user agent.
     @Test
-    public void setClientUserAgent() {
+    public void checkUserAgentParameters() throws Exception {
+        Map<String, String> newEnvMap = new HashMap<>();
+        newEnvMap.put("OCI_SDK_APPEND_USER_AGENT", "test-env-var");
+        setEnvironmentVariable(newEnvMap);
         String clientUserAgent = "foobar";
         ClientRuntime.setClientUserAgent(clientUserAgent);
         String userAgent = ClientRuntime.getRuntime().getUserAgent();
+        assertTrue(userAgent.contains(ClientRuntime.getRuntime().getClientInfo()));
+        assertTrue(userAgent.contains(System.getProperty("os.name")));
+        assertTrue(userAgent.contains(System.getProperty("os.version")));
+        assertTrue(userAgent.contains(System.getProperty("java.version")));
+        assertTrue(userAgent.contains(System.getProperty("java.vm.name")));
+        assertTrue(userAgent.contains(System.getProperty("java.vm.version")));
         assertTrue(userAgent.contains(clientUserAgent));
+        assertTrue(userAgent.endsWith(System.getenv("OCI_SDK_APPEND_USER_AGENT")));
     }
 }

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousExadataInfrastructure.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousExadataInfrastructure.java
@@ -189,6 +189,24 @@ public class AutonomousExadataInfrastructure {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+        private String scanDnsName;
+
+        public Builder scanDnsName(String scanDnsName) {
+            this.scanDnsName = scanDnsName;
+            this.__explicitlySet__.add("scanDnsName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+        private String zoneId;
+
+        public Builder zoneId(String zoneId) {
+            this.zoneId = zoneId;
+            this.__explicitlySet__.add("zoneId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -212,7 +230,9 @@ public class AutonomousExadataInfrastructure {
                             lastMaintenanceRunId,
                             nextMaintenanceRunId,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            scanDnsName,
+                            zoneId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -237,7 +257,9 @@ public class AutonomousExadataInfrastructure {
                             .lastMaintenanceRunId(o.getLastMaintenanceRunId())
                             .nextMaintenanceRunId(o.getNextMaintenanceRunId())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .scanDnsName(o.getScanDnsName())
+                            .zoneId(o.getZoneId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -469,6 +491,20 @@ public class AutonomousExadataInfrastructure {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The FQDN of the DNS record for the SCAN IP addresses that are associated with the Autonomous Exadata Infrastructure.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+    String scanDnsName;
+
+    /**
+     * The OCID of the zone the Autonomous Exadata Infrastructure is associated with.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+    String zoneId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousExadataInfrastructureSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousExadataInfrastructureSummary.java
@@ -203,6 +203,24 @@ public class AutonomousExadataInfrastructureSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+        private String scanDnsName;
+
+        public Builder scanDnsName(String scanDnsName) {
+            this.scanDnsName = scanDnsName;
+            this.__explicitlySet__.add("scanDnsName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+        private String zoneId;
+
+        public Builder zoneId(String zoneId) {
+            this.zoneId = zoneId;
+            this.__explicitlySet__.add("zoneId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -226,7 +244,9 @@ public class AutonomousExadataInfrastructureSummary {
                             lastMaintenanceRunId,
                             nextMaintenanceRunId,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            scanDnsName,
+                            zoneId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -251,7 +271,9 @@ public class AutonomousExadataInfrastructureSummary {
                             .lastMaintenanceRunId(o.getLastMaintenanceRunId())
                             .nextMaintenanceRunId(o.getNextMaintenanceRunId())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .scanDnsName(o.getScanDnsName())
+                            .zoneId(o.getZoneId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -483,6 +505,20 @@ public class AutonomousExadataInfrastructureSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The FQDN of the DNS record for the SCAN IP addresses that are associated with the Autonomous Exadata Infrastructure.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+    String scanDnsName;
+
+    /**
+     * The OCID of the zone the Autonomous Exadata Infrastructure is associated with.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+    String zoneId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudVmCluster.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudVmCluster.java
@@ -350,6 +350,24 @@ public class CloudVmCluster {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+        private String scanDnsName;
+
+        public Builder scanDnsName(String scanDnsName) {
+            this.scanDnsName = scanDnsName;
+            this.__explicitlySet__.add("scanDnsName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+        private String zoneId;
+
+        public Builder zoneId(String zoneId) {
+            this.zoneId = zoneId;
+            this.__explicitlySet__.add("zoneId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -391,7 +409,9 @@ public class CloudVmCluster {
                             vipIds,
                             scanDnsRecordId,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            scanDnsName,
+                            zoneId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -434,7 +454,9 @@ public class CloudVmCluster {
                             .vipIds(o.getVipIds())
                             .scanDnsRecordId(o.getScanDnsRecordId())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .scanDnsName(o.getScanDnsName())
+                            .zoneId(o.getZoneId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -847,6 +869,20 @@ public class CloudVmCluster {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The FQDN of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+    String scanDnsName;
+
+    /**
+     * The OCID of the zone the cloud VM cluster is associated with.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+    String zoneId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudVmClusterSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CloudVmClusterSummary.java
@@ -343,6 +343,24 @@ public class CloudVmClusterSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+        private String scanDnsName;
+
+        public Builder scanDnsName(String scanDnsName) {
+            this.scanDnsName = scanDnsName;
+            this.__explicitlySet__.add("scanDnsName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+        private String zoneId;
+
+        public Builder zoneId(String zoneId) {
+            this.zoneId = zoneId;
+            this.__explicitlySet__.add("zoneId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -383,7 +401,9 @@ public class CloudVmClusterSummary {
                             vipIds,
                             scanDnsRecordId,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            scanDnsName,
+                            zoneId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -425,7 +445,9 @@ public class CloudVmClusterSummary {
                             .vipIds(o.getVipIds())
                             .scanDnsRecordId(o.getScanDnsRecordId())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .scanDnsName(o.getScanDnsName())
+                            .zoneId(o.getZoneId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -835,6 +857,20 @@ public class CloudVmClusterSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The FQDN of the DNS record for the SCAN IP addresses that are associated with the cloud VM cluster.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+    String scanDnsName;
+
+    /**
+     * The OCID of the zone the cloud VM cluster is associated with.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+    String zoneId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystem.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystem.java
@@ -312,6 +312,24 @@ public class DbSystem {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+        private String scanDnsName;
+
+        public Builder scanDnsName(String scanDnsName) {
+            this.scanDnsName = scanDnsName;
+            this.__explicitlySet__.add("scanDnsName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+        private String zoneId;
+
+        public Builder zoneId(String zoneId) {
+            this.zoneId = zoneId;
+            this.__explicitlySet__.add("zoneId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInGBs")
         private Integer dataStorageSizeInGBs;
 
@@ -451,6 +469,8 @@ public class DbSystem {
                             scanIpIds,
                             vipIds,
                             scanDnsRecordId,
+                            scanDnsName,
+                            zoneId,
                             dataStorageSizeInGBs,
                             recoStorageSizeInGB,
                             nodeCount,
@@ -501,6 +521,8 @@ public class DbSystem {
                             .scanIpIds(o.getScanIpIds())
                             .vipIds(o.getVipIds())
                             .scanDnsRecordId(o.getScanDnsRecordId())
+                            .scanDnsName(o.getScanDnsName())
+                            .zoneId(o.getZoneId())
                             .dataStorageSizeInGBs(o.getDataStorageSizeInGBs())
                             .recoStorageSizeInGB(o.getRecoStorageSizeInGB())
                             .nodeCount(o.getNodeCount())
@@ -897,6 +919,20 @@ public class DbSystem {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scanDnsRecordId")
     String scanDnsRecordId;
+
+    /**
+     * The FQDN of the DNS record for the SCAN IP addresses that are associated with the DB system.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+    String scanDnsName;
+
+    /**
+     * The OCID of the zone the DB system is associated with.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+    String zoneId;
 
     /**
      * The data storage size, in gigabytes, that is currently available to the DB system. Applies only for virtual machine DB systems.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbSystemSummary.java
@@ -325,6 +325,24 @@ public class DbSystemSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+        private String scanDnsName;
+
+        public Builder scanDnsName(String scanDnsName) {
+            this.scanDnsName = scanDnsName;
+            this.__explicitlySet__.add("scanDnsName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+        private String zoneId;
+
+        public Builder zoneId(String zoneId) {
+            this.zoneId = zoneId;
+            this.__explicitlySet__.add("zoneId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInGBs")
         private Integer dataStorageSizeInGBs;
 
@@ -463,6 +481,8 @@ public class DbSystemSummary {
                             scanIpIds,
                             vipIds,
                             scanDnsRecordId,
+                            scanDnsName,
+                            zoneId,
                             dataStorageSizeInGBs,
                             recoStorageSizeInGB,
                             nodeCount,
@@ -512,6 +532,8 @@ public class DbSystemSummary {
                             .scanIpIds(o.getScanIpIds())
                             .vipIds(o.getVipIds())
                             .scanDnsRecordId(o.getScanDnsRecordId())
+                            .scanDnsName(o.getScanDnsName())
+                            .zoneId(o.getZoneId())
                             .dataStorageSizeInGBs(o.getDataStorageSizeInGBs())
                             .recoStorageSizeInGB(o.getRecoStorageSizeInGB())
                             .nodeCount(o.getNodeCount())
@@ -905,6 +927,20 @@ public class DbSystemSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scanDnsRecordId")
     String scanDnsRecordId;
+
+    /**
+     * The FQDN of the DNS record for the SCAN IP addresses that are associated with the DB system.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("scanDnsName")
+    String scanDnsName;
+
+    /**
+     * The OCID of the zone the DB system is associated with.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("zoneId")
+    String zoneId;
 
     /**
      * The data storage size, in gigabytes, that is currently available to the DB system. Applies only for virtual machine DB systems.

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/ObjectStorageAsyncExample.java
+++ b/bmc-examples/src/main/java/ObjectStorageAsyncExample.java
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
  * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
  */
+import java.io.InputStream;
 import java.util.concurrent.CountDownLatch;
 
 import com.oracle.bmc.ConfigFileReader;
@@ -12,9 +13,11 @@ import com.oracle.bmc.objectstorage.ObjectStorageAsync;
 import com.oracle.bmc.objectstorage.ObjectStorageAsyncClient;
 import com.oracle.bmc.objectstorage.model.BucketSummary;
 import com.oracle.bmc.objectstorage.requests.GetNamespaceRequest;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
 import com.oracle.bmc.objectstorage.requests.ListBucketsRequest;
 import com.oracle.bmc.objectstorage.requests.ListBucketsRequest.Builder;
 import com.oracle.bmc.objectstorage.responses.GetNamespaceResponse;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
 import com.oracle.bmc.objectstorage.responses.ListBucketsResponse;
 import com.oracle.bmc.responses.AsyncHandler;
 
@@ -62,6 +65,25 @@ public class ObjectStorageAsyncExample {
             }
             nextToken = listBucketsResponse.getOpcNextPage();
         } while (nextToken != null);
+
+        // fetch the uploaded file from object storage
+        String bucketName = null;
+        String objectName = null;
+        ResponseHandler<GetObjectRequest, GetObjectResponse> objectHandler =
+                new ResponseHandler<>();
+        GetObjectRequest getObjectRequest =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        client.getObject(getObjectRequest, objectHandler);
+        GetObjectResponse getResponse = objectHandler.waitForCompletion();
+
+        // stream contents should match the file uploaded
+        try (final InputStream fileStream = getResponse.getInputStream()) {
+            // use fileStream
+        } // try-with-resources automatically closes fileStream
 
         client.close();
     }

--- a/bmc-examples/src/main/java/ObjectStorageSyncExample.java
+++ b/bmc-examples/src/main/java/ObjectStorageSyncExample.java
@@ -10,10 +10,14 @@ import com.oracle.bmc.objectstorage.ObjectStorage;
 import com.oracle.bmc.objectstorage.ObjectStorageClient;
 import com.oracle.bmc.objectstorage.model.BucketSummary;
 import com.oracle.bmc.objectstorage.requests.GetNamespaceRequest;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
 import com.oracle.bmc.objectstorage.requests.ListBucketsRequest;
 import com.oracle.bmc.objectstorage.requests.ListBucketsRequest.Builder;
 import com.oracle.bmc.objectstorage.responses.GetNamespaceResponse;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
 import com.oracle.bmc.objectstorage.responses.ListBucketsResponse;
+
+import java.io.InputStream;
 
 public class ObjectStorageSyncExample {
 
@@ -54,6 +58,22 @@ public class ObjectStorageSyncExample {
             }
             nextToken = listBucketsResponse.getOpcNextPage();
         } while (nextToken != null);
+
+        // fetch the file from the object storage
+        String bucketName = null;
+        String objectName = null;
+        GetObjectResponse getResponse =
+                client.getObject(
+                        GetObjectRequest.builder()
+                                .namespaceName(namespaceName)
+                                .bucketName(bucketName)
+                                .objectName(objectName)
+                                .build());
+
+        // stream contents should match the file uploaded
+        try (final InputStream fileStream = getResponse.getInputStream()) {
+            // use fileStream
+        } // try-with-resources automatically closes fileStream
 
         client.close();
     }

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.32.0</version>
+        <version>1.32.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/IntegrationInstance.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/IntegrationInstance.java
@@ -58,6 +58,19 @@ public interface IntegrationInstance extends AutoCloseable {
             ChangeIntegrationInstanceCompartmentRequest request);
 
     /**
+     * Change an Integration instance network endpoint. The operation is long-running
+     * and creates a new WorkRequest.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/integration/ChangeIntegrationInstanceNetworkEndpointExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeIntegrationInstanceNetworkEndpoint API.
+     */
+    ChangeIntegrationInstanceNetworkEndpointResponse changeIntegrationInstanceNetworkEndpoint(
+            ChangeIntegrationInstanceNetworkEndpointRequest request);
+
+    /**
      * Creates a new Integration Instance.
      *
      * @param request The request object containing the details to send

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/IntegrationInstanceAsync.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/IntegrationInstanceAsync.java
@@ -65,6 +65,26 @@ public interface IntegrationInstanceAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Change an Integration instance network endpoint. The operation is long-running
+     * and creates a new WorkRequest.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeIntegrationInstanceNetworkEndpointResponse>
+            changeIntegrationInstanceNetworkEndpoint(
+                    ChangeIntegrationInstanceNetworkEndpointRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeIntegrationInstanceNetworkEndpointRequest,
+                                    ChangeIntegrationInstanceNetworkEndpointResponse>
+                            handler);
+
+    /**
      * Creates a new Integration Instance.
      *
      *

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/IntegrationInstanceAsyncClient.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/IntegrationInstanceAsyncClient.java
@@ -412,6 +412,55 @@ public class IntegrationInstanceAsyncClient implements IntegrationInstanceAsync 
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeIntegrationInstanceNetworkEndpointResponse>
+            changeIntegrationInstanceNetworkEndpoint(
+                    ChangeIntegrationInstanceNetworkEndpointRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeIntegrationInstanceNetworkEndpointRequest,
+                                    ChangeIntegrationInstanceNetworkEndpointResponse>
+                            handler) {
+        LOG.trace("Called async changeIntegrationInstanceNetworkEndpoint");
+        final ChangeIntegrationInstanceNetworkEndpointRequest interceptedRequest =
+                ChangeIntegrationInstanceNetworkEndpointConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeIntegrationInstanceNetworkEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeIntegrationInstanceNetworkEndpointResponse>
+                transformer = ChangeIntegrationInstanceNetworkEndpointConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeIntegrationInstanceNetworkEndpointRequest,
+                        ChangeIntegrationInstanceNetworkEndpointResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeIntegrationInstanceNetworkEndpointRequest,
+                                ChangeIntegrationInstanceNetworkEndpointResponse>,
+                        java.util.concurrent.Future<
+                                ChangeIntegrationInstanceNetworkEndpointResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeIntegrationInstanceNetworkEndpointRequest,
+                    ChangeIntegrationInstanceNetworkEndpointResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateIntegrationInstanceResponse> createIntegrationInstance(
             CreateIntegrationInstanceRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/IntegrationInstanceClient.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/IntegrationInstanceClient.java
@@ -479,6 +479,44 @@ public class IntegrationInstanceClient implements IntegrationInstance {
     }
 
     @Override
+    public ChangeIntegrationInstanceNetworkEndpointResponse
+            changeIntegrationInstanceNetworkEndpoint(
+                    ChangeIntegrationInstanceNetworkEndpointRequest request) {
+        LOG.trace("Called changeIntegrationInstanceNetworkEndpoint");
+        final ChangeIntegrationInstanceNetworkEndpointRequest interceptedRequest =
+                ChangeIntegrationInstanceNetworkEndpointConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeIntegrationInstanceNetworkEndpointConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeIntegrationInstanceNetworkEndpointResponse>
+                transformer = ChangeIntegrationInstanceNetworkEndpointConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeIntegrationInstanceNetworkEndpointDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateIntegrationInstanceResponse createIntegrationInstance(
             CreateIntegrationInstanceRequest request) {
         LOG.trace("Called createIntegrationInstance");

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/internal/http/ChangeIntegrationInstanceNetworkEndpointConverter.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/internal/http/ChangeIntegrationInstanceNetworkEndpointConverter.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.integration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.integration.model.*;
+import com.oracle.bmc.integration.requests.*;
+import com.oracle.bmc.integration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190131")
+@lombok.extern.slf4j.Slf4j
+public class ChangeIntegrationInstanceNetworkEndpointConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.integration.requests
+                    .ChangeIntegrationInstanceNetworkEndpointRequest
+            interceptRequest(
+                    com.oracle.bmc.integration.requests
+                                    .ChangeIntegrationInstanceNetworkEndpointRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.integration.requests.ChangeIntegrationInstanceNetworkEndpointRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getIntegrationInstanceId(), "integrationInstanceId must not be blank");
+        Validate.notNull(
+                request.getChangeIntegrationInstanceNetworkEndpointDetails(),
+                "changeIntegrationInstanceNetworkEndpointDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190131")
+                        .path("integrationInstances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getIntegrationInstanceId()))
+                        .path("actions")
+                        .path("changeNetworkEndpoint");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.integration.responses
+                            .ChangeIntegrationInstanceNetworkEndpointResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.integration.responses
+                                .ChangeIntegrationInstanceNetworkEndpointResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.integration.responses
+                                        .ChangeIntegrationInstanceNetworkEndpointResponse>() {
+                            @Override
+                            public com.oracle.bmc.integration.responses
+                                            .ChangeIntegrationInstanceNetworkEndpointResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.integration.responses.ChangeIntegrationInstanceNetworkEndpointResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.integration.responses
+                                                .ChangeIntegrationInstanceNetworkEndpointResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.integration.responses
+                                                        .ChangeIntegrationInstanceNetworkEndpointResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.integration.responses
+                                                .ChangeIntegrationInstanceNetworkEndpointResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/ChangeIntegrationInstanceNetworkEndpointDetails.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/ChangeIntegrationInstanceNetworkEndpointDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.integration.model;
+
+/**
+ * Input payload to update an Integration instance endpoint details. An empty payload will clear out any existing configuration.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190131")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeIntegrationInstanceNetworkEndpointDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeIntegrationInstanceNetworkEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+        private NetworkEndpointDetails networkEndpointDetails;
+
+        public Builder networkEndpointDetails(NetworkEndpointDetails networkEndpointDetails) {
+            this.networkEndpointDetails = networkEndpointDetails;
+            this.__explicitlySet__.add("networkEndpointDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeIntegrationInstanceNetworkEndpointDetails build() {
+            ChangeIntegrationInstanceNetworkEndpointDetails __instance__ =
+                    new ChangeIntegrationInstanceNetworkEndpointDetails(networkEndpointDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeIntegrationInstanceNetworkEndpointDetails o) {
+            Builder copiedBuilder = networkEndpointDetails(o.getNetworkEndpointDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+    NetworkEndpointDetails networkEndpointDetails;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/CreateIntegrationInstanceDetails.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/CreateIntegrationInstanceDetails.java
@@ -145,6 +145,15 @@ public class CreateIntegrationInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+        private NetworkEndpointDetails networkEndpointDetails;
+
+        public Builder networkEndpointDetails(NetworkEndpointDetails networkEndpointDetails) {
+            this.networkEndpointDetails = networkEndpointDetails;
+            this.__explicitlySet__.add("networkEndpointDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -163,7 +172,8 @@ public class CreateIntegrationInstanceDetails {
                             customEndpoint,
                             alternateCustomEndpoints,
                             consumptionModel,
-                            isFileServerEnabled);
+                            isFileServerEnabled,
+                            networkEndpointDetails);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -183,7 +193,8 @@ public class CreateIntegrationInstanceDetails {
                             .customEndpoint(o.getCustomEndpoint())
                             .alternateCustomEndpoints(o.getAlternateCustomEndpoints())
                             .consumptionModel(o.getConsumptionModel())
-                            .isFileServerEnabled(o.getIsFileServerEnabled());
+                            .isFileServerEnabled(o.getIsFileServerEnabled())
+                            .networkEndpointDetails(o.getNetworkEndpointDetails());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -274,7 +285,7 @@ public class CreateIntegrationInstanceDetails {
     Boolean isByol;
 
     /**
-     * IDCS Authentication token. This is is required for pre-UCPIS cloud accounts, but not UCPIS, hence not a required parameter
+     * IDCS Authentication token. This is required for all realms with IDCS. Its optional as its not required for non IDCS realms.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("idcsAt")
     String idcsAt;
@@ -348,6 +359,9 @@ public class CreateIntegrationInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isFileServerEnabled")
     Boolean isFileServerEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+    NetworkEndpointDetails networkEndpointDetails;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/IntegrationInstance.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/IntegrationInstance.java
@@ -190,6 +190,15 @@ public class IntegrationInstance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+        private NetworkEndpointDetails networkEndpointDetails;
+
+        public Builder networkEndpointDetails(NetworkEndpointDetails networkEndpointDetails) {
+            this.networkEndpointDetails = networkEndpointDetails;
+            this.__explicitlySet__.add("networkEndpointDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -213,7 +222,8 @@ public class IntegrationInstance {
                             isVisualBuilderEnabled,
                             customEndpoint,
                             alternateCustomEndpoints,
-                            consumptionModel);
+                            consumptionModel,
+                            networkEndpointDetails);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -238,7 +248,8 @@ public class IntegrationInstance {
                             .isVisualBuilderEnabled(o.getIsVisualBuilderEnabled())
                             .customEndpoint(o.getCustomEndpoint())
                             .alternateCustomEndpoints(o.getAlternateCustomEndpoints())
-                            .consumptionModel(o.getConsumptionModel());
+                            .consumptionModel(o.getConsumptionModel())
+                            .networkEndpointDetails(o.getNetworkEndpointDetails());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -504,6 +515,9 @@ public class IntegrationInstance {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("consumptionModel")
     ConsumptionModel consumptionModel;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+    NetworkEndpointDetails networkEndpointDetails;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/IntegrationInstanceSummary.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/IntegrationInstanceSummary.java
@@ -171,6 +171,15 @@ public class IntegrationInstanceSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+        private NetworkEndpointDetails networkEndpointDetails;
+
+        public Builder networkEndpointDetails(NetworkEndpointDetails networkEndpointDetails) {
+            this.networkEndpointDetails = networkEndpointDetails;
+            this.__explicitlySet__.add("networkEndpointDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -192,7 +201,8 @@ public class IntegrationInstanceSummary {
                             isVisualBuilderEnabled,
                             customEndpoint,
                             alternateCustomEndpoints,
-                            consumptionModel);
+                            consumptionModel,
+                            networkEndpointDetails);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -215,7 +225,8 @@ public class IntegrationInstanceSummary {
                             .isVisualBuilderEnabled(o.getIsVisualBuilderEnabled())
                             .customEndpoint(o.getCustomEndpoint())
                             .alternateCustomEndpoints(o.getAlternateCustomEndpoints())
-                            .consumptionModel(o.getConsumptionModel());
+                            .consumptionModel(o.getConsumptionModel())
+                            .networkEndpointDetails(o.getNetworkEndpointDetails());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -463,6 +474,9 @@ public class IntegrationInstanceSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("consumptionModel")
     ConsumptionModel consumptionModel;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("networkEndpointDetails")
+    NetworkEndpointDetails networkEndpointDetails;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/NetworkEndpointDetails.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/NetworkEndpointDetails.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.integration.model;
+
+/**
+ * Base representation of a network endpoint.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190131")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "networkEndpointType",
+    defaultImpl = NetworkEndpointDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PublicEndpointDetails.class,
+        name = "PUBLIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class NetworkEndpointDetails {}

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/NetworkEndpointType.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/NetworkEndpointType.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.integration.model;
+
+/**
+ * Public endpoint access type.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190131")
+@lombok.extern.slf4j.Slf4j
+public enum NetworkEndpointType {
+    Public("PUBLIC"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, NetworkEndpointType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (NetworkEndpointType v : NetworkEndpointType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    NetworkEndpointType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static NetworkEndpointType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'NetworkEndpointType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/PublicEndpointDetails.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/PublicEndpointDetails.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.integration.model;
+
+/**
+ * Public endpoint configuration details.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190131")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PublicEndpointDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "networkEndpointType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PublicEndpointDetails extends NetworkEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("allowlistedHttpIps")
+        private java.util.List<String> allowlistedHttpIps;
+
+        public Builder allowlistedHttpIps(java.util.List<String> allowlistedHttpIps) {
+            this.allowlistedHttpIps = allowlistedHttpIps;
+            this.__explicitlySet__.add("allowlistedHttpIps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("allowlistedHttpVcns")
+        private java.util.List<VirtualCloudNetwork> allowlistedHttpVcns;
+
+        public Builder allowlistedHttpVcns(
+                java.util.List<VirtualCloudNetwork> allowlistedHttpVcns) {
+            this.allowlistedHttpVcns = allowlistedHttpVcns;
+            this.__explicitlySet__.add("allowlistedHttpVcns");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isIntegrationVcnAllowlisted")
+        private Boolean isIntegrationVcnAllowlisted;
+
+        public Builder isIntegrationVcnAllowlisted(Boolean isIntegrationVcnAllowlisted) {
+            this.isIntegrationVcnAllowlisted = isIntegrationVcnAllowlisted;
+            this.__explicitlySet__.add("isIntegrationVcnAllowlisted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PublicEndpointDetails build() {
+            PublicEndpointDetails __instance__ =
+                    new PublicEndpointDetails(
+                            allowlistedHttpIps, allowlistedHttpVcns, isIntegrationVcnAllowlisted);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PublicEndpointDetails o) {
+            Builder copiedBuilder =
+                    allowlistedHttpIps(o.getAllowlistedHttpIps())
+                            .allowlistedHttpVcns(o.getAllowlistedHttpVcns())
+                            .isIntegrationVcnAllowlisted(o.getIsIntegrationVcnAllowlisted());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PublicEndpointDetails(
+            java.util.List<String> allowlistedHttpIps,
+            java.util.List<VirtualCloudNetwork> allowlistedHttpVcns,
+            Boolean isIntegrationVcnAllowlisted) {
+        super();
+        this.allowlistedHttpIps = allowlistedHttpIps;
+        this.allowlistedHttpVcns = allowlistedHttpVcns;
+        this.isIntegrationVcnAllowlisted = isIntegrationVcnAllowlisted;
+    }
+
+    /**
+     * Source IP addresses or IP address ranges ingress rules.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allowlistedHttpIps")
+    java.util.List<String> allowlistedHttpIps;
+
+    /**
+     * Virtual Cloud Networks allowed to access this network endpoint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allowlistedHttpVcns")
+    java.util.List<VirtualCloudNetwork> allowlistedHttpVcns;
+
+    /**
+     * The Integration service's VCN is allow-listed to allow integrations to call back into other integrations
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isIntegrationVcnAllowlisted")
+    Boolean isIntegrationVcnAllowlisted;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/model/VirtualCloudNetwork.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/model/VirtualCloudNetwork.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.integration.model;
+
+/**
+ * Virtual Cloud Network definition.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190131")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VirtualCloudNetwork.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VirtualCloudNetwork {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("allowlistedIps")
+        private java.util.List<String> allowlistedIps;
+
+        public Builder allowlistedIps(java.util.List<String> allowlistedIps) {
+            this.allowlistedIps = allowlistedIps;
+            this.__explicitlySet__.add("allowlistedIps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VirtualCloudNetwork build() {
+            VirtualCloudNetwork __instance__ = new VirtualCloudNetwork(id, allowlistedIps);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VirtualCloudNetwork o) {
+            Builder copiedBuilder = id(o.getId()).allowlistedIps(o.getAllowlistedIps());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The Virtual Cloud Network OCID.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Source IP addresses or IP address ranges ingress rules.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allowlistedIps")
+    java.util.List<String> allowlistedIps;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/requests/ChangeIntegrationInstanceNetworkEndpointRequest.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/requests/ChangeIntegrationInstanceNetworkEndpointRequest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.integration.requests;
+
+import com.oracle.bmc.integration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/integration/ChangeIntegrationInstanceNetworkEndpointExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeIntegrationInstanceNetworkEndpointRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190131")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeIntegrationInstanceNetworkEndpointRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                ChangeIntegrationInstanceNetworkEndpointDetails> {
+
+    /**
+     * Unique Integration Instance identifier.
+     */
+    private String integrationInstanceId;
+
+    /**
+     * Details for the updated Integration instance network endpoint
+     */
+    private ChangeIntegrationInstanceNetworkEndpointDetails
+            changeIntegrationInstanceNetworkEndpointDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations. For example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeIntegrationInstanceNetworkEndpointDetails getBody$() {
+        return changeIntegrationInstanceNetworkEndpointDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeIntegrationInstanceNetworkEndpointRequest,
+                    ChangeIntegrationInstanceNetworkEndpointDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeIntegrationInstanceNetworkEndpointRequest o) {
+            integrationInstanceId(o.getIntegrationInstanceId());
+            changeIntegrationInstanceNetworkEndpointDetails(
+                    o.getChangeIntegrationInstanceNetworkEndpointDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeIntegrationInstanceNetworkEndpointRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeIntegrationInstanceNetworkEndpointRequest
+         */
+        public ChangeIntegrationInstanceNetworkEndpointRequest build() {
+            ChangeIntegrationInstanceNetworkEndpointRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeIntegrationInstanceNetworkEndpointDetails body) {
+            changeIntegrationInstanceNetworkEndpointDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-integration/src/main/java/com/oracle/bmc/integration/responses/ChangeIntegrationInstanceNetworkEndpointResponse.java
+++ b/bmc-integration/src/main/java/com/oracle/bmc/integration/responses/ChangeIntegrationInstanceNetworkEndpointResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.integration.responses;
+
+import com.oracle.bmc.integration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190131")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeIntegrationInstanceNetworkEndpointResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeIntegrationInstanceNetworkEndpointResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.0</version>
+    <version>1.32.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.0</version>
+      <version>1.32.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.32.0</version>
+  <version>1.32.1</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>
@@ -36,6 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson.version>2.12.0</jackson.version>
     <jersey.version>2.32</jersey.version>
+    <apache-httpcomponents.version>4.5.13</apache-httpcomponents.version>
     <guava.version>30.1-jre</guava.version>
     <junit.version>4.13.1</junit.version>
     <lombok.version>1.18.4</lombok.version>


### PR DESCRIPTION
### Added

- Support for scan DNS names and zone ids on database system, cloud VM cluster, and autonomous Exadata infrastructure responses in the Database service

- Support for specifying ACL rules to limit ingress into public load balancers in the Integration service

- Support for Cloud at Customer as a source type in the Application Migration service

- Support for selective migration of specific resources in the Application Migration service