### PR TITLE
Releasing version 1.32.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.32.2 - 2021-02-23
+### Added
+- Support for the OCI Registry service
+- Support for exporting an existing running VM, or a copy of VM, into a VMDK, QCOW2, VDI, VHD, or OCI formatted image in the Compute service
+- Support for platform configurations on instances in the Compute service
+- Support for providing target tags and target compartments on profiles in the Optimizer service
+- Support for the 'Fix it' feature in the Optimizer service
+
 ## 1.32.1 - 2021-02-16
 ### Added
 - Support for scan DNS names and zone ids on database system, cloud VM cluster, and autonomous Exadata infrastructure responses in the Database service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.oracle.oci.sdk</groupId>
+    <artifactId>oci-java-sdk</artifactId>
+    <version>1.32.2</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>oci-java-sdk-artifacts</artifactId>
+  <name>Oracle Cloud Infrastructure SDK - Artifacts</name>
+  <description>This project contains the SDK used for Oracle Cloud Infrastructure Artifacts</description>
+  <url>https://docs.cloud.oracle.com/Content/API/SDKDocs/javasdk.htm</url>
+  <dependencies>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-common</artifactId>
+      <version>1.32.2</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/Artifacts.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/Artifacts.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts;
+
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+
+/**
+ * API covering the [Registry](https://docs.cloud.oracle.com/iaas/Content/Registry/Concepts/registryoverview.htm) services.
+ * Use this API to manage resources such as container images and repositories.
+ *
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+public interface Artifacts extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Moves a container repository into a different compartment within the same tenancy. For information about moving
+     * resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ChangeContainerRepositoryCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeContainerRepositoryCompartment API.
+     */
+    ChangeContainerRepositoryCompartmentResponse changeContainerRepositoryCompartment(
+            ChangeContainerRepositoryCompartmentRequest request);
+
+    /**
+     * Create a new empty container repository. Avoid entering confidential information.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/CreateContainerRepositoryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateContainerRepository API.
+     */
+    CreateContainerRepositoryResponse createContainerRepository(
+            CreateContainerRepositoryRequest request);
+
+    /**
+     * Delete a container image.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteContainerImageExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteContainerImage API.
+     */
+    DeleteContainerImageResponse deleteContainerImage(DeleteContainerImageRequest request);
+
+    /**
+     * Delete container repository.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteContainerRepositoryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteContainerRepository API.
+     */
+    DeleteContainerRepositoryResponse deleteContainerRepository(
+            DeleteContainerRepositoryRequest request);
+
+    /**
+     * Get container configuration.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetContainerConfigurationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetContainerConfiguration API.
+     */
+    GetContainerConfigurationResponse getContainerConfiguration(
+            GetContainerConfigurationRequest request);
+
+    /**
+     * Get container image metadata.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetContainerImageExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetContainerImage API.
+     */
+    GetContainerImageResponse getContainerImage(GetContainerImageRequest request);
+
+    /**
+     * Get container repository.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetContainerRepositoryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetContainerRepository API.
+     */
+    GetContainerRepositoryResponse getContainerRepository(GetContainerRepositoryRequest request);
+
+    /**
+     * List container images in a compartment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ListContainerImagesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListContainerImages API.
+     */
+    ListContainerImagesResponse listContainerImages(ListContainerImagesRequest request);
+
+    /**
+     * List container repositories in a compartment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ListContainerRepositoriesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListContainerRepositories API.
+     */
+    ListContainerRepositoriesResponse listContainerRepositories(
+            ListContainerRepositoriesRequest request);
+
+    /**
+     * Remove version from container image.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/RemoveContainerVersionExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RemoveContainerVersion API.
+     */
+    RemoveContainerVersionResponse removeContainerVersion(RemoveContainerVersionRequest request);
+
+    /**
+     * Restore a container image.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/RestoreContainerImageExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RestoreContainerImage API.
+     */
+    RestoreContainerImageResponse restoreContainerImage(RestoreContainerImageRequest request);
+
+    /**
+     * Update container configuration.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateContainerConfigurationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateContainerConfiguration API.
+     */
+    UpdateContainerConfigurationResponse updateContainerConfiguration(
+            UpdateContainerConfigurationRequest request);
+
+    /**
+     * Modify the properties of a container repository. Avoid entering confidential information.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateContainerRepositoryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateContainerRepository API.
+     */
+    UpdateContainerRepositoryResponse updateContainerRepository(
+            UpdateContainerRepositoryRequest request);
+
+    /**
+     * Gets the pre-configured waiters available for resources for this service.
+     *
+     * @return The service waiters.
+     */
+    ArtifactsWaiters getWaiters();
+
+    /**
+     * Gets the pre-configured paginators available for list operations in this service which may return multiple
+     * pages of data. These paginators provide an {@link java.lang.Iterable} interface so that service responses, or
+     * resources/records, can be iterated through without having to manually deal with pagination and page tokens.
+     *
+     * @return The service paginators.
+     */
+    ArtifactsPaginators getPaginators();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsAsync.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsAsync.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts;
+
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+
+/**
+ * API covering the [Registry](https://docs.cloud.oracle.com/iaas/Content/Registry/Concepts/registryoverview.htm) services.
+ * Use this API to manage resources such as container images and repositories.
+ *
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+public interface ArtifactsAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Moves a container repository into a different compartment within the same tenancy. For information about moving
+     * resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeContainerRepositoryCompartmentResponse>
+            changeContainerRepositoryCompartment(
+                    ChangeContainerRepositoryCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeContainerRepositoryCompartmentRequest,
+                                    ChangeContainerRepositoryCompartmentResponse>
+                            handler);
+
+    /**
+     * Create a new empty container repository. Avoid entering confidential information.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateContainerRepositoryResponse> createContainerRepository(
+            CreateContainerRepositoryRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateContainerRepositoryRequest, CreateContainerRepositoryResponse>
+                    handler);
+
+    /**
+     * Delete a container image.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteContainerImageResponse> deleteContainerImage(
+            DeleteContainerImageRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteContainerImageRequest, DeleteContainerImageResponse>
+                    handler);
+
+    /**
+     * Delete container repository.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteContainerRepositoryResponse> deleteContainerRepository(
+            DeleteContainerRepositoryRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteContainerRepositoryRequest, DeleteContainerRepositoryResponse>
+                    handler);
+
+    /**
+     * Get container configuration.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetContainerConfigurationResponse> getContainerConfiguration(
+            GetContainerConfigurationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetContainerConfigurationRequest, GetContainerConfigurationResponse>
+                    handler);
+
+    /**
+     * Get container image metadata.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetContainerImageResponse> getContainerImage(
+            GetContainerImageRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetContainerImageRequest, GetContainerImageResponse>
+                    handler);
+
+    /**
+     * Get container repository.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetContainerRepositoryResponse> getContainerRepository(
+            GetContainerRepositoryRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetContainerRepositoryRequest, GetContainerRepositoryResponse>
+                    handler);
+
+    /**
+     * List container images in a compartment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListContainerImagesResponse> listContainerImages(
+            ListContainerImagesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListContainerImagesRequest, ListContainerImagesResponse>
+                    handler);
+
+    /**
+     * List container repositories in a compartment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListContainerRepositoriesResponse> listContainerRepositories(
+            ListContainerRepositoriesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListContainerRepositoriesRequest, ListContainerRepositoriesResponse>
+                    handler);
+
+    /**
+     * Remove version from container image.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RemoveContainerVersionResponse> removeContainerVersion(
+            RemoveContainerVersionRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            RemoveContainerVersionRequest, RemoveContainerVersionResponse>
+                    handler);
+
+    /**
+     * Restore a container image.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RestoreContainerImageResponse> restoreContainerImage(
+            RestoreContainerImageRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            RestoreContainerImageRequest, RestoreContainerImageResponse>
+                    handler);
+
+    /**
+     * Update container configuration.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateContainerConfigurationResponse> updateContainerConfiguration(
+            UpdateContainerConfigurationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateContainerConfigurationRequest,
+                            UpdateContainerConfigurationResponse>
+                    handler);
+
+    /**
+     * Modify the properties of a container repository. Avoid entering confidential information.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateContainerRepositoryResponse> updateContainerRepository(
+            UpdateContainerRepositoryRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateContainerRepositoryRequest, UpdateContainerRepositoryResponse>
+                    handler);
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsAsyncClient.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsAsyncClient.java
@@ -1,0 +1,913 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts;
+
+import com.oracle.bmc.artifacts.internal.http.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+
+/**
+ * Async client implementation for Artifacts service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ArtifactsAsyncClient implements ArtifactsAsync {
+    /**
+     * Service instance for Artifacts.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("ARTIFACTS")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://artifacts.{region}.oci.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public ArtifactsAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public ArtifactsAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public ArtifactsAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public ArtifactsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public ArtifactsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ArtifactsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ArtifactsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    public ArtifactsAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, ArtifactsAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public ArtifactsAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new ArtifactsAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<ChangeContainerRepositoryCompartmentResponse>
+            changeContainerRepositoryCompartment(
+                    ChangeContainerRepositoryCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeContainerRepositoryCompartmentRequest,
+                                    ChangeContainerRepositoryCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeContainerRepositoryCompartment");
+        final ChangeContainerRepositoryCompartmentRequest interceptedRequest =
+                ChangeContainerRepositoryCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeContainerRepositoryCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeContainerRepositoryCompartmentResponse>
+                transformer = ChangeContainerRepositoryCompartmentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeContainerRepositoryCompartmentRequest,
+                        ChangeContainerRepositoryCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeContainerRepositoryCompartmentRequest,
+                                ChangeContainerRepositoryCompartmentResponse>,
+                        java.util.concurrent.Future<ChangeContainerRepositoryCompartmentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeContainerRepositoryCompartmentRequest,
+                    ChangeContainerRepositoryCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateContainerRepositoryResponse> createContainerRepository(
+            CreateContainerRepositoryRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateContainerRepositoryRequest, CreateContainerRepositoryResponse>
+                    handler) {
+        LOG.trace("Called async createContainerRepository");
+        final CreateContainerRepositoryRequest interceptedRequest =
+                CreateContainerRepositoryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateContainerRepositoryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateContainerRepositoryResponse>
+                transformer = CreateContainerRepositoryConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateContainerRepositoryRequest, CreateContainerRepositoryResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateContainerRepositoryRequest,
+                                CreateContainerRepositoryResponse>,
+                        java.util.concurrent.Future<CreateContainerRepositoryResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateContainerRepositoryRequest, CreateContainerRepositoryResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteContainerImageResponse> deleteContainerImage(
+            DeleteContainerImageRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteContainerImageRequest, DeleteContainerImageResponse>
+                    handler) {
+        LOG.trace("Called async deleteContainerImage");
+        final DeleteContainerImageRequest interceptedRequest =
+                DeleteContainerImageConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteContainerImageConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteContainerImageResponse>
+                transformer = DeleteContainerImageConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteContainerImageRequest, DeleteContainerImageResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteContainerImageRequest, DeleteContainerImageResponse>,
+                        java.util.concurrent.Future<DeleteContainerImageResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteContainerImageRequest, DeleteContainerImageResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteContainerRepositoryResponse> deleteContainerRepository(
+            DeleteContainerRepositoryRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteContainerRepositoryRequest, DeleteContainerRepositoryResponse>
+                    handler) {
+        LOG.trace("Called async deleteContainerRepository");
+        final DeleteContainerRepositoryRequest interceptedRequest =
+                DeleteContainerRepositoryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteContainerRepositoryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteContainerRepositoryResponse>
+                transformer = DeleteContainerRepositoryConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteContainerRepositoryRequest, DeleteContainerRepositoryResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteContainerRepositoryRequest,
+                                DeleteContainerRepositoryResponse>,
+                        java.util.concurrent.Future<DeleteContainerRepositoryResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteContainerRepositoryRequest, DeleteContainerRepositoryResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetContainerConfigurationResponse> getContainerConfiguration(
+            GetContainerConfigurationRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetContainerConfigurationRequest, GetContainerConfigurationResponse>
+                    handler) {
+        LOG.trace("Called async getContainerConfiguration");
+        final GetContainerConfigurationRequest interceptedRequest =
+                GetContainerConfigurationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetContainerConfigurationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetContainerConfigurationResponse>
+                transformer = GetContainerConfigurationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetContainerConfigurationRequest, GetContainerConfigurationResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetContainerConfigurationRequest,
+                                GetContainerConfigurationResponse>,
+                        java.util.concurrent.Future<GetContainerConfigurationResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetContainerConfigurationRequest, GetContainerConfigurationResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetContainerImageResponse> getContainerImage(
+            GetContainerImageRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetContainerImageRequest, GetContainerImageResponse>
+                    handler) {
+        LOG.trace("Called async getContainerImage");
+        final GetContainerImageRequest interceptedRequest =
+                GetContainerImageConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetContainerImageConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetContainerImageResponse>
+                transformer = GetContainerImageConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetContainerImageRequest, GetContainerImageResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetContainerImageRequest, GetContainerImageResponse>,
+                        java.util.concurrent.Future<GetContainerImageResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetContainerImageRequest, GetContainerImageResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetContainerRepositoryResponse> getContainerRepository(
+            GetContainerRepositoryRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetContainerRepositoryRequest, GetContainerRepositoryResponse>
+                    handler) {
+        LOG.trace("Called async getContainerRepository");
+        final GetContainerRepositoryRequest interceptedRequest =
+                GetContainerRepositoryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetContainerRepositoryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetContainerRepositoryResponse>
+                transformer = GetContainerRepositoryConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetContainerRepositoryRequest, GetContainerRepositoryResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetContainerRepositoryRequest, GetContainerRepositoryResponse>,
+                        java.util.concurrent.Future<GetContainerRepositoryResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetContainerRepositoryRequest, GetContainerRepositoryResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListContainerImagesResponse> listContainerImages(
+            ListContainerImagesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListContainerImagesRequest, ListContainerImagesResponse>
+                    handler) {
+        LOG.trace("Called async listContainerImages");
+        final ListContainerImagesRequest interceptedRequest =
+                ListContainerImagesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListContainerImagesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListContainerImagesResponse>
+                transformer = ListContainerImagesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListContainerImagesRequest, ListContainerImagesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListContainerImagesRequest, ListContainerImagesResponse>,
+                        java.util.concurrent.Future<ListContainerImagesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListContainerImagesRequest, ListContainerImagesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListContainerRepositoriesResponse> listContainerRepositories(
+            ListContainerRepositoriesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListContainerRepositoriesRequest, ListContainerRepositoriesResponse>
+                    handler) {
+        LOG.trace("Called async listContainerRepositories");
+        final ListContainerRepositoriesRequest interceptedRequest =
+                ListContainerRepositoriesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListContainerRepositoriesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListContainerRepositoriesResponse>
+                transformer = ListContainerRepositoriesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListContainerRepositoriesRequest, ListContainerRepositoriesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListContainerRepositoriesRequest,
+                                ListContainerRepositoriesResponse>,
+                        java.util.concurrent.Future<ListContainerRepositoriesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListContainerRepositoriesRequest, ListContainerRepositoriesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<RemoveContainerVersionResponse> removeContainerVersion(
+            RemoveContainerVersionRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            RemoveContainerVersionRequest, RemoveContainerVersionResponse>
+                    handler) {
+        LOG.trace("Called async removeContainerVersion");
+        final RemoveContainerVersionRequest interceptedRequest =
+                RemoveContainerVersionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveContainerVersionConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RemoveContainerVersionResponse>
+                transformer = RemoveContainerVersionConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        RemoveContainerVersionRequest, RemoveContainerVersionResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RemoveContainerVersionRequest, RemoveContainerVersionResponse>,
+                        java.util.concurrent.Future<RemoveContainerVersionResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RemoveContainerVersionRequest, RemoveContainerVersionResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<RestoreContainerImageResponse> restoreContainerImage(
+            RestoreContainerImageRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            RestoreContainerImageRequest, RestoreContainerImageResponse>
+                    handler) {
+        LOG.trace("Called async restoreContainerImage");
+        final RestoreContainerImageRequest interceptedRequest =
+                RestoreContainerImageConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RestoreContainerImageConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RestoreContainerImageResponse>
+                transformer = RestoreContainerImageConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        RestoreContainerImageRequest, RestoreContainerImageResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RestoreContainerImageRequest, RestoreContainerImageResponse>,
+                        java.util.concurrent.Future<RestoreContainerImageResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RestoreContainerImageRequest, RestoreContainerImageResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateContainerConfigurationResponse>
+            updateContainerConfiguration(
+                    UpdateContainerConfigurationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateContainerConfigurationRequest,
+                                    UpdateContainerConfigurationResponse>
+                            handler) {
+        LOG.trace("Called async updateContainerConfiguration");
+        final UpdateContainerConfigurationRequest interceptedRequest =
+                UpdateContainerConfigurationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateContainerConfigurationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateContainerConfigurationResponse>
+                transformer = UpdateContainerConfigurationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateContainerConfigurationRequest, UpdateContainerConfigurationResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateContainerConfigurationRequest,
+                                UpdateContainerConfigurationResponse>,
+                        java.util.concurrent.Future<UpdateContainerConfigurationResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateContainerConfigurationRequest, UpdateContainerConfigurationResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateContainerRepositoryResponse> updateContainerRepository(
+            UpdateContainerRepositoryRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateContainerRepositoryRequest, UpdateContainerRepositoryResponse>
+                    handler) {
+        LOG.trace("Called async updateContainerRepository");
+        final UpdateContainerRepositoryRequest interceptedRequest =
+                UpdateContainerRepositoryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateContainerRepositoryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateContainerRepositoryResponse>
+                transformer = UpdateContainerRepositoryConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateContainerRepositoryRequest, UpdateContainerRepositoryResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateContainerRepositoryRequest,
+                                UpdateContainerRepositoryResponse>,
+                        java.util.concurrent.Future<UpdateContainerRepositoryResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateContainerRepositoryRequest, UpdateContainerRepositoryResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsClient.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsClient.java
@@ -1,0 +1,868 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts;
+
+import com.oracle.bmc.artifacts.internal.http.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ArtifactsClient implements Artifacts {
+    /**
+     * Service instance for Artifacts.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("ARTIFACTS")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://artifacts.{region}.oci.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    private final ArtifactsWaiters waiters;
+
+    private final ArtifactsPaginators paginators;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public ArtifactsClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public ArtifactsClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public ArtifactsClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public ArtifactsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public ArtifactsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ArtifactsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public ArtifactsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     */
+    public ArtifactsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                executorService,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * Use the {@link Builder} to get access to all these parameters.
+     *
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    protected ArtifactsClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (executorService == null) {
+            // up to 50 (core) threads, time out after 60s idle, all daemon
+            java.util.concurrent.ThreadPoolExecutor threadPoolExecutor =
+                    new java.util.concurrent.ThreadPoolExecutor(
+                            50,
+                            50,
+                            60L,
+                            java.util.concurrent.TimeUnit.SECONDS,
+                            new java.util.concurrent.LinkedBlockingQueue<Runnable>(),
+                            new com.google.common.util.concurrent.ThreadFactoryBuilder()
+                                    .setDaemon(true)
+                                    .setNameFormat("Artifacts-waiters-%d")
+                                    .build());
+            threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+            executorService = threadPoolExecutor;
+        }
+        this.waiters = new ArtifactsWaiters(executorService, this);
+
+        this.paginators = new ArtifactsPaginators(this);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, ArtifactsClient> {
+        private java.util.concurrent.ExecutorService executorService;
+
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Set the ExecutorService for the client to be created.
+         * @param executorService executorService
+         * @return this builder
+         */
+        public Builder executorService(java.util.concurrent.ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public ArtifactsClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new ArtifactsClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint,
+                    executorService);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public ChangeContainerRepositoryCompartmentResponse changeContainerRepositoryCompartment(
+            ChangeContainerRepositoryCompartmentRequest request) {
+        LOG.trace("Called changeContainerRepositoryCompartment");
+        final ChangeContainerRepositoryCompartmentRequest interceptedRequest =
+                ChangeContainerRepositoryCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeContainerRepositoryCompartmentConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeContainerRepositoryCompartmentResponse>
+                transformer = ChangeContainerRepositoryCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeContainerRepositoryCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateContainerRepositoryResponse createContainerRepository(
+            CreateContainerRepositoryRequest request) {
+        LOG.trace("Called createContainerRepository");
+        final CreateContainerRepositoryRequest interceptedRequest =
+                CreateContainerRepositoryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateContainerRepositoryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateContainerRepositoryResponse>
+                transformer = CreateContainerRepositoryConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getCreateContainerRepositoryDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteContainerImageResponse deleteContainerImage(DeleteContainerImageRequest request) {
+        LOG.trace("Called deleteContainerImage");
+        final DeleteContainerImageRequest interceptedRequest =
+                DeleteContainerImageConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteContainerImageConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteContainerImageResponse>
+                transformer = DeleteContainerImageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteContainerRepositoryResponse deleteContainerRepository(
+            DeleteContainerRepositoryRequest request) {
+        LOG.trace("Called deleteContainerRepository");
+        final DeleteContainerRepositoryRequest interceptedRequest =
+                DeleteContainerRepositoryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteContainerRepositoryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteContainerRepositoryResponse>
+                transformer = DeleteContainerRepositoryConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetContainerConfigurationResponse getContainerConfiguration(
+            GetContainerConfigurationRequest request) {
+        LOG.trace("Called getContainerConfiguration");
+        final GetContainerConfigurationRequest interceptedRequest =
+                GetContainerConfigurationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetContainerConfigurationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetContainerConfigurationResponse>
+                transformer = GetContainerConfigurationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetContainerImageResponse getContainerImage(GetContainerImageRequest request) {
+        LOG.trace("Called getContainerImage");
+        final GetContainerImageRequest interceptedRequest =
+                GetContainerImageConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetContainerImageConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetContainerImageResponse>
+                transformer = GetContainerImageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetContainerRepositoryResponse getContainerRepository(
+            GetContainerRepositoryRequest request) {
+        LOG.trace("Called getContainerRepository");
+        final GetContainerRepositoryRequest interceptedRequest =
+                GetContainerRepositoryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetContainerRepositoryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetContainerRepositoryResponse>
+                transformer = GetContainerRepositoryConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListContainerImagesResponse listContainerImages(ListContainerImagesRequest request) {
+        LOG.trace("Called listContainerImages");
+        final ListContainerImagesRequest interceptedRequest =
+                ListContainerImagesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListContainerImagesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListContainerImagesResponse>
+                transformer = ListContainerImagesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListContainerRepositoriesResponse listContainerRepositories(
+            ListContainerRepositoriesRequest request) {
+        LOG.trace("Called listContainerRepositories");
+        final ListContainerRepositoriesRequest interceptedRequest =
+                ListContainerRepositoriesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListContainerRepositoriesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListContainerRepositoriesResponse>
+                transformer = ListContainerRepositoriesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public RemoveContainerVersionResponse removeContainerVersion(
+            RemoveContainerVersionRequest request) {
+        LOG.trace("Called removeContainerVersion");
+        final RemoveContainerVersionRequest interceptedRequest =
+                RemoveContainerVersionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveContainerVersionConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, RemoveContainerVersionResponse>
+                transformer = RemoveContainerVersionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getRemoveContainerVersionDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public RestoreContainerImageResponse restoreContainerImage(
+            RestoreContainerImageRequest request) {
+        LOG.trace("Called restoreContainerImage");
+        final RestoreContainerImageRequest interceptedRequest =
+                RestoreContainerImageConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RestoreContainerImageConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, RestoreContainerImageResponse>
+                transformer = RestoreContainerImageConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getRestoreContainerImageDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateContainerConfigurationResponse updateContainerConfiguration(
+            UpdateContainerConfigurationRequest request) {
+        LOG.trace("Called updateContainerConfiguration");
+        final UpdateContainerConfigurationRequest interceptedRequest =
+                UpdateContainerConfigurationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateContainerConfigurationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateContainerConfigurationResponse>
+                transformer = UpdateContainerConfigurationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest
+                                                        .getUpdateContainerConfigurationDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateContainerRepositoryResponse updateContainerRepository(
+            UpdateContainerRepositoryRequest request) {
+        LOG.trace("Called updateContainerRepository");
+        final UpdateContainerRepositoryRequest interceptedRequest =
+                UpdateContainerRepositoryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateContainerRepositoryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateContainerRepositoryResponse>
+                transformer = UpdateContainerRepositoryConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest
+                                                        .getUpdateContainerRepositoryDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ArtifactsWaiters getWaiters() {
+        return waiters;
+    }
+
+    @Override
+    public ArtifactsPaginators getPaginators() {
+        return paginators;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsPaginators.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsPaginators.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts;
+
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+
+/**
+ * Collection of helper methods that can be used to provide an {@link java.lang.Iterable} interface
+ * to any list operations of Artifacts where multiple pages of data may be fetched.
+ * Two styles of iteration are supported:
+ *
+ * <ul>
+ *   <li>Iterating over the Response objects returned by the list operation. These are referred to as ResponseIterators, and the methods are suffixed with ResponseIterator. For example: <i>listUsersResponseIterator</i></li>
+ *   <li>Iterating over the resources/records being listed. These are referred to as RecordIterators, and the methods are suffixed with RecordIterator. For example: <i>listUsersRecordIterator</i></li>
+ * </ul>
+ *
+ * These iterables abstract away the need to write code to manually handle pagination via looping and using the page tokens.
+ * They will automatically fetch more data from the service when required.
+ *
+ * As an example, if we were using the ListUsers operation in IdentityService, then the {@link java.lang.Iterable} returned by calling a
+ * ResponseIterator method would iterate over the ListUsersResponse objects returned by each ListUsers call, whereas the {@link java.lang.Iterable}
+ * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
+ * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.RequiredArgsConstructor
+public class ArtifactsPaginators {
+    private final Artifacts client;
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listContainerImages operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListContainerImagesResponse> listContainerImagesResponseIterator(
+            final ListContainerImagesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListContainerImagesRequest.Builder, ListContainerImagesRequest,
+                ListContainerImagesResponse>(
+                new com.google.common.base.Supplier<ListContainerImagesRequest.Builder>() {
+                    @Override
+                    public ListContainerImagesRequest.Builder get() {
+                        return ListContainerImagesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListContainerImagesResponse, String>() {
+                    @Override
+                    public String apply(ListContainerImagesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListContainerImagesRequest.Builder>,
+                        ListContainerImagesRequest>() {
+                    @Override
+                    public ListContainerImagesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListContainerImagesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListContainerImagesRequest, ListContainerImagesResponse>() {
+                    @Override
+                    public ListContainerImagesResponse apply(ListContainerImagesRequest request) {
+                        return client.listContainerImages(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.artifacts.model.ContainerImageSummary} objects
+     * contained in responses from the listContainerImages operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.artifacts.model.ContainerImageSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.artifacts.model.ContainerImageSummary>
+            listContainerImagesRecordIterator(final ListContainerImagesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListContainerImagesRequest.Builder, ListContainerImagesRequest,
+                ListContainerImagesResponse, com.oracle.bmc.artifacts.model.ContainerImageSummary>(
+                new com.google.common.base.Supplier<ListContainerImagesRequest.Builder>() {
+                    @Override
+                    public ListContainerImagesRequest.Builder get() {
+                        return ListContainerImagesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListContainerImagesResponse, String>() {
+                    @Override
+                    public String apply(ListContainerImagesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListContainerImagesRequest.Builder>,
+                        ListContainerImagesRequest>() {
+                    @Override
+                    public ListContainerImagesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListContainerImagesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListContainerImagesRequest, ListContainerImagesResponse>() {
+                    @Override
+                    public ListContainerImagesResponse apply(ListContainerImagesRequest request) {
+                        return client.listContainerImages(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListContainerImagesResponse,
+                        java.util.List<com.oracle.bmc.artifacts.model.ContainerImageSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.artifacts.model.ContainerImageSummary>
+                            apply(ListContainerImagesResponse response) {
+                        return response.getContainerImageCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listContainerRepositories operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListContainerRepositoriesResponse> listContainerRepositoriesResponseIterator(
+            final ListContainerRepositoriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListContainerRepositoriesRequest.Builder, ListContainerRepositoriesRequest,
+                ListContainerRepositoriesResponse>(
+                new com.google.common.base.Supplier<ListContainerRepositoriesRequest.Builder>() {
+                    @Override
+                    public ListContainerRepositoriesRequest.Builder get() {
+                        return ListContainerRepositoriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListContainerRepositoriesResponse, String>() {
+                    @Override
+                    public String apply(ListContainerRepositoriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListContainerRepositoriesRequest.Builder>,
+                        ListContainerRepositoriesRequest>() {
+                    @Override
+                    public ListContainerRepositoriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListContainerRepositoriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListContainerRepositoriesRequest, ListContainerRepositoriesResponse>() {
+                    @Override
+                    public ListContainerRepositoriesResponse apply(
+                            ListContainerRepositoriesRequest request) {
+                        return client.listContainerRepositories(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.artifacts.model.ContainerRepositorySummary} objects
+     * contained in responses from the listContainerRepositories operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.artifacts.model.ContainerRepositorySummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.artifacts.model.ContainerRepositorySummary>
+            listContainerRepositoriesRecordIterator(
+                    final ListContainerRepositoriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListContainerRepositoriesRequest.Builder, ListContainerRepositoriesRequest,
+                ListContainerRepositoriesResponse,
+                com.oracle.bmc.artifacts.model.ContainerRepositorySummary>(
+                new com.google.common.base.Supplier<ListContainerRepositoriesRequest.Builder>() {
+                    @Override
+                    public ListContainerRepositoriesRequest.Builder get() {
+                        return ListContainerRepositoriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListContainerRepositoriesResponse, String>() {
+                    @Override
+                    public String apply(ListContainerRepositoriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListContainerRepositoriesRequest.Builder>,
+                        ListContainerRepositoriesRequest>() {
+                    @Override
+                    public ListContainerRepositoriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListContainerRepositoriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListContainerRepositoriesRequest, ListContainerRepositoriesResponse>() {
+                    @Override
+                    public ListContainerRepositoriesResponse apply(
+                            ListContainerRepositoriesRequest request) {
+                        return client.listContainerRepositories(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListContainerRepositoriesResponse,
+                        java.util.List<
+                                com.oracle.bmc.artifacts.model.ContainerRepositorySummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.artifacts.model.ContainerRepositorySummary>
+                            apply(ListContainerRepositoriesResponse response) {
+                        return response.getContainerRepositoryCollection().getItems();
+                    }
+                });
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsWaiters.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsWaiters.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts;
+
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+
+/**
+ * Collection of helper methods to produce {@link com.oracle.bmc.waiter.Waiter}s for different
+ * resources of Artifacts.
+ * <p>
+ * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.RequiredArgsConstructor
+public class ArtifactsWaiters {
+    private final java.util.concurrent.ExecutorService executorService;
+    private final Artifacts client;
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetContainerImageRequest, GetContainerImageResponse>
+            forContainerImage(
+                    GetContainerImageRequest request,
+                    com.oracle.bmc.artifacts.model.ContainerImage.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forContainerImage(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetContainerImageRequest, GetContainerImageResponse>
+            forContainerImage(
+                    GetContainerImageRequest request,
+                    com.oracle.bmc.artifacts.model.ContainerImage.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forContainerImage(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetContainerImageRequest, GetContainerImageResponse>
+            forContainerImage(
+                    GetContainerImageRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.artifacts.model.ContainerImage.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forContainerImage(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for ContainerImage.
+    private com.oracle.bmc.waiter.Waiter<GetContainerImageRequest, GetContainerImageResponse>
+            forContainerImage(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetContainerImageRequest request,
+                    final com.oracle.bmc.artifacts.model.ContainerImage.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.artifacts.model.ContainerImage.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetContainerImageRequest, GetContainerImageResponse>() {
+                            @Override
+                            public GetContainerImageResponse apply(
+                                    GetContainerImageRequest request) {
+                                return client.getContainerImage(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetContainerImageResponse>() {
+                            @Override
+                            public boolean apply(GetContainerImageResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getContainerImage().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.artifacts.model.ContainerImage.LifecycleState
+                                        .Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetContainerRepositoryRequest, GetContainerRepositoryResponse>
+            forContainerRepository(
+                    GetContainerRepositoryRequest request,
+                    com.oracle.bmc.artifacts.model.ContainerRepository.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forContainerRepository(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetContainerRepositoryRequest, GetContainerRepositoryResponse>
+            forContainerRepository(
+                    GetContainerRepositoryRequest request,
+                    com.oracle.bmc.artifacts.model.ContainerRepository.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forContainerRepository(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetContainerRepositoryRequest, GetContainerRepositoryResponse>
+            forContainerRepository(
+                    GetContainerRepositoryRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.artifacts.model.ContainerRepository.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forContainerRepository(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for ContainerRepository.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetContainerRepositoryRequest, GetContainerRepositoryResponse>
+            forContainerRepository(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetContainerRepositoryRequest request,
+                    final com.oracle.bmc.artifacts.model.ContainerRepository.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.artifacts.model.ContainerRepository.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetContainerRepositoryRequest, GetContainerRepositoryResponse>() {
+                            @Override
+                            public GetContainerRepositoryResponse apply(
+                                    GetContainerRepositoryRequest request) {
+                                return client.getContainerRepository(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetContainerRepositoryResponse>() {
+                            @Override
+                            public boolean apply(GetContainerRepositoryResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getContainerRepository().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.artifacts.model.ContainerRepository.LifecycleState
+                                        .Deleted)),
+                request);
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ChangeContainerRepositoryCompartmentConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ChangeContainerRepositoryCompartmentConverter.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ChangeContainerRepositoryCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.ChangeContainerRepositoryCompartmentRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.ChangeContainerRepositoryCompartmentRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.ChangeContainerRepositoryCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notNull(
+                request.getChangeContainerRepositoryCompartmentDetails(),
+                "changeContainerRepositoryCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("container")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.ChangeContainerRepositoryCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses
+                                .ChangeContainerRepositoryCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .ChangeContainerRepositoryCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .ChangeContainerRepositoryCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.ChangeContainerRepositoryCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses
+                                                .ChangeContainerRepositoryCompartmentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .ChangeContainerRepositoryCompartmentResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses
+                                                .ChangeContainerRepositoryCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/CreateContainerRepositoryConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/CreateContainerRepositoryConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CreateContainerRepositoryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.CreateContainerRepositoryRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.CreateContainerRepositoryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.CreateContainerRepositoryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateContainerRepositoryDetails(),
+                "createContainerRepositoryDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("container").path("repositories");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.CreateContainerRepositoryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.CreateContainerRepositoryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .CreateContainerRepositoryResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .CreateContainerRepositoryResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.CreateContainerRepositoryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerRepository>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerRepository.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ContainerRepository>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.CreateContainerRepositoryResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .CreateContainerRepositoryResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerRepository(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.CreateContainerRepositoryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteContainerImageConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteContainerImageConverter.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteContainerImageConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.DeleteContainerImageRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.DeleteContainerImageRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.DeleteContainerImageRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getImageId(), "imageId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("container")
+                        .path("images")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getImageId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.DeleteContainerImageResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.DeleteContainerImageResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.DeleteContainerImageResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.DeleteContainerImageResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.DeleteContainerImageResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.DeleteContainerImageResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .DeleteContainerImageResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.DeleteContainerImageResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteContainerRepositoryConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteContainerRepositoryConverter.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteContainerRepositoryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.DeleteContainerRepositoryRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.DeleteContainerRepositoryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.DeleteContainerRepositoryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("container")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.DeleteContainerRepositoryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.DeleteContainerRepositoryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .DeleteContainerRepositoryResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .DeleteContainerRepositoryResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.DeleteContainerRepositoryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.DeleteContainerRepositoryResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .DeleteContainerRepositoryResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.DeleteContainerRepositoryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetContainerConfigurationConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetContainerConfigurationConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetContainerConfigurationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.GetContainerConfigurationRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.GetContainerConfigurationRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.GetContainerConfigurationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("container").path("configuration");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.GetContainerConfigurationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.GetContainerConfigurationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .GetContainerConfigurationResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .GetContainerConfigurationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.GetContainerConfigurationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerConfiguration>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerConfiguration.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ContainerConfiguration>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.GetContainerConfigurationResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .GetContainerConfigurationResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerConfiguration(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.GetContainerConfigurationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetContainerImageConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetContainerImageConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetContainerImageConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.GetContainerImageRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.GetContainerImageRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.GetContainerImageRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getImageId(), "imageId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("container")
+                        .path("images")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getImageId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.GetContainerImageResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.GetContainerImageResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.GetContainerImageResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.GetContainerImageResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.GetContainerImageResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerImage>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerImage.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ContainerImage> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.GetContainerImageResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .GetContainerImageResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerImage(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.GetContainerImageResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetContainerRepositoryConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetContainerRepositoryConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetContainerRepositoryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.GetContainerRepositoryRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.GetContainerRepositoryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.GetContainerRepositoryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("container")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.GetContainerRepositoryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.GetContainerRepositoryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .GetContainerRepositoryResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.GetContainerRepositoryResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.GetContainerRepositoryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerRepository>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerRepository.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ContainerRepository>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.GetContainerRepositoryResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .GetContainerRepositoryResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerRepository(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.GetContainerRepositoryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ListContainerImagesConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ListContainerImagesConverter.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListContainerImagesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.ListContainerImagesRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.ListContainerImagesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.ListContainerImagesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("container").path("images");
+
+        if (request.getCompartmentIdInSubtree() != null) {
+            target =
+                    target.queryParam(
+                            "compartmentIdInSubtree",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCompartmentIdInSubtree()));
+        }
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getImageId() != null) {
+            target =
+                    target.queryParam(
+                            "imageId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getImageId()));
+        }
+
+        if (request.getIsVersioned() != null) {
+            target =
+                    target.queryParam(
+                            "isVersioned",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsVersioned()));
+        }
+
+        if (request.getRepositoryId() != null) {
+            target =
+                    target.queryParam(
+                            "repositoryId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getRepositoryId()));
+        }
+
+        if (request.getRepositoryName() != null) {
+            target =
+                    target.queryParam(
+                            "repositoryName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getRepositoryName()));
+        }
+
+        if (request.getVersion() != null) {
+            target =
+                    target.queryParam(
+                            "version",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getVersion()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.ListContainerImagesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.ListContainerImagesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.ListContainerImagesResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.ListContainerImagesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.ListContainerImagesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerImageCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerImageCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ContainerImageCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.ListContainerImagesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .ListContainerImagesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerImageCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.ListContainerImagesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ListContainerRepositoriesConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ListContainerRepositoriesConverter.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListContainerRepositoriesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.ListContainerRepositoriesRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.ListContainerRepositoriesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.ListContainerRepositoriesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("container").path("repositories");
+
+        if (request.getCompartmentIdInSubtree() != null) {
+            target =
+                    target.queryParam(
+                            "compartmentIdInSubtree",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCompartmentIdInSubtree()));
+        }
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getRepositoryId() != null) {
+            target =
+                    target.queryParam(
+                            "repositoryId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getRepositoryId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getIsPublic() != null) {
+            target =
+                    target.queryParam(
+                            "isPublic",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsPublic()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.ListContainerRepositoriesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.ListContainerRepositoriesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .ListContainerRepositoriesResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .ListContainerRepositoriesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.ListContainerRepositoriesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerRepositoryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerRepositoryCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                ContainerRepositoryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.ListContainerRepositoriesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .ListContainerRepositoriesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerRepositoryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.ListContainerRepositoriesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/RemoveContainerVersionConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/RemoveContainerVersionConverter.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class RemoveContainerVersionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.RemoveContainerVersionRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.RemoveContainerVersionRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.RemoveContainerVersionRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getImageId(), "imageId must not be blank");
+        Validate.notNull(
+                request.getRemoveContainerVersionDetails(),
+                "removeContainerVersionDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("container")
+                        .path("images")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getImageId()))
+                        .path("actions")
+                        .path("removeVersion");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.RemoveContainerVersionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.RemoveContainerVersionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .RemoveContainerVersionResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.RemoveContainerVersionResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.RemoveContainerVersionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerImage>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerImage.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ContainerImage> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.RemoveContainerVersionResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .RemoveContainerVersionResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerImage(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.RemoveContainerVersionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/RestoreContainerImageConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/RestoreContainerImageConverter.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class RestoreContainerImageConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.RestoreContainerImageRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.RestoreContainerImageRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.RestoreContainerImageRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getImageId(), "imageId must not be blank");
+        Validate.notNull(
+                request.getRestoreContainerImageDetails(),
+                "restoreContainerImageDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("container")
+                        .path("images")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getImageId()))
+                        .path("actions")
+                        .path("restore");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.RestoreContainerImageResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.RestoreContainerImageResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .RestoreContainerImageResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.RestoreContainerImageResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.RestoreContainerImageResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerImage>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerImage.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ContainerImage> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.RestoreContainerImageResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .RestoreContainerImageResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerImage(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.RestoreContainerImageResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateContainerConfigurationConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateContainerConfigurationConverter.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateContainerConfigurationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.UpdateContainerConfigurationRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.UpdateContainerConfigurationRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.UpdateContainerConfigurationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+        Validate.notNull(
+                request.getUpdateContainerConfigurationDetails(),
+                "updateContainerConfigurationDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("container").path("configuration");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.UpdateContainerConfigurationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.UpdateContainerConfigurationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .UpdateContainerConfigurationResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .UpdateContainerConfigurationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.UpdateContainerConfigurationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerConfiguration>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerConfiguration.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ContainerConfiguration>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses
+                                                .UpdateContainerConfigurationResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .UpdateContainerConfigurationResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerConfiguration(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses
+                                                .UpdateContainerConfigurationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateContainerRepositoryConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateContainerRepositoryConverter.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateContainerRepositoryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.UpdateContainerRepositoryRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.UpdateContainerRepositoryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.UpdateContainerRepositoryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notNull(
+                request.getUpdateContainerRepositoryDetails(),
+                "updateContainerRepositoryDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("container")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.UpdateContainerRepositoryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.UpdateContainerRepositoryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .UpdateContainerRepositoryResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .UpdateContainerRepositoryResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.UpdateContainerRepositoryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ContainerRepository>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ContainerRepository.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ContainerRepository>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.UpdateContainerRepositoryResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .UpdateContainerRepositoryResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.containerRepository(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.UpdateContainerRepositoryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ChangeContainerRepositoryCompartmentDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ChangeContainerRepositoryCompartmentDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Change container repository compartment details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeContainerRepositoryCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeContainerRepositoryCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeContainerRepositoryCompartmentDetails build() {
+            ChangeContainerRepositoryCompartmentDetails __instance__ =
+                    new ChangeContainerRepositoryCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeContainerRepositoryCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment into which to move the resource.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerConfiguration.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerConfiguration.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Container configuration.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ContainerConfiguration.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerConfiguration {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isRepositoryCreatedOnFirstPush")
+        private Boolean isRepositoryCreatedOnFirstPush;
+
+        public Builder isRepositoryCreatedOnFirstPush(Boolean isRepositoryCreatedOnFirstPush) {
+            this.isRepositoryCreatedOnFirstPush = isRepositoryCreatedOnFirstPush;
+            this.__explicitlySet__.add("isRepositoryCreatedOnFirstPush");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerConfiguration build() {
+            ContainerConfiguration __instance__ =
+                    new ContainerConfiguration(isRepositoryCreatedOnFirstPush, namespace);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerConfiguration o) {
+            Builder copiedBuilder =
+                    isRepositoryCreatedOnFirstPush(o.getIsRepositoryCreatedOnFirstPush())
+                            .namespace(o.getNamespace());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Whether to create a new container repository when a container is pushed to a new repository path.
+     * Repositories created in this way belong to the root compartment.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isRepositoryCreatedOnFirstPush")
+    Boolean isRepositoryCreatedOnFirstPush;
+
+    /**
+     * The tenancy namespace used in the container repository path.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerImage.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerImage.java
@@ -1,0 +1,381 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Container image metadata.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ContainerImage.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerImage {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+        private String createdBy;
+
+        public Builder createdBy(String createdBy) {
+            this.createdBy = createdBy;
+            this.__explicitlySet__.add("createdBy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("digest")
+        private String digest;
+
+        public Builder digest(String digest) {
+            this.digest = digest;
+            this.__explicitlySet__.add("digest");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("layers")
+        private java.util.List<ContainerImageLayer> layers;
+
+        public Builder layers(java.util.List<ContainerImageLayer> layers) {
+            this.layers = layers;
+            this.__explicitlySet__.add("layers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("layersSizeInBytes")
+        private Long layersSizeInBytes;
+
+        public Builder layersSizeInBytes(Long layersSizeInBytes) {
+            this.layersSizeInBytes = layersSizeInBytes;
+            this.__explicitlySet__.add("layersSizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("manifestSizeInBytes")
+        private Integer manifestSizeInBytes;
+
+        public Builder manifestSizeInBytes(Integer manifestSizeInBytes) {
+            this.manifestSizeInBytes = manifestSizeInBytes;
+            this.__explicitlySet__.add("manifestSizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pullCount")
+        private Long pullCount;
+
+        public Builder pullCount(Long pullCount) {
+            this.pullCount = pullCount;
+            this.__explicitlySet__.add("pullCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+        private String repositoryId;
+
+        public Builder repositoryId(String repositoryId) {
+            this.repositoryId = repositoryId;
+            this.__explicitlySet__.add("repositoryId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("repositoryName")
+        private String repositoryName;
+
+        public Builder repositoryName(String repositoryName) {
+            this.repositoryName = repositoryName;
+            this.__explicitlySet__.add("repositoryName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastPulled")
+        private java.util.Date timeLastPulled;
+
+        public Builder timeLastPulled(java.util.Date timeLastPulled) {
+            this.timeLastPulled = timeLastPulled;
+            this.__explicitlySet__.add("timeLastPulled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("versions")
+        private java.util.List<ContainerVersion> versions;
+
+        public Builder versions(java.util.List<ContainerVersion> versions) {
+            this.versions = versions;
+            this.__explicitlySet__.add("versions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerImage build() {
+            ContainerImage __instance__ =
+                    new ContainerImage(
+                            compartmentId,
+                            createdBy,
+                            digest,
+                            displayName,
+                            id,
+                            layers,
+                            layersSizeInBytes,
+                            lifecycleState,
+                            manifestSizeInBytes,
+                            pullCount,
+                            repositoryId,
+                            repositoryName,
+                            timeCreated,
+                            timeLastPulled,
+                            version,
+                            versions);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerImage o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .createdBy(o.getCreatedBy())
+                            .digest(o.getDigest())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .layers(o.getLayers())
+                            .layersSizeInBytes(o.getLayersSizeInBytes())
+                            .lifecycleState(o.getLifecycleState())
+                            .manifestSizeInBytes(o.getManifestSizeInBytes())
+                            .pullCount(o.getPullCount())
+                            .repositoryId(o.getRepositoryId())
+                            .repositoryName(o.getRepositoryName())
+                            .timeCreated(o.getTimeCreated())
+                            .timeLastPulled(o.getTimeLastPulled())
+                            .version(o.getVersion())
+                            .versions(o.getVersions());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The compartment OCID to which the container image belongs. Inferred from the container repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the user or principal that created the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+    String createdBy;
+
+    /**
+     * The container image digest.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("digest")
+    String digest;
+
+    /**
+     * The repository name and the most recent version associated with the image.
+     * If there are no versions associated with the image, then last known version and digest are used instead.
+     * If the last known version is unavailable, then 'unknown' is used instead of the version.
+     * <p>
+     * Example: `ubuntu:latest` or `ubuntu:latest@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the container image.
+     * <p>
+     * Example: `ocid1.containerimage.oc1..exampleuniqueID`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Layers of which the image is composed, ordered by the layer digest.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("layers")
+    java.util.List<ContainerImageLayer> layers;
+
+    /**
+     * The total size of the container image layers in bytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("layersSizeInBytes")
+    Long layersSizeInBytes;
+    /**
+     * The current state of the container image.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Available("AVAILABLE"),
+        Deleted("DELETED"),
+        Deleting("DELETING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the container image.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The size of the container image manifest in bytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("manifestSizeInBytes")
+    Integer manifestSizeInBytes;
+
+    /**
+     * Total number of pulls.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("pullCount")
+    Long pullCount;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the container repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+    String repositoryId;
+
+    /**
+     * The container repository name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("repositoryName")
+    String repositoryName;
+
+    /**
+     * An RFC 3339 timestamp indicating when the image was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * An RFC 3339 timestamp indicating when the image was last pulled.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastPulled")
+    java.util.Date timeLastPulled;
+
+    /**
+     * The most recent version associated with this image.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    /**
+     * The versions associated with this image.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("versions")
+    java.util.List<ContainerVersion> versions;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerImageCollection.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerImageCollection.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * List container image results.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ContainerImageCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerImageCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<ContainerImageSummary> items;
+
+        public Builder items(java.util.List<ContainerImageSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remainingItemsCount")
+        private Integer remainingItemsCount;
+
+        public Builder remainingItemsCount(Integer remainingItemsCount) {
+            this.remainingItemsCount = remainingItemsCount;
+            this.__explicitlySet__.add("remainingItemsCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerImageCollection build() {
+            ContainerImageCollection __instance__ =
+                    new ContainerImageCollection(items, remainingItemsCount);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerImageCollection o) {
+            Builder copiedBuilder =
+                    items(o.getItems()).remainingItemsCount(o.getRemainingItemsCount());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Page of matching container images.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<ContainerImageSummary> items;
+
+    /**
+     * Estimated number of remaining results.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remainingItemsCount")
+    Integer remainingItemsCount;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerImageLayer.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerImageLayer.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * The container image layer metadata.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ContainerImageLayer.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerImageLayer {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("digest")
+        private String digest;
+
+        public Builder digest(String digest) {
+            this.digest = digest;
+            this.__explicitlySet__.add("digest");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+        private Long sizeInBytes;
+
+        public Builder sizeInBytes(Long sizeInBytes) {
+            this.sizeInBytes = sizeInBytes;
+            this.__explicitlySet__.add("sizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerImageLayer build() {
+            ContainerImageLayer __instance__ =
+                    new ContainerImageLayer(digest, sizeInBytes, timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerImageLayer o) {
+            Builder copiedBuilder =
+                    digest(o.getDigest())
+                            .sizeInBytes(o.getSizeInBytes())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The sha256 digest of the image layer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("digest")
+    String digest;
+
+    /**
+     * The size of the layer in bytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+    Long sizeInBytes;
+
+    /**
+     * An RFC 3339 timestamp indicating when the layer was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerImageSummary.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerImageSummary.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Container image summary.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ContainerImageSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerImageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("digest")
+        private String digest;
+
+        public Builder digest(String digest) {
+            this.digest = digest;
+            this.__explicitlySet__.add("digest");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private ContainerImage.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(ContainerImage.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+        private String repositoryId;
+
+        public Builder repositoryId(String repositoryId) {
+            this.repositoryId = repositoryId;
+            this.__explicitlySet__.add("repositoryId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("repositoryName")
+        private String repositoryName;
+
+        public Builder repositoryName(String repositoryName) {
+            this.repositoryName = repositoryName;
+            this.__explicitlySet__.add("repositoryName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerImageSummary build() {
+            ContainerImageSummary __instance__ =
+                    new ContainerImageSummary(
+                            compartmentId,
+                            digest,
+                            displayName,
+                            id,
+                            lifecycleState,
+                            repositoryId,
+                            repositoryName,
+                            timeCreated,
+                            version);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerImageSummary o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .digest(o.getDigest())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .repositoryId(o.getRepositoryId())
+                            .repositoryName(o.getRepositoryName())
+                            .timeCreated(o.getTimeCreated())
+                            .version(o.getVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The compartment OCID to which the container image belongs. Inferred from the container repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The container image digest.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("digest")
+    String digest;
+
+    /**
+     * The repository name and the most recent version associated with the image.
+     * If there are no versions associated with the image, then last known version and digest are used instead.
+     * If the last known version is unavailable, then 'unknown' is used instead of the version.
+     * <p>
+     * Example: `ubuntu:latest` or `ubuntu:latest@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the container image.
+     * <p>
+     * Example: `ocid1.containerimage.oc1..exampleuniqueID`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The current state of the container image.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    ContainerImage.LifecycleState lifecycleState;
+
+    /**
+     * The OCID of the container repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+    String repositoryId;
+
+    /**
+     * The container repository name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("repositoryName")
+    String repositoryName;
+
+    /**
+     * An RFC 3339 timestamp indicating when the image was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The most recent version associated with this image.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepository.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepository.java
@@ -1,0 +1,324 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Container repository metadata.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ContainerRepository.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerRepository {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+        private String createdBy;
+
+        public Builder createdBy(String createdBy) {
+            this.createdBy = createdBy;
+            this.__explicitlySet__.add("createdBy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("imageCount")
+        private Integer imageCount;
+
+        public Builder imageCount(Integer imageCount) {
+            this.imageCount = imageCount;
+            this.__explicitlySet__.add("imageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+        private Boolean isImmutable;
+
+        public Builder isImmutable(Boolean isImmutable) {
+            this.isImmutable = isImmutable;
+            this.__explicitlySet__.add("isImmutable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPublic")
+        private Boolean isPublic;
+
+        public Builder isPublic(Boolean isPublic) {
+            this.isPublic = isPublic;
+            this.__explicitlySet__.add("isPublic");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("layerCount")
+        private Integer layerCount;
+
+        public Builder layerCount(Integer layerCount) {
+            this.layerCount = layerCount;
+            this.__explicitlySet__.add("layerCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("layersSizeInBytes")
+        private Long layersSizeInBytes;
+
+        public Builder layersSizeInBytes(Long layersSizeInBytes) {
+            this.layersSizeInBytes = layersSizeInBytes;
+            this.__explicitlySet__.add("layersSizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("readme")
+        private ContainerRepositoryReadme readme;
+
+        public Builder readme(ContainerRepositoryReadme readme) {
+            this.readme = readme;
+            this.__explicitlySet__.add("readme");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastPushed")
+        private java.util.Date timeLastPushed;
+
+        public Builder timeLastPushed(java.util.Date timeLastPushed) {
+            this.timeLastPushed = timeLastPushed;
+            this.__explicitlySet__.add("timeLastPushed");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerRepository build() {
+            ContainerRepository __instance__ =
+                    new ContainerRepository(
+                            compartmentId,
+                            createdBy,
+                            displayName,
+                            id,
+                            imageCount,
+                            isImmutable,
+                            isPublic,
+                            layerCount,
+                            layersSizeInBytes,
+                            lifecycleState,
+                            readme,
+                            timeCreated,
+                            timeLastPushed);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerRepository o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .createdBy(o.getCreatedBy())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .imageCount(o.getImageCount())
+                            .isImmutable(o.getIsImmutable())
+                            .isPublic(o.getIsPublic())
+                            .layerCount(o.getLayerCount())
+                            .layersSizeInBytes(o.getLayersSizeInBytes())
+                            .lifecycleState(o.getLifecycleState())
+                            .readme(o.getReadme())
+                            .timeCreated(o.getTimeCreated())
+                            .timeLastPushed(o.getTimeLastPushed());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the compartment in which the container repository exists.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The id of the user or principal that created the resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+    String createdBy;
+
+    /**
+     * The container repository name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container repository.
+     * <p>
+     * Example: `ocid1.containerrepo.oc1..exampleuniqueID`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Total number of images.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("imageCount")
+    Integer imageCount;
+
+    /**
+     * Whether the repository is immutable. Images cannot be overwritten in an immutable repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+    Boolean isImmutable;
+
+    /**
+     * Whether the repository is public. A public repository allows unauthenticated access.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPublic")
+    Boolean isPublic;
+
+    /**
+     * Total number of layers.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("layerCount")
+    Integer layerCount;
+
+    /**
+     * Total storage in bytes consumed by layers.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("layersSizeInBytes")
+    Long layersSizeInBytes;
+    /**
+     * The current state of the container repository.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Available("AVAILABLE"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the container repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("readme")
+    ContainerRepositoryReadme readme;
+
+    /**
+     * An RFC 3339 timestamp indicating when the repository was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * An RFC 3339 timestamp indicating when an image was last pushed to the repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastPushed")
+    java.util.Date timeLastPushed;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepositoryCollection.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepositoryCollection.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * List of container repository results.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ContainerRepositoryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerRepositoryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("layerCount")
+        private Integer layerCount;
+
+        public Builder layerCount(Integer layerCount) {
+            this.layerCount = layerCount;
+            this.__explicitlySet__.add("layerCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("layersSizeInBytes")
+        private Long layersSizeInBytes;
+
+        public Builder layersSizeInBytes(Long layersSizeInBytes) {
+            this.layersSizeInBytes = layersSizeInBytes;
+            this.__explicitlySet__.add("layersSizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("imageCount")
+        private Integer imageCount;
+
+        public Builder imageCount(Integer imageCount) {
+            this.imageCount = imageCount;
+            this.__explicitlySet__.add("imageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<ContainerRepositorySummary> items;
+
+        public Builder items(java.util.List<ContainerRepositorySummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remainingItemsCount")
+        private Integer remainingItemsCount;
+
+        public Builder remainingItemsCount(Integer remainingItemsCount) {
+            this.remainingItemsCount = remainingItemsCount;
+            this.__explicitlySet__.add("remainingItemsCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("repositoryCount")
+        private Integer repositoryCount;
+
+        public Builder repositoryCount(Integer repositoryCount) {
+            this.repositoryCount = repositoryCount;
+            this.__explicitlySet__.add("repositoryCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerRepositoryCollection build() {
+            ContainerRepositoryCollection __instance__ =
+                    new ContainerRepositoryCollection(
+                            layerCount,
+                            layersSizeInBytes,
+                            imageCount,
+                            items,
+                            remainingItemsCount,
+                            repositoryCount);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerRepositoryCollection o) {
+            Builder copiedBuilder =
+                    layerCount(o.getLayerCount())
+                            .layersSizeInBytes(o.getLayersSizeInBytes())
+                            .imageCount(o.getImageCount())
+                            .items(o.getItems())
+                            .remainingItemsCount(o.getRemainingItemsCount())
+                            .repositoryCount(o.getRepositoryCount());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Total number of layers.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("layerCount")
+    Integer layerCount;
+
+    /**
+     * Total storage in bytes consumed by layers.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("layersSizeInBytes")
+    Long layersSizeInBytes;
+
+    /**
+     * Total number of images.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("imageCount")
+    Integer imageCount;
+
+    /**
+     * Collection of container repositories.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<ContainerRepositorySummary> items;
+
+    /**
+     * Estimated number of remaining results.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remainingItemsCount")
+    Integer remainingItemsCount;
+
+    /**
+     * Total number of repositories.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("repositoryCount")
+    Integer repositoryCount;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepositoryReadme.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepositoryReadme.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Container repository readme.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ContainerRepositoryReadme.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerRepositoryReadme {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("content")
+        private String content;
+
+        public Builder content(String content) {
+            this.content = content;
+            this.__explicitlySet__.add("content");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("format")
+        private Format format;
+
+        public Builder format(Format format) {
+            this.format = format;
+            this.__explicitlySet__.add("format");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerRepositoryReadme build() {
+            ContainerRepositoryReadme __instance__ = new ContainerRepositoryReadme(content, format);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerRepositoryReadme o) {
+            Builder copiedBuilder = content(o.getContent()).format(o.getFormat());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Readme content. Avoid entering confidential information.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("content")
+    String content;
+    /**
+     * Readme format. Supported formats are text/plain and text/markdown.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Format {
+        TextMarkdown("TEXT_MARKDOWN"),
+        TextPlain("TEXT_PLAIN"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Format> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Format v : Format.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Format(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Format create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Format', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Readme format. Supported formats are text/plain and text/markdown.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("format")
+    Format format;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepositorySummary.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepositorySummary.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Container repository summary.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ContainerRepositorySummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerRepositorySummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("imageCount")
+        private Integer imageCount;
+
+        public Builder imageCount(Integer imageCount) {
+            this.imageCount = imageCount;
+            this.__explicitlySet__.add("imageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPublic")
+        private Boolean isPublic;
+
+        public Builder isPublic(Boolean isPublic) {
+            this.isPublic = isPublic;
+            this.__explicitlySet__.add("isPublic");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("layerCount")
+        private Integer layerCount;
+
+        public Builder layerCount(Integer layerCount) {
+            this.layerCount = layerCount;
+            this.__explicitlySet__.add("layerCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("layersSizeInBytes")
+        private Long layersSizeInBytes;
+
+        public Builder layersSizeInBytes(Long layersSizeInBytes) {
+            this.layersSizeInBytes = layersSizeInBytes;
+            this.__explicitlySet__.add("layersSizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private ContainerRepository.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(ContainerRepository.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerRepositorySummary build() {
+            ContainerRepositorySummary __instance__ =
+                    new ContainerRepositorySummary(
+                            compartmentId,
+                            displayName,
+                            id,
+                            imageCount,
+                            isPublic,
+                            layerCount,
+                            layersSizeInBytes,
+                            lifecycleState,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerRepositorySummary o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .id(o.getId())
+                            .imageCount(o.getImageCount())
+                            .isPublic(o.getIsPublic())
+                            .layerCount(o.getLayerCount())
+                            .layersSizeInBytes(o.getLayersSizeInBytes())
+                            .lifecycleState(o.getLifecycleState())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the compartment in which the container repository exists.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The container repository name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container repository.
+     * <p>
+     * Example: `ocid1.containerrepo.oc1..exampleuniqueID`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Total number of images.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("imageCount")
+    Integer imageCount;
+
+    /**
+     * Whether the repository is public. A public repository allows unauthenticated access.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPublic")
+    Boolean isPublic;
+
+    /**
+     * Total number of layers.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("layerCount")
+    Integer layerCount;
+
+    /**
+     * Total storage in bytes consumed by layers.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("layersSizeInBytes")
+    Long layersSizeInBytes;
+
+    /**
+     * The current state of the container repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    ContainerRepository.LifecycleState lifecycleState;
+
+    /**
+     * An RFC 3339 timestamp indicating when the repository was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerVersion.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerVersion.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Container version metadata.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ContainerVersion.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ContainerVersion {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+        private String createdBy;
+
+        public Builder createdBy(String createdBy) {
+            this.createdBy = createdBy;
+            this.__explicitlySet__.add("createdBy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ContainerVersion build() {
+            ContainerVersion __instance__ = new ContainerVersion(createdBy, timeCreated, version);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ContainerVersion o) {
+            Builder copiedBuilder =
+                    createdBy(o.getCreatedBy())
+                            .timeCreated(o.getTimeCreated())
+                            .version(o.getVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the user or principal that pushed the version.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+    String createdBy;
+
+    /**
+     * The creation time of the version.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The version name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/CreateContainerRepositoryDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/CreateContainerRepositoryDetails.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Create container repository details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateContainerRepositoryDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateContainerRepositoryDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+        private Boolean isImmutable;
+
+        public Builder isImmutable(Boolean isImmutable) {
+            this.isImmutable = isImmutable;
+            this.__explicitlySet__.add("isImmutable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPublic")
+        private Boolean isPublic;
+
+        public Builder isPublic(Boolean isPublic) {
+            this.isPublic = isPublic;
+            this.__explicitlySet__.add("isPublic");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("readme")
+        private ContainerRepositoryReadme readme;
+
+        public Builder readme(ContainerRepositoryReadme readme) {
+            this.readme = readme;
+            this.__explicitlySet__.add("readme");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateContainerRepositoryDetails build() {
+            CreateContainerRepositoryDetails __instance__ =
+                    new CreateContainerRepositoryDetails(
+                            compartmentId, displayName, isImmutable, isPublic, readme);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateContainerRepositoryDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .displayName(o.getDisplayName())
+                            .isImmutable(o.getIsImmutable())
+                            .isPublic(o.getIsPublic())
+                            .readme(o.getReadme());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which to create the resource.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The container repository name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Whether the repository is immutable. Images cannot be overwritten in an immutable repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+    Boolean isImmutable;
+
+    /**
+     * Whether the repository is public. A public repository allows unauthenticated access.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPublic")
+    Boolean isPublic;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("readme")
+    ContainerRepositoryReadme readme;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/RemoveContainerVersionDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/RemoveContainerVersionDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Remove version details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RemoveContainerVersionDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RemoveContainerVersionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RemoveContainerVersionDetails build() {
+            RemoveContainerVersionDetails __instance__ = new RemoveContainerVersionDetails(version);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RemoveContainerVersionDetails o) {
+            Builder copiedBuilder = version(o.getVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The version to remove.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/RestoreContainerImageDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/RestoreContainerImageDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Undelete container image request details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RestoreContainerImageDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RestoreContainerImageDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RestoreContainerImageDetails build() {
+            RestoreContainerImageDetails __instance__ = new RestoreContainerImageDetails(version);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RestoreContainerImageDetails o) {
+            Builder copiedBuilder = version(o.getVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Optional version to associate with image.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateContainerConfigurationDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateContainerConfigurationDetails.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Update container configuration request details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateContainerConfigurationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateContainerConfigurationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isRepositoryCreatedOnFirstPush")
+        private Boolean isRepositoryCreatedOnFirstPush;
+
+        public Builder isRepositoryCreatedOnFirstPush(Boolean isRepositoryCreatedOnFirstPush) {
+            this.isRepositoryCreatedOnFirstPush = isRepositoryCreatedOnFirstPush;
+            this.__explicitlySet__.add("isRepositoryCreatedOnFirstPush");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateContainerConfigurationDetails build() {
+            UpdateContainerConfigurationDetails __instance__ =
+                    new UpdateContainerConfigurationDetails(isRepositoryCreatedOnFirstPush);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateContainerConfigurationDetails o) {
+            Builder copiedBuilder =
+                    isRepositoryCreatedOnFirstPush(o.getIsRepositoryCreatedOnFirstPush());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Whether to create a new container repository when a container is pushed to a new repository path.
+     * Repositories created in this way belong to the root compartment.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isRepositoryCreatedOnFirstPush")
+    Boolean isRepositoryCreatedOnFirstPush;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateContainerRepositoryDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateContainerRepositoryDetails.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Update container repository request details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateContainerRepositoryDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateContainerRepositoryDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+        private Boolean isImmutable;
+
+        public Builder isImmutable(Boolean isImmutable) {
+            this.isImmutable = isImmutable;
+            this.__explicitlySet__.add("isImmutable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPublic")
+        private Boolean isPublic;
+
+        public Builder isPublic(Boolean isPublic) {
+            this.isPublic = isPublic;
+            this.__explicitlySet__.add("isPublic");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("readme")
+        private ContainerRepositoryReadme readme;
+
+        public Builder readme(ContainerRepositoryReadme readme) {
+            this.readme = readme;
+            this.__explicitlySet__.add("readme");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateContainerRepositoryDetails build() {
+            UpdateContainerRepositoryDetails __instance__ =
+                    new UpdateContainerRepositoryDetails(isImmutable, isPublic, readme);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateContainerRepositoryDetails o) {
+            Builder copiedBuilder =
+                    isImmutable(o.getIsImmutable()).isPublic(o.getIsPublic()).readme(o.getReadme());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Whether the repository is immutable. Images cannot be overwritten in an immutable repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+    Boolean isImmutable;
+
+    /**
+     * Whether the repository is public. A public repository allows unauthenticated access.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPublic")
+    Boolean isPublic;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("readme")
+    ContainerRepositoryReadme readme;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ChangeContainerRepositoryCompartmentRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ChangeContainerRepositoryCompartmentRequest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ChangeContainerRepositoryCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeContainerRepositoryCompartmentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeContainerRepositoryCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeContainerRepositoryCompartmentDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container repository.
+     * <p>
+     * Example: `ocid1.containerrepo.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * Change container repository compartment details.
+     */
+    private ChangeContainerRepositoryCompartmentDetails changeContainerRepositoryCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeContainerRepositoryCompartmentDetails getBody$() {
+        return changeContainerRepositoryCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeContainerRepositoryCompartmentRequest,
+                    ChangeContainerRepositoryCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeContainerRepositoryCompartmentRequest o) {
+            repositoryId(o.getRepositoryId());
+            changeContainerRepositoryCompartmentDetails(
+                    o.getChangeContainerRepositoryCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeContainerRepositoryCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeContainerRepositoryCompartmentRequest
+         */
+        public ChangeContainerRepositoryCompartmentRequest build() {
+            ChangeContainerRepositoryCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeContainerRepositoryCompartmentDetails body) {
+            changeContainerRepositoryCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/CreateContainerRepositoryRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/CreateContainerRepositoryRequest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/CreateContainerRepositoryExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateContainerRepositoryRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateContainerRepositoryRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateContainerRepositoryDetails> {
+
+    /**
+     * Create container repository details.
+     */
+    private CreateContainerRepositoryDetails createContainerRepositoryDetails;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateContainerRepositoryDetails getBody$() {
+        return createContainerRepositoryDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateContainerRepositoryRequest, CreateContainerRepositoryDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateContainerRepositoryRequest o) {
+            createContainerRepositoryDetails(o.getCreateContainerRepositoryDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateContainerRepositoryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateContainerRepositoryRequest
+         */
+        public CreateContainerRepositoryRequest build() {
+            CreateContainerRepositoryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateContainerRepositoryDetails body) {
+            createContainerRepositoryDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteContainerImageRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteContainerImageRequest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteContainerImageExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteContainerImageRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteContainerImageRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container image.
+     * <p>
+     * Example: `ocid1.containerimage.oc1..exampleuniqueID`
+     *
+     */
+    private String imageId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteContainerImageRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteContainerImageRequest o) {
+            imageId(o.getImageId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteContainerImageRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteContainerImageRequest
+         */
+        public DeleteContainerImageRequest build() {
+            DeleteContainerImageRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteContainerRepositoryRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteContainerRepositoryRequest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteContainerRepositoryExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteContainerRepositoryRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteContainerRepositoryRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container repository.
+     * <p>
+     * Example: `ocid1.containerrepo.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteContainerRepositoryRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteContainerRepositoryRequest o) {
+            repositoryId(o.getRepositoryId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteContainerRepositoryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteContainerRepositoryRequest
+         */
+        public DeleteContainerRepositoryRequest build() {
+            DeleteContainerRepositoryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetContainerConfigurationRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetContainerConfigurationRequest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetContainerConfigurationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetContainerConfigurationRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetContainerConfigurationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetContainerConfigurationRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetContainerConfigurationRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetContainerConfigurationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetContainerConfigurationRequest
+         */
+        public GetContainerConfigurationRequest build() {
+            GetContainerConfigurationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetContainerImageRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetContainerImageRequest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetContainerImageExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetContainerImageRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetContainerImageRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container image.
+     * <p>
+     * Example: `ocid1.containerimage.oc1..exampleuniqueID`
+     *
+     */
+    private String imageId;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetContainerImageRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetContainerImageRequest o) {
+            imageId(o.getImageId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetContainerImageRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetContainerImageRequest
+         */
+        public GetContainerImageRequest build() {
+            GetContainerImageRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetContainerRepositoryRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetContainerRepositoryRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetContainerRepositoryExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetContainerRepositoryRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetContainerRepositoryRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container repository.
+     * <p>
+     * Example: `ocid1.containerrepo.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetContainerRepositoryRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetContainerRepositoryRequest o) {
+            repositoryId(o.getRepositoryId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetContainerRepositoryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetContainerRepositoryRequest
+         */
+        public GetContainerRepositoryRequest build() {
+            GetContainerRepositoryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ListContainerImagesRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ListContainerImagesRequest.java
@@ -1,0 +1,274 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ListContainerImagesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListContainerImagesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListContainerImagesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * When set to true, the hierarchy of compartments is traversed
+     * and all compartments and subcompartments in the tenancy are
+     * inspected depending on the the setting of `accessLevel`.
+     * Default is false. Can only be set to true when calling the API
+     * on the tenancy (root compartment).
+     *
+     */
+    private Boolean compartmentIdInSubtree;
+
+    /**
+     * A filter to return only resources that match the given display name exactly.
+     *
+     */
+    private String displayName;
+
+    /**
+     * A filter to return a container image summary only for the specified container image OCID.
+     *
+     */
+    private String imageId;
+
+    /**
+     * A filter to return container images based on whether there are any associated versions.
+     *
+     */
+    private Boolean isVersioned;
+
+    /**
+     * A filter to return container images only for the specified container repository OCID.
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * A filter to return container images or container image signatures that match the repository name.
+     * <p>
+     * Example: `foo` or `foo*`
+     *
+     */
+    private String repositoryName;
+
+    /**
+     * A filter to return container images that match the version.
+     * <p>
+     * Example: `foo` or `foo*`
+     *
+     */
+    private String version;
+
+    /**
+     * A filter to return only resources that match the given lifecycle state name exactly.
+     *
+     */
+    private String lifecycleState;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated
+     * \"List\" call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `50`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+     * call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListContainerImagesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListContainerImagesRequest o) {
+            compartmentId(o.getCompartmentId());
+            compartmentIdInSubtree(o.getCompartmentIdInSubtree());
+            displayName(o.getDisplayName());
+            imageId(o.getImageId());
+            isVersioned(o.getIsVersioned());
+            repositoryId(o.getRepositoryId());
+            repositoryName(o.getRepositoryName());
+            version(o.getVersion());
+            lifecycleState(o.getLifecycleState());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListContainerImagesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListContainerImagesRequest
+         */
+        public ListContainerImagesRequest build() {
+            ListContainerImagesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ListContainerRepositoriesRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ListContainerRepositoriesRequest.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ListContainerRepositoriesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListContainerRepositoriesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListContainerRepositoriesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * When set to true, the hierarchy of compartments is traversed
+     * and all compartments and subcompartments in the tenancy are
+     * inspected depending on the the setting of `accessLevel`.
+     * Default is false. Can only be set to true when calling the API
+     * on the tenancy (root compartment).
+     *
+     */
+    private Boolean compartmentIdInSubtree;
+
+    /**
+     * A filter to return container images only for the specified container repository OCID.
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * A filter to return only resources that match the given display name exactly.
+     *
+     */
+    private String displayName;
+
+    /**
+     * A filter to return resources that match the isPublic value.
+     *
+     */
+    private Boolean isPublic;
+
+    /**
+     * A filter to return only resources that match the given lifecycle state name exactly.
+     *
+     */
+    private String lifecycleState;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated
+     * \"List\" call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `50`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+     * call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListContainerRepositoriesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListContainerRepositoriesRequest o) {
+            compartmentId(o.getCompartmentId());
+            compartmentIdInSubtree(o.getCompartmentIdInSubtree());
+            repositoryId(o.getRepositoryId());
+            displayName(o.getDisplayName());
+            isPublic(o.getIsPublic());
+            lifecycleState(o.getLifecycleState());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListContainerRepositoriesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListContainerRepositoriesRequest
+         */
+        public ListContainerRepositoriesRequest build() {
+            ListContainerRepositoriesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/RemoveContainerVersionRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/RemoveContainerVersionRequest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/RemoveContainerVersionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use RemoveContainerVersionRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class RemoveContainerVersionRequest
+        extends com.oracle.bmc.requests.BmcRequest<RemoveContainerVersionDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container image.
+     * <p>
+     * Example: `ocid1.containerimage.oc1..exampleuniqueID`
+     *
+     */
+    private String imageId;
+
+    /**
+     * Remove version details.
+     */
+    private RemoveContainerVersionDetails removeContainerVersionDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public RemoveContainerVersionDetails getBody$() {
+        return removeContainerVersionDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RemoveContainerVersionRequest, RemoveContainerVersionDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveContainerVersionRequest o) {
+            imageId(o.getImageId());
+            removeContainerVersionDetails(o.getRemoveContainerVersionDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RemoveContainerVersionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RemoveContainerVersionRequest
+         */
+        public RemoveContainerVersionRequest build() {
+            RemoveContainerVersionRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(RemoveContainerVersionDetails body) {
+            removeContainerVersionDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/RestoreContainerImageRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/RestoreContainerImageRequest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/RestoreContainerImageExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use RestoreContainerImageRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class RestoreContainerImageRequest
+        extends com.oracle.bmc.requests.BmcRequest<RestoreContainerImageDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container image.
+     * <p>
+     * Example: `ocid1.containerimage.oc1..exampleuniqueID`
+     *
+     */
+    private String imageId;
+
+    /**
+     * Restore container image details.
+     */
+    private RestoreContainerImageDetails restoreContainerImageDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public RestoreContainerImageDetails getBody$() {
+        return restoreContainerImageDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RestoreContainerImageRequest, RestoreContainerImageDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RestoreContainerImageRequest o) {
+            imageId(o.getImageId());
+            restoreContainerImageDetails(o.getRestoreContainerImageDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RestoreContainerImageRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RestoreContainerImageRequest
+         */
+        public RestoreContainerImageRequest build() {
+            RestoreContainerImageRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(RestoreContainerImageDetails body) {
+            restoreContainerImageDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateContainerConfigurationRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateContainerConfigurationRequest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateContainerConfigurationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateContainerConfigurationRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateContainerConfigurationRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateContainerConfigurationDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * Update container configuration details.
+     */
+    private UpdateContainerConfigurationDetails updateContainerConfigurationDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateContainerConfigurationDetails getBody$() {
+        return updateContainerConfigurationDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateContainerConfigurationRequest, UpdateContainerConfigurationDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateContainerConfigurationRequest o) {
+            compartmentId(o.getCompartmentId());
+            updateContainerConfigurationDetails(o.getUpdateContainerConfigurationDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateContainerConfigurationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateContainerConfigurationRequest
+         */
+        public UpdateContainerConfigurationRequest build() {
+            UpdateContainerConfigurationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateContainerConfigurationDetails body) {
+            updateContainerConfigurationDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateContainerRepositoryRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateContainerRepositoryRequest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateContainerRepositoryExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateContainerRepositoryRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateContainerRepositoryRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateContainerRepositoryDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the container repository.
+     * <p>
+     * Example: `ocid1.containerrepo.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * Update container repository details.
+     */
+    private UpdateContainerRepositoryDetails updateContainerRepositoryDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateContainerRepositoryDetails getBody$() {
+        return updateContainerRepositoryDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateContainerRepositoryRequest, UpdateContainerRepositoryDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateContainerRepositoryRequest o) {
+            repositoryId(o.getRepositoryId());
+            updateContainerRepositoryDetails(o.getUpdateContainerRepositoryDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateContainerRepositoryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateContainerRepositoryRequest
+         */
+        public UpdateContainerRepositoryRequest build() {
+            UpdateContainerRepositoryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateContainerRepositoryDetails body) {
+            updateContainerRepositoryDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ChangeContainerRepositoryCompartmentResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ChangeContainerRepositoryCompartmentResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeContainerRepositoryCompartmentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeContainerRepositoryCompartmentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/CreateContainerRepositoryResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/CreateContainerRepositoryResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateContainerRepositoryResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerRepository instance.
+     */
+    private ContainerRepository containerRepository;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateContainerRepositoryResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            containerRepository(o.getContainerRepository());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteContainerImageResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteContainerImageResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteContainerImageResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteContainerImageResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteContainerRepositoryResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteContainerRepositoryResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteContainerRepositoryResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteContainerRepositoryResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetContainerConfigurationResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetContainerConfigurationResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetContainerConfigurationResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerConfiguration instance.
+     */
+    private ContainerConfiguration containerConfiguration;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetContainerConfigurationResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            containerConfiguration(o.getContainerConfiguration());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetContainerImageResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetContainerImageResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetContainerImageResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerImage instance.
+     */
+    private ContainerImage containerImage;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetContainerImageResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            containerImage(o.getContainerImage());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetContainerRepositoryResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetContainerRepositoryResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetContainerRepositoryResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerRepository instance.
+     */
+    private ContainerRepository containerRepository;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetContainerRepositoryResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            containerRepository(o.getContainerRepository());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ListContainerImagesResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ListContainerImagesResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListContainerImagesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerImageCollection instance.
+     */
+    private ContainerImageCollection containerImageCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListContainerImagesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            containerImageCollection(o.getContainerImageCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ListContainerRepositoriesResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ListContainerRepositoriesResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListContainerRepositoriesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerRepositoryCollection instance.
+     */
+    private ContainerRepositoryCollection containerRepositoryCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListContainerRepositoriesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            containerRepositoryCollection(o.getContainerRepositoryCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/RemoveContainerVersionResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/RemoveContainerVersionResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class RemoveContainerVersionResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerImage instance.
+     */
+    private ContainerImage containerImage;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveContainerVersionResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            containerImage(o.getContainerImage());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/RestoreContainerImageResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/RestoreContainerImageResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class RestoreContainerImageResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerImage instance.
+     */
+    private ContainerImage containerImage;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RestoreContainerImageResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            containerImage(o.getContainerImage());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateContainerConfigurationResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateContainerConfigurationResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateContainerConfigurationResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerConfiguration instance.
+     */
+    private ContainerConfiguration containerConfiguration;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateContainerConfigurationResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            containerConfiguration(o.getContainerConfiguration());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateContainerRepositoryResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateContainerRepositoryResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateContainerRepositoryResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ContainerRepository instance.
+     */
+    private ContainerRepository containerRepository;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateContainerRepositoryResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            containerRepository(o.getContainerRepository());
+
+            return this;
+        }
+    }
+}

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,408 +19,414 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
+        <optional>false</optional>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle.oci.sdk</groupId>
+        <artifactId>oci-java-sdk-artifacts</artifactId>
+        <version>1.32.2</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/http/JerseyLoggingClientConfigurator.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/JerseyLoggingClientConfigurator.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.http;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+/**
+ * Configurator allowing SDK users to enable Jersey logging request & response on client-side.
+ */
+@RequiredArgsConstructor
+public class JerseyLoggingClientConfigurator implements ClientConfigurator {
+
+    @NonNull private org.glassfish.jersey.logging.LoggingFeature.Verbosity verbosity;
+    @NonNull private String loggingLevel;
+
+    @Override
+    public void customizeBuilder(ClientBuilder builder) {}
+
+    @Override
+    public void customizeClient(Client client) {
+        client.property(
+                org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_VERBOSITY_CLIENT,
+                verbosity);
+        client.property(
+                org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_CLIENT,
+                loggingLevel);
+    }
+}

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetwork.java
@@ -453,7 +453,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * an Identity and Access Management (IAM) policy that gives the requestor permission
      * to connect to LPGs in the acceptor's compartment. Without that permission, this
      * operation will fail. For more information, see
-     * [VCN Peering](https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm).
+     * [VCN Peering](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/VCNpeering.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -472,7 +472,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * an Identity and Access Management (IAM) policy that gives the requestor permission
      * to connect to RPCs in the acceptor's compartment. Without that permission, this
      * operation will fail. For more information, see
-     * [VCN Peering](https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm).
+     * [VCN Peering](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/VCNpeering.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -496,17 +496,17 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Creates a new virtual customer-premises equipment (CPE) object in the specified compartment. For
-     * more information, see [IPSec VPNs](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPsec.htm).
+     * more information, see [IPSec VPNs](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPsec.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want
      * the CPE to reside. Notice that the CPE doesn't have to be in the same compartment as the IPSec
      * connection or other Networking Service components. If you're not sure which compartment to
      * use, put the CPE in the same compartment as the DRG. For more information about
-     * compartments and access control, see [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
-     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * compartments and access control, see [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
+     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You must provide the public IP address of your on-premises router. See
-     * [Configuring Your On-Premises Router for an IPSec VPN](https://docs.cloud.oracle.com/Content/Network/Tasks/configuringCPE.htm).
+     * [Configuring Your On-Premises Router for an IPSec VPN](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/configuringCPE.htm).
      * <p>
      * You may optionally specify a *display name* for the CPE, otherwise a default is provided. It does not have to
      * be unique, and you can change it. Avoid entering confidential information.
@@ -526,16 +526,16 @@ public interface VirtualNetwork extends AutoCloseable {
      * <p>
      * After creating the `CrossConnect` object, you need to go the FastConnect location
      * and request to have the physical cable installed. For more information, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the
      * compartment where you want the cross-connect to reside. If you're
      * not sure which compartment to use, put the cross-connect in the
      * same compartment with your VCN. For more information about
      * compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
      * For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the cross-connect.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -551,16 +551,16 @@ public interface VirtualNetwork extends AutoCloseable {
     /**
      * Creates a new cross-connect group to use with Oracle Cloud Infrastructure
      * FastConnect. For more information, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the
      * compartment where you want the cross-connect group to reside. If you're
      * not sure which compartment to use, put the cross-connect group in the
      * same compartment with your VCN. For more information about
      * compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
      * For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the cross-connect group.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -581,8 +581,8 @@ public interface VirtualNetwork extends AutoCloseable {
      * DHCP options to reside. Notice that the set of options doesn't have to be in the same compartment as the VCN,
      * subnets, or other Networking Service components. If you're not sure which compartment to use, put the set
      * of DHCP options in the same compartment as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the set of DHCP options, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -597,14 +597,14 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Creates a new dynamic routing gateway (DRG) in the specified compartment. For more information,
-     * see [Dynamic Routing Gateways (DRGs)](https://docs.cloud.oracle.com/Content/Network/Tasks/managingDRGs.htm).
+     * see [Dynamic Routing Gateways (DRGs)](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingDRGs.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want
      * the DRG to reside. Notice that the DRG doesn't have to be in the same compartment as the VCN,
      * the DRG attachment, or other Networking Service components. If you're not sure which compartment
      * to use, put the DRG in the same compartment as the VCN. For more information about compartments
-     * and access control, see [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
-     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * and access control, see [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
+     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the DRG, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -621,14 +621,14 @@ public interface VirtualNetwork extends AutoCloseable {
      * Attaches the specified DRG to the specified VCN. A VCN can be attached to only one DRG at a time,
      * and vice versa. The response includes a `DrgAttachment` object with its own OCID. For more
      * information about DRGs, see
-     * [Dynamic Routing Gateways (DRGs)](https://docs.cloud.oracle.com/Content/Network/Tasks/managingDRGs.htm).
+     * [Dynamic Routing Gateways (DRGs)](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingDRGs.htm).
      * <p>
      * You may optionally specify a *display name* for the attachment, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
      * <p>
      * For the purposes of access control, the DRG attachment is automatically placed into the same compartment
      * as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -640,7 +640,7 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Creates a new IPSec connection between the specified DRG and CPE. For more information, see
-     * [IPSec VPNs](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPsec.htm).
+     * [IPSec VPNs](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPsec.htm).
      * <p>
      * If you configure at least one tunnel to use static routing, then in the request you must provide
      * at least one valid static route (you're allowed a maximum of 10). For example: 10.0.0.0/16.
@@ -653,8 +653,8 @@ public interface VirtualNetwork extends AutoCloseable {
      * as the DRG, CPE, or other Networking Service components. If you're not sure which compartment to
      * use, put the IPSec connection in the same compartment as the DRG. For more information about
      * compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
-     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
+     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the IPSec connection, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -667,7 +667,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * <p>
      * For each tunnel, you need the IP address of Oracle's VPN headend and the shared secret
      * (that is, the pre-shared key). For more information, see
-     * [Configuring Your On-Premises Router for an IPSec VPN](https://docs.cloud.oracle.com/Content/Network/Tasks/configuringCPE.htm).
+     * [Configuring Your On-Premises Router for an IPSec VPN](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/configuringCPE.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -679,14 +679,14 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Creates a new internet gateway for the specified VCN. For more information, see
-     * [Access to the Internet](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIGs.htm).
+     * [Access to the Internet](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIGs.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the Internet
      * Gateway to reside. Notice that the internet gateway doesn't have to be in the same compartment as the VCN or
      * other Networking Service components. If you're not sure which compartment to use, put the Internet
      * Gateway in the same compartment with the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the internet gateway, otherwise a default is provided. It
      * does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -758,7 +758,7 @@ public interface VirtualNetwork extends AutoCloseable {
     /**
      * Creates a secondary private IP for the specified VNIC.
      * For more information about secondary private IPs, see
-     * [IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPaddresses.htm).
+     * [IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPaddresses.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -771,7 +771,7 @@ public interface VirtualNetwork extends AutoCloseable {
     /**
      * Creates a public IP. Use the `lifetime` property to specify whether it's an ephemeral or
      * reserved public IP. For information about limits on how many you can create, see
-     * [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+     * [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
      * <p>
      * **For an ephemeral public IP assigned to a private IP:** You must also specify a `privateIpId`
      * with the OCID of the primary private IP you want to assign the public IP to. The public IP is
@@ -825,16 +825,16 @@ public interface VirtualNetwork extends AutoCloseable {
     /**
      * Creates a new route table for the specified VCN. In the request you must also include at least one route
      * rule for the new route table. For information on the number of rules you can have in a route table, see
-     * [Service Limits](https://docs.cloud.oracle.com/Content/General/Concepts/servicelimits.htm). For general information about route
+     * [Service Limits](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/servicelimits.htm). For general information about route
      * tables in your VCN and the types of targets you can use in route rules,
-     * see [Route Tables](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm).
+     * see [Route Tables](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the route
      * table to reside. Notice that the route table doesn't have to be in the same compartment as the VCN, subnets,
      * or other Networking Service components. If you're not sure which compartment to use, put the route
      * table in the same compartment as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the route table, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -849,16 +849,16 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Creates a new security list for the specified VCN. For more information
-     * about security lists, see [Security Lists](https://docs.cloud.oracle.com/Content/Network/Concepts/securitylists.htm).
+     * about security lists, see [Security Lists](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/securitylists.htm).
      * For information on the number of rules you can have in a security list, see
-     * [Service Limits](https://docs.cloud.oracle.com/Content/General/Concepts/servicelimits.htm).
+     * [Service Limits](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/servicelimits.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the security
      * list to reside. Notice that the security list doesn't have to be in the same compartment as the VCN, subnets,
      * or other Networking Service components. If you're not sure which compartment to use, put the security
      * list in the same compartment as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the security list, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -876,8 +876,8 @@ public interface VirtualNetwork extends AutoCloseable {
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want
      * the service gateway to reside. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
-     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
+     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the service gateway, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -893,35 +893,35 @@ public interface VirtualNetwork extends AutoCloseable {
     /**
      * Creates a new subnet in the specified VCN. You can't change the size of the subnet after creation,
      * so it's important to think about the size of subnets you need before creating them.
-     * For more information, see [VCNs and Subnets](https://docs.cloud.oracle.com/Content/Network/Tasks/managingVCNs.htm).
+     * For more information, see [VCNs and Subnets](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingVCNs.htm).
      * For information on the number of subnets you can have in a VCN, see
-     * [Service Limits](https://docs.cloud.oracle.com/Content/General/Concepts/servicelimits.htm).
+     * [Service Limits](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/servicelimits.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the subnet
      * to reside. Notice that the subnet doesn't have to be in the same compartment as the VCN, route tables, or
      * other Networking Service components. If you're not sure which compartment to use, put the subnet in
      * the same compartment as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs,
-     * see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs,
+     * see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally associate a route table with the subnet. If you don't, the subnet will use the
      * VCN's default route table. For more information about route tables, see
-     * [Route Tables](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm).
+     * [Route Tables](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm).
      * <p>
      * You may optionally associate a security list with the subnet. If you don't, the subnet will use the
      * VCN's default security list. For more information about security lists, see
-     * [Security Lists](https://docs.cloud.oracle.com/Content/Network/Concepts/securitylists.htm).
+     * [Security Lists](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/securitylists.htm).
      * <p>
      * You may optionally associate a set of DHCP options with the subnet. If you don't, the subnet will use the
      * VCN's default set. For more information about DHCP options, see
-     * [DHCP Options](https://docs.cloud.oracle.com/Content/Network/Tasks/managingDHCP.htm).
+     * [DHCP Options](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingDHCP.htm).
      * <p>
      * You may optionally specify a *display name* for the subnet, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
      * <p>
      * You can also add a DNS label for the subnet, which is required if you want the Internet and
      * VCN Resolver to resolve hostnames for instances in the subnet. For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -933,7 +933,7 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Creates a new virtual cloud network (VCN). For more information, see
-     * [VCNs and Subnets](https://docs.cloud.oracle.com/Content/Network/Tasks/managingVCNs.htm).
+     * [VCNs and Subnets](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingVCNs.htm).
      * <p>
      * For the VCN, you specify a list of one or more IPv4 CIDR blocks that meet the following criteria:
      * <p>
@@ -948,15 +948,15 @@ public interface VirtualNetwork extends AutoCloseable {
      * reside. Consult an Oracle Cloud Infrastructure administrator in your organization if you're not sure which
      * compartment to use. Notice that the VCN doesn't have to be in the same compartment as the subnets or other
      * Networking Service components. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the VCN, otherwise a default is provided. It does not have to
      * be unique, and you can change it. Avoid entering confidential information.
      * <p>
      * You can also add a DNS label for the VCN, which is required if you want the instances to use the
      * Interent and VCN Resolver option for DNS in the VCN. For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * The VCN automatically comes with a default route table, default security list, and default set of DHCP options.
      * The OCID for each is returned in the response. You can't delete these default objects, but you can change their
@@ -964,7 +964,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * <p>
      * The VCN and subnets you create are not accessible until you attach an internet gateway or set up an IPSec VPN
      * or FastConnect. For more information, see
-     * [Overview of the Networking Service](https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm).
+     * [Overview of the Networking Service](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -977,16 +977,16 @@ public interface VirtualNetwork extends AutoCloseable {
     /**
      * Creates a new virtual circuit to use with Oracle Cloud
      * Infrastructure FastConnect. For more information, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the
      * compartment where you want the virtual circuit to reside. If you're
      * not sure which compartment to use, put the virtual circuit in the
      * same compartment with the DRG it's using. For more information about
      * compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
      * For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the virtual circuit.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -995,7 +995,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * the traffic to flow through. Make sure you attach the DRG to your
      * VCN and confirm the VCN's routing sends traffic to the DRG. Otherwise
      * traffic will not flow. For more information, see
-     * [Route Tables](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm).
+     * [Route Tables](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1020,7 +1020,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * Deletes the specified `ByoipRange` resource.
      * The resource must be in one of the following states: CREATING, PROVISIONED, ACTIVE, or FAILED.
      * It must not have any subranges currently allocated to a PublicIpPool object or the deletion will fail.
-     * You must specify the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * You must specify the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * If the `ByoipRange` resource is currently in the PROVISIONED or ACTIVE state, it will be de-provisioned and then deleted.
      *
      * @param request The request object containing the details to send
@@ -1213,7 +1213,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * automatically unassigned and deleted when the VNIC is terminated.
      * <p>
      **Important:** If a secondary private IP is the
-     * [target of a route rule](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip),
+     * [target of a route rule](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm#privateip),
      * unassigning it from the VNIC causes that route rule to blackhole and the traffic
      * will be dropped.
      *
@@ -1253,7 +1253,7 @@ public interface VirtualNetwork extends AutoCloseable {
     /**
      * Deletes the specified public IP pool.
      * To delete a public IP pool it must not have any active IP address allocations.
-     * You must specify the object's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) when deleting an IP pool.
+     * You must specify the object's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) when deleting an IP pool.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1395,7 +1395,7 @@ public interface VirtualNetwork extends AutoCloseable {
     DetachServiceIdResponse detachServiceId(DetachServiceIdRequest request);
 
     /**
-     * Gets the `ByoipRange` resource. You must specify the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * Gets the `ByoipRange` resource. You must specify the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1537,7 +1537,7 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Gets the redundancy status for the specified DRG. For more information, see
-     * [Redundancy Remedies](https://docs.cloud.oracle.com/Content/Network/Troubleshoot/drgredundancy.htm).
+     * [Redundancy Remedies](https://docs.cloud.oracle.com/iaas/Content/Network/Troubleshoot/drgredundancy.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1549,7 +1549,7 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Gets the specified provider service.
-     * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1805,7 +1805,7 @@ public interface VirtualNetwork extends AutoCloseable {
             GetPublicIpByPrivateIpIdRequest request);
 
     /**
-     * Gets the specified `PublicIpPool` object. You must specify the object's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * Gets the specified `PublicIpPool` object. You must specify the object's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -1980,7 +1980,7 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Lists the regions that support remote VCN peering (which is peering across regions).
-     * For more information, see [VCN Peering](https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm).
+     * For more information, see [VCN Peering](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/VCNpeering.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -2144,7 +2144,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * <p>
      * For the compartment ID, provide the OCID of your tenancy (the root compartment).
      * <p>
-     * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -2159,7 +2159,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * Gets the list of available virtual circuit bandwidth levels for a provider.
      * You need this information so you can specify your desired bandwidth level (shape) when you create a virtual circuit.
      * <p>
-     * For more information about virtual circuits, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * For more information about virtual circuits, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -2830,7 +2830,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * a VNIC or instance can have. If you try to move a reserved public IP
      * to a VNIC or instance that has already reached its public IP limit, an error is
      * returned. For information about the public IP limits, see
-     * [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+     * [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -2956,7 +2956,7 @@ public interface VirtualNetwork extends AutoCloseable {
      * its state will return to PROVISIONED. Make sure you confirm that
      * the associated BGP session is back up. For more information
      * about the various states and how to test connectivity, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      * <p>
      * To change the list of public IP prefixes for a public virtual circuit,
      * use {@link #bulkAddVirtualCircuitPublicPrefixes(BulkAddVirtualCircuitPublicPrefixesRequest) bulkAddVirtualCircuitPublicPrefixes}
@@ -2999,7 +2999,7 @@ public interface VirtualNetwork extends AutoCloseable {
 
     /**
      * Submits the BYOIP CIDR block you are importing for validation. Do not submit to Oracle for validation if you have not already
-     * modified the information for the BYOIP CIDR block with your Regional Internet Registry. See [To import a CIDR block](https://docs.cloud.oracle.com/Content/Network/Concepts/BYOIP.htm#import_cidr) for details.
+     * modified the information for the BYOIP CIDR block with your Regional Internet Registry. See [To import a CIDR block](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/BYOIP.htm#import_cidr) for details.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/VirtualNetworkAsync.java
@@ -628,7 +628,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * an Identity and Access Management (IAM) policy that gives the requestor permission
      * to connect to LPGs in the acceptor's compartment. Without that permission, this
      * operation will fail. For more information, see
-     * [VCN Peering](https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm).
+     * [VCN Peering](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/VCNpeering.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -652,7 +652,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * an Identity and Access Management (IAM) policy that gives the requestor permission
      * to connect to RPCs in the acceptor's compartment. Without that permission, this
      * operation will fail. For more information, see
-     * [VCN Peering](https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm).
+     * [VCN Peering](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/VCNpeering.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -688,17 +688,17 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Creates a new virtual customer-premises equipment (CPE) object in the specified compartment. For
-     * more information, see [IPSec VPNs](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPsec.htm).
+     * more information, see [IPSec VPNs](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPsec.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want
      * the CPE to reside. Notice that the CPE doesn't have to be in the same compartment as the IPSec
      * connection or other Networking Service components. If you're not sure which compartment to
      * use, put the CPE in the same compartment as the DRG. For more information about
-     * compartments and access control, see [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
-     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * compartments and access control, see [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
+     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You must provide the public IP address of your on-premises router. See
-     * [Configuring Your On-Premises Router for an IPSec VPN](https://docs.cloud.oracle.com/Content/Network/Tasks/configuringCPE.htm).
+     * [Configuring Your On-Premises Router for an IPSec VPN](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/configuringCPE.htm).
      * <p>
      * You may optionally specify a *display name* for the CPE, otherwise a default is provided. It does not have to
      * be unique, and you can change it. Avoid entering confidential information.
@@ -722,16 +722,16 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * <p>
      * After creating the `CrossConnect` object, you need to go the FastConnect location
      * and request to have the physical cable installed. For more information, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the
      * compartment where you want the cross-connect to reside. If you're
      * not sure which compartment to use, put the cross-connect in the
      * same compartment with your VCN. For more information about
      * compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
      * For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the cross-connect.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -753,16 +753,16 @@ public interface VirtualNetworkAsync extends AutoCloseable {
     /**
      * Creates a new cross-connect group to use with Oracle Cloud Infrastructure
      * FastConnect. For more information, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the
      * compartment where you want the cross-connect group to reside. If you're
      * not sure which compartment to use, put the cross-connect group in the
      * same compartment with your VCN. For more information about
      * compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
      * For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the cross-connect group.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -789,8 +789,8 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * DHCP options to reside. Notice that the set of options doesn't have to be in the same compartment as the VCN,
      * subnets, or other Networking Service components. If you're not sure which compartment to use, put the set
      * of DHCP options in the same compartment as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the set of DHCP options, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -811,14 +811,14 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Creates a new dynamic routing gateway (DRG) in the specified compartment. For more information,
-     * see [Dynamic Routing Gateways (DRGs)](https://docs.cloud.oracle.com/Content/Network/Tasks/managingDRGs.htm).
+     * see [Dynamic Routing Gateways (DRGs)](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingDRGs.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want
      * the DRG to reside. Notice that the DRG doesn't have to be in the same compartment as the VCN,
      * the DRG attachment, or other Networking Service components. If you're not sure which compartment
      * to use, put the DRG in the same compartment as the VCN. For more information about compartments
-     * and access control, see [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
-     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * and access control, see [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
+     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the DRG, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -839,14 +839,14 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * Attaches the specified DRG to the specified VCN. A VCN can be attached to only one DRG at a time,
      * and vice versa. The response includes a `DrgAttachment` object with its own OCID. For more
      * information about DRGs, see
-     * [Dynamic Routing Gateways (DRGs)](https://docs.cloud.oracle.com/Content/Network/Tasks/managingDRGs.htm).
+     * [Dynamic Routing Gateways (DRGs)](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingDRGs.htm).
      * <p>
      * You may optionally specify a *display name* for the attachment, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
      * <p>
      * For the purposes of access control, the DRG attachment is automatically placed into the same compartment
      * as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -864,7 +864,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Creates a new IPSec connection between the specified DRG and CPE. For more information, see
-     * [IPSec VPNs](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPsec.htm).
+     * [IPSec VPNs](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPsec.htm).
      * <p>
      * If you configure at least one tunnel to use static routing, then in the request you must provide
      * at least one valid static route (you're allowed a maximum of 10). For example: 10.0.0.0/16.
@@ -877,8 +877,8 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * as the DRG, CPE, or other Networking Service components. If you're not sure which compartment to
      * use, put the IPSec connection in the same compartment as the DRG. For more information about
      * compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
-     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
+     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the IPSec connection, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -891,7 +891,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * <p>
      * For each tunnel, you need the IP address of Oracle's VPN headend and the shared secret
      * (that is, the pre-shared key). For more information, see
-     * [Configuring Your On-Premises Router for an IPSec VPN](https://docs.cloud.oracle.com/Content/Network/Tasks/configuringCPE.htm).
+     * [Configuring Your On-Premises Router for an IPSec VPN](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/configuringCPE.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -909,14 +909,14 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Creates a new internet gateway for the specified VCN. For more information, see
-     * [Access to the Internet](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIGs.htm).
+     * [Access to the Internet](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIGs.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the Internet
      * Gateway to reside. Notice that the internet gateway doesn't have to be in the same compartment as the VCN or
      * other Networking Service components. If you're not sure which compartment to use, put the Internet
      * Gateway in the same compartment with the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the internet gateway, otherwise a default is provided. It
      * does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -1013,7 +1013,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
     /**
      * Creates a secondary private IP for the specified VNIC.
      * For more information about secondary private IPs, see
-     * [IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPaddresses.htm).
+     * [IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPaddresses.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -1031,7 +1031,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
     /**
      * Creates a public IP. Use the `lifetime` property to specify whether it's an ephemeral or
      * reserved public IP. For information about limits on how many you can create, see
-     * [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+     * [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
      * <p>
      * **For an ephemeral public IP assigned to a private IP:** You must also specify a `privateIpId`
      * with the OCID of the primary private IP you want to assign the public IP to. The public IP is
@@ -1103,16 +1103,16 @@ public interface VirtualNetworkAsync extends AutoCloseable {
     /**
      * Creates a new route table for the specified VCN. In the request you must also include at least one route
      * rule for the new route table. For information on the number of rules you can have in a route table, see
-     * [Service Limits](https://docs.cloud.oracle.com/Content/General/Concepts/servicelimits.htm). For general information about route
+     * [Service Limits](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/servicelimits.htm). For general information about route
      * tables in your VCN and the types of targets you can use in route rules,
-     * see [Route Tables](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm).
+     * see [Route Tables](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the route
      * table to reside. Notice that the route table doesn't have to be in the same compartment as the VCN, subnets,
      * or other Networking Service components. If you're not sure which compartment to use, put the route
      * table in the same compartment as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the route table, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -1132,16 +1132,16 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Creates a new security list for the specified VCN. For more information
-     * about security lists, see [Security Lists](https://docs.cloud.oracle.com/Content/Network/Concepts/securitylists.htm).
+     * about security lists, see [Security Lists](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/securitylists.htm).
      * For information on the number of rules you can have in a security list, see
-     * [Service Limits](https://docs.cloud.oracle.com/Content/General/Concepts/servicelimits.htm).
+     * [Service Limits](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/servicelimits.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the security
      * list to reside. Notice that the security list doesn't have to be in the same compartment as the VCN, subnets,
      * or other Networking Service components. If you're not sure which compartment to use, put the security
      * list in the same compartment as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the security list, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -1165,8 +1165,8 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want
      * the service gateway to reside. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
-     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
+     * For information about OCIDs, see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the service gateway, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -1188,35 +1188,35 @@ public interface VirtualNetworkAsync extends AutoCloseable {
     /**
      * Creates a new subnet in the specified VCN. You can't change the size of the subnet after creation,
      * so it's important to think about the size of subnets you need before creating them.
-     * For more information, see [VCNs and Subnets](https://docs.cloud.oracle.com/Content/Network/Tasks/managingVCNs.htm).
+     * For more information, see [VCNs and Subnets](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingVCNs.htm).
      * For information on the number of subnets you can have in a VCN, see
-     * [Service Limits](https://docs.cloud.oracle.com/Content/General/Concepts/servicelimits.htm).
+     * [Service Limits](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/servicelimits.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the compartment where you want the subnet
      * to reside. Notice that the subnet doesn't have to be in the same compartment as the VCN, route tables, or
      * other Networking Service components. If you're not sure which compartment to use, put the subnet in
      * the same compartment as the VCN. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs,
-     * see [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs,
+     * see [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally associate a route table with the subnet. If you don't, the subnet will use the
      * VCN's default route table. For more information about route tables, see
-     * [Route Tables](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm).
+     * [Route Tables](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm).
      * <p>
      * You may optionally associate a security list with the subnet. If you don't, the subnet will use the
      * VCN's default security list. For more information about security lists, see
-     * [Security Lists](https://docs.cloud.oracle.com/Content/Network/Concepts/securitylists.htm).
+     * [Security Lists](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/securitylists.htm).
      * <p>
      * You may optionally associate a set of DHCP options with the subnet. If you don't, the subnet will use the
      * VCN's default set. For more information about DHCP options, see
-     * [DHCP Options](https://docs.cloud.oracle.com/Content/Network/Tasks/managingDHCP.htm).
+     * [DHCP Options](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingDHCP.htm).
      * <p>
      * You may optionally specify a *display name* for the subnet, otherwise a default is provided.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
      * <p>
      * You can also add a DNS label for the subnet, which is required if you want the Internet and
      * VCN Resolver to resolve hostnames for instances in the subnet. For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -1233,7 +1233,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Creates a new virtual cloud network (VCN). For more information, see
-     * [VCNs and Subnets](https://docs.cloud.oracle.com/Content/Network/Tasks/managingVCNs.htm).
+     * [VCNs and Subnets](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingVCNs.htm).
      * <p>
      * For the VCN, you specify a list of one or more IPv4 CIDR blocks that meet the following criteria:
      * <p>
@@ -1248,15 +1248,15 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * reside. Consult an Oracle Cloud Infrastructure administrator in your organization if you're not sure which
      * compartment to use. Notice that the VCN doesn't have to be in the same compartment as the subnets or other
      * Networking Service components. For more information about compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm). For information about OCIDs, see
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the VCN, otherwise a default is provided. It does not have to
      * be unique, and you can change it. Avoid entering confidential information.
      * <p>
      * You can also add a DNS label for the VCN, which is required if you want the instances to use the
      * Interent and VCN Resolver option for DNS in the VCN. For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * The VCN automatically comes with a default route table, default security list, and default set of DHCP options.
      * The OCID for each is returned in the response. You can't delete these default objects, but you can change their
@@ -1264,7 +1264,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * <p>
      * The VCN and subnets you create are not accessible until you attach an internet gateway or set up an IPSec VPN
      * or FastConnect. For more information, see
-     * [Overview of the Networking Service](https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm).
+     * [Overview of the Networking Service](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -1281,16 +1281,16 @@ public interface VirtualNetworkAsync extends AutoCloseable {
     /**
      * Creates a new virtual circuit to use with Oracle Cloud
      * Infrastructure FastConnect. For more information, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      * <p>
      * For the purposes of access control, you must provide the OCID of the
      * compartment where you want the virtual circuit to reside. If you're
      * not sure which compartment to use, put the virtual circuit in the
      * same compartment with the DRG it's using. For more information about
      * compartments and access control, see
-     * [Overview of the IAM Service](https://docs.cloud.oracle.com/Content/Identity/Concepts/overview.htm).
+     * [Overview of the IAM Service](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/overview.htm).
      * For information about OCIDs, see
-     * [Resource Identifiers](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * [Resource Identifiers](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * <p>
      * You may optionally specify a *display name* for the virtual circuit.
      * It does not have to be unique, and you can change it. Avoid entering confidential information.
@@ -1299,7 +1299,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * the traffic to flow through. Make sure you attach the DRG to your
      * VCN and confirm the VCN's routing sends traffic to the DRG. Otherwise
      * traffic will not flow. For more information, see
-     * [Route Tables](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm).
+     * [Route Tables](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -1334,7 +1334,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * Deletes the specified `ByoipRange` resource.
      * The resource must be in one of the following states: CREATING, PROVISIONED, ACTIVE, or FAILED.
      * It must not have any subranges currently allocated to a PublicIpPool object or the deletion will fail.
-     * You must specify the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * You must specify the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      * If the `ByoipRange` resource is currently in the PROVISIONED or ACTIVE state, it will be de-provisioned and then deleted.
      *
      *
@@ -1595,7 +1595,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * automatically unassigned and deleted when the VNIC is terminated.
      * <p>
      **Important:** If a secondary private IP is the
-     * [target of a route rule](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip),
+     * [target of a route rule](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm#privateip),
      * unassigning it from the VNIC causes that route rule to blackhole and the traffic
      * will be dropped.
      *
@@ -1645,7 +1645,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
     /**
      * Deletes the specified public IP pool.
      * To delete a public IP pool it must not have any active IP address allocations.
-     * You must specify the object's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) when deleting an IP pool.
+     * You must specify the object's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) when deleting an IP pool.
      *
      *
      * @param request The request object containing the details to send
@@ -1841,7 +1841,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets the `ByoipRange` resource. You must specify the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * Gets the `ByoipRange` resource. You must specify the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -2041,7 +2041,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Gets the redundancy status for the specified DRG. For more information, see
-     * [Redundancy Remedies](https://docs.cloud.oracle.com/Content/Network/Troubleshoot/drgredundancy.htm).
+     * [Redundancy Remedies](https://docs.cloud.oracle.com/iaas/Content/Network/Troubleshoot/drgredundancy.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -2059,7 +2059,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Gets the specified provider service.
-     * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -2415,7 +2415,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets the specified `PublicIpPool` object. You must specify the object's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * Gets the specified `PublicIpPool` object. You must specify the object's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -2660,7 +2660,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Lists the regions that support remote VCN peering (which is peering across regions).
-     * For more information, see [VCN Peering](https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm).
+     * For more information, see [VCN Peering](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/VCNpeering.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -2890,7 +2890,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * <p>
      * For the compartment ID, provide the OCID of your tenancy (the root compartment).
      * <p>
-     * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -2912,7 +2912,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * Gets the list of available virtual circuit bandwidth levels for a provider.
      * You need this information so you can specify your desired bandwidth level (shape) when you create a virtual circuit.
      * <p>
-     * For more information about virtual circuits, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * For more information about virtual circuits, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -3829,7 +3829,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * a VNIC or instance can have. If you try to move a reserved public IP
      * to a VNIC or instance that has already reached its public IP limit, an error is
      * returned. For information about the public IP limits, see
-     * [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+     * [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
      *
      *
      * @param request The request object containing the details to send
@@ -4004,7 +4004,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
      * its state will return to PROVISIONED. Make sure you confirm that
      * the associated BGP session is back up. For more information
      * about the various states and how to test connectivity, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      * <p>
      * To change the list of public IP prefixes for a public virtual circuit,
      * use {@link #bulkAddVirtualCircuitPublicPrefixes(BulkAddVirtualCircuitPublicPrefixesRequest, Consumer, Consumer) bulkAddVirtualCircuitPublicPrefixes}
@@ -4061,7 +4061,7 @@ public interface VirtualNetworkAsync extends AutoCloseable {
 
     /**
      * Submits the BYOIP CIDR block you are importing for validation. Do not submit to Oracle for validation if you have not already
-     * modified the information for the BYOIP CIDR block with your Regional Internet Registry. See [To import a CIDR block](https://docs.cloud.oracle.com/Content/Network/Concepts/BYOIP.htm#import_cidr) for details.
+     * modified the information for the BYOIP CIDR block with your Regional Internet Registry. See [To import a CIDR block](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/BYOIP.htm#import_cidr) for details.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/AddPublicIpPoolCapacityDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/AddPublicIpPoolCapacityDetails.java
@@ -71,7 +71,7 @@ public class AddPublicIpPoolCapacityDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource to which the CIDR block belongs.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource to which the CIDR block belongs.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("byoipRangeId")
     String byoipRangeId;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/AddSecurityRuleDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/AddSecurityRuleDetails.java
@@ -188,7 +188,7 @@ public class AddSecurityRuleDetails {
      * <p>
      * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
      *     Note that IPv6 addressing is currently supported only in certain regions. See
-     *     [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     *     [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
      *     setting up a security rule for traffic destined for a particular `Service` through
@@ -343,7 +343,7 @@ public class AddSecurityRuleDetails {
      * <p>
      * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
      *     Note that IPv6 addressing is currently supported only in certain regions. See
-     *     [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     *     [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
      *     setting up a security rule for traffic coming from a particular `Service` through

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/AmdMilanBmLaunchInstancePlatformConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/AmdMilanBmLaunchInstancePlatformConfig.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The platform configuration used when launching a bare metal instance specific to the AMD Milan platform.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AmdMilanBmLaunchInstancePlatformConfig.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AmdMilanBmLaunchInstancePlatformConfig extends LaunchInstancePlatformConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("numaNodesPerSocket")
+        private NumaNodesPerSocket numaNodesPerSocket;
+
+        public Builder numaNodesPerSocket(NumaNodesPerSocket numaNodesPerSocket) {
+            this.numaNodesPerSocket = numaNodesPerSocket;
+            this.__explicitlySet__.add("numaNodesPerSocket");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AmdMilanBmLaunchInstancePlatformConfig build() {
+            AmdMilanBmLaunchInstancePlatformConfig __instance__ =
+                    new AmdMilanBmLaunchInstancePlatformConfig(numaNodesPerSocket);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AmdMilanBmLaunchInstancePlatformConfig o) {
+            Builder copiedBuilder = numaNodesPerSocket(o.getNumaNodesPerSocket());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AmdMilanBmLaunchInstancePlatformConfig(NumaNodesPerSocket numaNodesPerSocket) {
+        super();
+        this.numaNodesPerSocket = numaNodesPerSocket;
+    }
+
+    /**
+     * The number of NUMA nodes per socket.
+     *
+     **/
+    public enum NumaNodesPerSocket {
+        Nps0("NPS0"),
+        Nps1("NPS1"),
+        Nps2("NPS2"),
+        Nps4("NPS4"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, NumaNodesPerSocket> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (NumaNodesPerSocket v : NumaNodesPerSocket.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        NumaNodesPerSocket(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static NumaNodesPerSocket create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid NumaNodesPerSocket: " + key);
+        }
+    };
+    /**
+     * The number of NUMA nodes per socket.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("numaNodesPerSocket")
+    NumaNodesPerSocket numaNodesPerSocket;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/AmdMilanBmPlatformConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/AmdMilanBmPlatformConfig.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The platform configuration of a bare metal instance specific to the AMD Milan platform.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AmdMilanBmPlatformConfig.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AmdMilanBmPlatformConfig extends PlatformConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("numaNodesPerSocket")
+        private NumaNodesPerSocket numaNodesPerSocket;
+
+        public Builder numaNodesPerSocket(NumaNodesPerSocket numaNodesPerSocket) {
+            this.numaNodesPerSocket = numaNodesPerSocket;
+            this.__explicitlySet__.add("numaNodesPerSocket");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AmdMilanBmPlatformConfig build() {
+            AmdMilanBmPlatformConfig __instance__ =
+                    new AmdMilanBmPlatformConfig(numaNodesPerSocket);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AmdMilanBmPlatformConfig o) {
+            Builder copiedBuilder = numaNodesPerSocket(o.getNumaNodesPerSocket());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AmdMilanBmPlatformConfig(NumaNodesPerSocket numaNodesPerSocket) {
+        super();
+        this.numaNodesPerSocket = numaNodesPerSocket;
+    }
+
+    /**
+     * The number of NUMA nodes per socket.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum NumaNodesPerSocket {
+        Nps0("NPS0"),
+        Nps1("NPS1"),
+        Nps2("NPS2"),
+        Nps4("NPS4"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, NumaNodesPerSocket> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (NumaNodesPerSocket v : NumaNodesPerSocket.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        NumaNodesPerSocket(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static NumaNodesPerSocket create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'NumaNodesPerSocket', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The number of NUMA nodes per socket.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("numaNodesPerSocket")
+    NumaNodesPerSocket numaNodesPerSocket;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ByoipAllocatedRangeSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ByoipAllocatedRangeSummary.java
@@ -78,7 +78,7 @@ public class ByoipAllocatedRangeSummary {
     String cidrBlock;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the IP pool containing the CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the IP pool containing the CIDR block.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicIpPoolId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ByoipRange.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ByoipRange.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.core.model;
 
 /**
  * Oracle offers the ability to Bring Your Own IP (BYOIP), importing public IP addresses that you currently own to Oracle Cloud Infrastructure. A `ByoipRange` resource is a record of the imported address block (a BYOIP CIDR block) and also some associated metadata.
- * The process used to [Bring Your Own IP](https://docs.cloud.oracle.com/Content/Network/Concepts/BYOIP.htm) is explained in the documentation.
+ * The process used to [Bring Your Own IP](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/BYOIP.htm) is explained in the documentation.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -202,7 +202,7 @@ public class ByoipRange {
     String cidrBlock;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the BYOIP CIDR block.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
@@ -237,7 +237,7 @@ public class ByoipRange {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -391,7 +391,7 @@ public class ByoipRange {
     java.util.Date timeWithdrawn;
 
     /**
-     * The validation token is an internally-generated ASCII string used in the validation process. See [Importing a CIDR block](https://docs.cloud.oracle.com/Content/Network/Concepts/BYOIP.htm#import_cidr) for details.
+     * The validation token is an internally-generated ASCII string used in the validation process. See [Importing a CIDR block](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/BYOIP.htm#import_cidr) for details.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("validationToken")
     String validationToken;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ByoipRangeSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ByoipRangeSummary.java
@@ -159,7 +159,7 @@ public class ByoipRangeSummary {
     String cidrBlock;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the `ByoipRange` resource.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the `ByoipRange` resource.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
@@ -194,7 +194,7 @@ public class ByoipRangeSummary {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeByoipRangeCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeByoipRangeCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeByoipRangeCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the destination compartment for the BYOIP CIDR block move.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the destination compartment for the BYOIP CIDR block move.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeCpeCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeCpeCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeCpeCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * CPE object to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeCrossConnectCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeCrossConnectCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeCrossConnectCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * cross-connect to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeCrossConnectGroupCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeCrossConnectGroupCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeCrossConnectGroupCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * cross-connect group to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeDhcpOptionsCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeDhcpOptionsCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeDhcpOptionsCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * set of DHCP options to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeDrgCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeDrgCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeDrgCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * DRG to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeIPSecConnectionCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeIPSecConnectionCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeIPSecConnectionCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * IPSec connection to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeInternetGatewayCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeInternetGatewayCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeInternetGatewayCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * internet gateway to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeLocalPeeringGatewayCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeLocalPeeringGatewayCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeLocalPeeringGatewayCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * local peering gateway to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeNatGatewayCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeNatGatewayCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeNatGatewayCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the NAT gateway to.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the NAT gateway to.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeNetworkSecurityGroupCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeNetworkSecurityGroupCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeNetworkSecurityGroupCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the network
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the network
      * security group to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangePublicIpCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangePublicIpCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangePublicIpCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * public IP to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangePublicIpPoolCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangePublicIpPoolCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangePublicIpPoolCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the destination compartment for the public IP pool move.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the destination compartment for the public IP pool move.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeRemotePeeringConnectionCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeRemotePeeringConnectionCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeRemotePeeringConnectionCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * remote peering connection to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeRouteTableCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeRouteTableCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeRouteTableCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * route table to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeSecurityListCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeSecurityListCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeSecurityListCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * security list to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeServiceGatewayCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeServiceGatewayCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeServiceGatewayCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * service gateway to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeSubnetCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeSubnetCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeSubnetCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * subnet to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeVcnCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeVcnCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeVcnCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * VCN to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeVirtualCircuitCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeVirtualCircuitCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeVirtualCircuitCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the
      * virtual circuit to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeVlanCompartmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ChangeVlanCompartmentDetails.java
@@ -62,7 +62,7 @@ public class ChangeVlanCompartmentDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to move the VLAN to.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to move the VLAN to.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Cpe.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Cpe.java
@@ -9,11 +9,11 @@ package com.oracle.bmc.core.model;
  * and VCN. The `Cpe` is a virtual representation of your customer-premises equipment,
  * which is the actual router on-premises at your site at your end of the IPSec VPN connection.
  * For more information,
- * see [Overview of the Networking Service](https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm).
+ * see [Overview of the Networking Service](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -195,7 +195,7 @@ public class Cpe {
     String ipAddress;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE's device type.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the CPE's device type.
      * The Networking service maintains a general list of CPE device types (for example,
      * Cisco ASA). For each type, Oracle provides CPE configuration content that can help
      * a network engineer configure the CPE. The OCID uniquely identifies the type of

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CpeDeviceShapeDetail.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CpeDeviceShapeDetail.java
@@ -95,7 +95,7 @@ public class CpeDeviceShapeDetail {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device shape.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the CPE device shape.
      * This value uniquely identifies the type of CPE device.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CpeDeviceShapeSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CpeDeviceShapeSummary.java
@@ -72,7 +72,7 @@ public class CpeDeviceShapeSummary {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device shape.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the CPE device shape.
      * This value uniquely identifies the type of CPE device.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateByoipRangeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateByoipRangeDetails.java
@@ -113,7 +113,7 @@ public class CreateByoipRangeDetails {
     String cidrBlock;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the BYOIP CIDR block.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCpeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateCpeDetails.java
@@ -161,7 +161,7 @@ public class CreateCpeDetails {
     String ipAddress;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device type. You can provide
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the CPE device type. You can provide
      * a value if you want to later generate CPE device configuration content for IPSec connections
      * that use this CPE. You can also call {@link #updateCpe(UpdateCpeRequest) updateCpe} later to
      * provide a value. For a list of possible values, see

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateDrgAttachmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateDrgAttachmentDetails.java
@@ -114,8 +114,8 @@ public class CreateDrgAttachmentDetails {
      * with the DRG attachment.
      * For information about why you would associate a route table with a DRG attachment, see:
      * <p>
-     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm)
-     *   * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/Content/Network/Tasks/transitroutingoracleservices.htm)
+     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitrouting.htm)
+     *   * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitroutingoracleservices.htm)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecConnectionDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIPSecConnectionDetails.java
@@ -219,7 +219,7 @@ public class CreateIPSecConnectionDetails {
      * object specified by `cpeId` is used as the `cpeLocalIdentifier`.
      * <p>
      * For information about why you'd provide this value, see
-     * [If Your CPE Is Behind a NAT Device](https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat).
+     * [If Your CPE Is Behind a NAT Device](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/overviewIPsec.htm#nat).
      * <p>
      * Example IP address: `10.0.3.3`
      * <p>
@@ -284,7 +284,7 @@ public class CreateIPSecConnectionDetails {
      * For more information, see the important note in {@link IPSecConnection}.
      * <p>
      * The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-     * in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: `10.0.1.0/24`
      * <p>

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIpv6Details.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateIpv6Details.java
@@ -174,7 +174,7 @@ public class CreateIpv6Details {
     Boolean isInternetAccessAllowed;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VNIC to assign the IPv6 to. The
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VNIC to assign the IPv6 to. The
      * IPv6 will be in the VNIC's subnet.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateLocalPeeringGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateLocalPeeringGatewayDetails.java
@@ -162,7 +162,7 @@ public class CreateLocalPeeringGatewayDetails {
      * with the LPG.
      * <p>
      * For information about why you would associate a route table with an LPG, see
-     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm).
+     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitrouting.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateNatGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateNatGatewayDetails.java
@@ -131,7 +131,7 @@ public class CreateNatGatewayDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to contain the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to contain the
      * NAT gateway.
      *
      **/
@@ -176,14 +176,14 @@ public class CreateNatGatewayDetails {
     Boolean blockTraffic;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN the gateway belongs to.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN the gateway belongs to.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
     String vcnId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP address associated with the NAT gateway.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP address associated with the NAT gateway.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicIpId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateNetworkSecurityGroupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateNetworkSecurityGroupDetails.java
@@ -105,7 +105,7 @@ public class CreateNetworkSecurityGroupDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to contain the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to contain the
      * network security group.
      *
      **/
@@ -141,7 +141,7 @@ public class CreateNetworkSecurityGroupDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN to create the network
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN to create the network
      * security group in.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreatePrivateIpDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreatePrivateIpDetails.java
@@ -167,7 +167,7 @@ public class CreatePrivateIpDetails {
      * [RFC 1123](https://tools.ietf.org/html/rfc1123).
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `bminstance-1`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreatePublicIpDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreatePublicIpDetails.java
@@ -168,7 +168,7 @@ public class CreatePublicIpDetails {
     /**
      * Defines when the public IP is deleted and released back to the Oracle Cloud
      * Infrastructure public IP pool. For more information, see
-     * [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+     * [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
      *
      **/
     public enum Lifetime {
@@ -206,7 +206,7 @@ public class CreatePublicIpDetails {
     /**
      * Defines when the public IP is deleted and released back to the Oracle Cloud
      * Infrastructure public IP pool. For more information, see
-     * [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+     * [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifetime")
@@ -227,7 +227,7 @@ public class CreatePublicIpDetails {
     String privateIpId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP pool.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicIpPoolId")
     String publicIpPoolId;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreatePublicIpPoolDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreatePublicIpPoolDetails.java
@@ -95,7 +95,7 @@ public class CreatePublicIpPoolDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the public IP pool.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateServiceGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateServiceGatewayDetails.java
@@ -173,7 +173,7 @@ public class CreateServiceGatewayDetails {
      * with the service gateway.
      * <p>
      * For information about why you would associate a route table with a service gateway, see
-     * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/Content/Network/Tasks/transitroutingoracleservices.htm).
+     * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitroutingoracleservices.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")
@@ -195,7 +195,7 @@ public class CreateServiceGatewayDetails {
     java.util.List<ServiceIdRequestDetails> services;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateSubnetDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateSubnetDetails.java
@@ -271,7 +271,7 @@ public class CreateSubnetDetails {
      * was created with a DNS label.
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `subnet123`
      *
@@ -294,7 +294,7 @@ public class CreateSubnetDetails {
      * You can't change this subnet characteristic later. All subnets are /64 in size. The subnet
      * portion of the IPv6 address is the fourth hextet from the left (1111 in the following example).
      * <p>
-     * For important details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * For important details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: `2001:0db8:0123:1111::/64`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVcnDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVcnDetails.java
@@ -178,7 +178,7 @@ public class CreateVcnDetails {
 
     /**
      * If you enable IPv6 for the VCN (see `isIpv6Enabled`), you may optionally provide an IPv6
-     * /48 CIDR block from the supported ranges (see [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * /48 CIDR block from the supported ranges (see [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * The addresses in this block will be considered private and cannot be accessed
      * from the internet. The documentation refers to this as a *custom CIDR* for the VCN.
      * <p>
@@ -194,7 +194,7 @@ public class CreateVcnDetails {
      * an IPv6 address can be used for internet communication by using the `isInternetAccessAllowed`
      * attribute in the {@link Ipv6} object.
      * <p>
-     * For important details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * For important details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: `2001:0db8:0123::/48`
      *
@@ -233,7 +233,7 @@ public class CreateVcnDetails {
      * will not work.
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `vcn1`
      *
@@ -253,7 +253,7 @@ public class CreateVcnDetails {
 
     /**
      * Whether IPv6 is enabled for the VCN. Default is `false`. You cannot change this later.
-     * For important details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * For important details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: `true`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVnicDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVnicDetails.java
@@ -8,7 +8,7 @@ package com.oracle.bmc.core.model;
  * Contains properties for a VNIC. You use this object when creating the
  * primary VNIC during instance launch or when creating a secondary VNIC.
  * For more information about VNICs, see
- * [Virtual Network Interface Cards (VNICs)](https://docs.cloud.oracle.com/Content/Network/Tasks/managingVNICs.htm).
+ * [Virtual Network Interface Cards (VNICs)](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingVNICs.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -178,14 +178,14 @@ public class CreateVnicDetails {
      * <p>
      **Note:** This public IP address is associated with the primary private IP
      * on the VNIC. For more information, see
-     * [IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPaddresses.htm).
+     * [IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPaddresses.htm).
      * <p>
      **Note:** There's a limit to the number of {@link PublicIp}
      * a VNIC or instance can have. If you try to create a secondary VNIC
      * with an assigned public IP for an instance that has already
      * reached its public IP limit, an error is returned. For information
      * about the public IP limits, see
-     * [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+     * [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
      * <p>
      * Example: `false`
      * <p>
@@ -237,7 +237,7 @@ public class CreateVnicDetails {
      * {@link #getPrivateIp(GetPrivateIpRequest) getPrivateIp}.
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * When launching an instance, use this `hostnameLabel` instead
      * of the deprecated `hostnameLabel` in
@@ -291,7 +291,7 @@ public class CreateVnicDetails {
      * Whether the source/destination check is disabled on the VNIC.
      * Defaults to `false`, which means the check is performed. For information
      * about why you would skip the source/destination check, see
-     * [Using a Private IP as a Route Target](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip).
+     * [Using a Private IP as a Route Target](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm#privateip).
      * <p>
      *
      * If you specify a `vlanId`, the `skipSourceDestCheck` cannot be specified because the

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnect.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnect.java
@@ -8,7 +8,7 @@ package com.oracle.bmc.core.model;
  * For use with Oracle Cloud Infrastructure FastConnect. A cross-connect represents a
  * physical connection between an existing network and Oracle. Customers who are colocated
  * with Oracle in a FastConnect location create and use cross-connects. For more
- * information, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+ * information, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
  * <p>
  * Oracle recommends you create each cross-connect in a
  * {@link CrossConnectGroup} so you can use link aggregation
@@ -20,7 +20,7 @@ package com.oracle.bmc.core.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectGroup.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectGroup.java
@@ -9,7 +9,7 @@ package com.oracle.bmc.core.model;
  * is a link aggregation group (LAG), which can contain one or more
  * {@link CrossConnect}. Customers who are colocated with
  * Oracle in a FastConnect location create and use cross-connect groups. For more
- * information, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+ * information, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
  * <p>
  **Note:** If you're a provider who is setting up a physical connection to Oracle so customers
  * can use FastConnect over the connection, be aware that your connection is modeled the
@@ -17,7 +17,7 @@ package com.oracle.bmc.core.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectMapping.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CrossConnectMapping.java
@@ -217,7 +217,7 @@ public class CrossConnectMapping {
      * There's one exception: for a public virtual circuit, Oracle specifies the BGP IPv6 addresses.
      * <p>
      * Note that IPv6 addressing is currently supported only in certain regions. See
-     * [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: `2001:db8::1/64`
      *
@@ -234,7 +234,7 @@ public class CrossConnectMapping {
      * There's one exception: for a public virtual circuit, Oracle specifies the BGP IPv6 addresses.
      * <p>
      * Note that IPv6 addressing is currently supported only in certain regions. See
-     * [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: `2001:db8::2/64`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpDnsOption.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpDnsOption.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.core.model;
 /**
  * DHCP option for specifying how DNS (hostname resolution) is handled in the subnets in the VCN.
  * For more information, see
- * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+ * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -103,7 +103,7 @@ public class DhcpDnsOption extends DhcpOption {
      * The Internet and VCN Resolver also enables reverse DNS lookup, which lets
      * you determine the hostname corresponding to the private IP address. For more
      * information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * **CustomDnsServer:** Instances use a DNS server of your choice (three
      * maximum).
@@ -165,7 +165,7 @@ public class DhcpDnsOption extends DhcpOption {
      * The Internet and VCN Resolver also enables reverse DNS lookup, which lets
      * you determine the hostname corresponding to the private IP address. For more
      * information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * **CustomDnsServer:** Instances use a DNS server of your choice (three
      * maximum).

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpOption.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpOption.java
@@ -8,8 +8,8 @@ package com.oracle.bmc.core.model;
  * A single DHCP option according to [RFC 1533](https://tools.ietf.org/html/rfc1533).
  * The two options available to use are {@link DhcpDnsOption}
  * and {@link DhcpSearchDomainOption}. For more
- * information, see [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm)
- * and [DHCP Options](https://docs.cloud.oracle.com/Content/Network/Tasks/managingDHCP.htm).
+ * information, see [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm)
+ * and [DHCP Options](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingDHCP.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpOptions.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpOptions.java
@@ -14,12 +14,12 @@ package com.oracle.bmc.core.model;
  * - {@link DhcpSearchDomainOption}: Lets you specify
  * a search domain name to use for DNS queries.
  * <p>
- * For more information, see  [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm)
- * and [DHCP Options](https://docs.cloud.oracle.com/Content/Network/Tasks/managingDHCP.htm).
+ * For more information, see  [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm)
+ * and [DHCP Options](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingDHCP.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpSearchDomainOption.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DhcpSearchDomainOption.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.core.model;
 
 /**
  * DHCP option for specifying a search domain name for DNS queries. For more information, see
- * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+ * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Drg.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Drg.java
@@ -9,11 +9,11 @@ package com.oracle.bmc.core.model;
  * network traffic between your VCN and your existing network. You use it with other Networking
  * Service components to create an IPSec VPN or a connection that uses
  * Oracle Cloud Infrastructure FastConnect. For more information, see
- * [Overview of the Networking Service](https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm).
+ * [Overview of the Networking Service](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgAttachment.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgAttachment.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.core.model;
 
 /**
  * A link between a DRG and VCN. For more information, see
- * [Overview of the Networking Service](https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm).
+ * [Overview of the Networking Service](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -233,8 +233,8 @@ public class DrgAttachment {
      * <p>
      * For information about why you would associate a route table with a DRG attachment, see:
      * <p>
-     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm)
-     *   * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/Content/Network/Tasks/transitroutingoracleservices.htm)
+     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitrouting.htm)
+     *   * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitroutingoracleservices.htm)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgRedundancyStatus.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgRedundancyStatus.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.core.model;
 
 /**
  * The redundancy status of the DRG. For more information, see
- * [Redundancy Remedies](https://docs.cloud.oracle.com/Content/Network/Troubleshoot/drgredundancy.htm).
+ * [Redundancy Remedies](https://docs.cloud.oracle.com/iaas/Content/Network/Troubleshoot/drgredundancy.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/EgressSecurityRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/EgressSecurityRule.java
@@ -148,7 +148,7 @@ public class EgressSecurityRule {
      * <p>
      * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
      *     Note that IPv6 addressing is currently supported only in certain regions. See
-     *     [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     *     [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
      *     setting up a security list rule for traffic destined for a particular `Service` through

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageDetails.java
@@ -47,4 +47,49 @@ package com.oracle.bmc.core.model;
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-public class ExportImageDetails {}
+public class ExportImageDetails {
+
+    /**
+     * The format of the image to be exported. The default value is \"OCI\".
+     **/
+    public enum ExportFormat {
+        Qcow2("QCOW2"),
+        Vmdk("VMDK"),
+        Oci("OCI"),
+        Vhd("VHD"),
+        Vdi("VDI"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ExportFormat> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ExportFormat v : ExportFormat.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ExportFormat(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ExportFormat create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ExportFormat: " + key);
+        }
+    };
+    /**
+     * The format of the image to be exported. The default value is \"OCI\".
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("exportFormat")
+    ExportFormat exportFormat;
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageTupleDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageTupleDetails.java
@@ -32,6 +32,15 @@ public class ExportImageViaObjectStorageTupleDetails extends ExportImageDetails 
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("exportFormat")
+        private ExportFormat exportFormat;
+
+        public Builder exportFormat(ExportFormat exportFormat) {
+            this.exportFormat = exportFormat;
+            this.__explicitlySet__.add("exportFormat");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("bucketName")
         private String bucketName;
 
@@ -65,7 +74,7 @@ public class ExportImageViaObjectStorageTupleDetails extends ExportImageDetails 
         public ExportImageViaObjectStorageTupleDetails build() {
             ExportImageViaObjectStorageTupleDetails __instance__ =
                     new ExportImageViaObjectStorageTupleDetails(
-                            bucketName, namespaceName, objectName);
+                            exportFormat, bucketName, namespaceName, objectName);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -73,7 +82,8 @@ public class ExportImageViaObjectStorageTupleDetails extends ExportImageDetails 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ExportImageViaObjectStorageTupleDetails o) {
             Builder copiedBuilder =
-                    bucketName(o.getBucketName())
+                    exportFormat(o.getExportFormat())
+                            .bucketName(o.getBucketName())
                             .namespaceName(o.getNamespaceName())
                             .objectName(o.getObjectName());
 
@@ -91,8 +101,8 @@ public class ExportImageViaObjectStorageTupleDetails extends ExportImageDetails 
 
     @Deprecated
     public ExportImageViaObjectStorageTupleDetails(
-            String bucketName, String namespaceName, String objectName) {
-        super();
+            ExportFormat exportFormat, String bucketName, String namespaceName, String objectName) {
+        super(exportFormat);
         this.bucketName = bucketName;
         this.namespaceName = namespaceName;
         this.objectName = objectName;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageUriDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ExportImageViaObjectStorageUriDetails.java
@@ -32,6 +32,15 @@ public class ExportImageViaObjectStorageUriDetails extends ExportImageDetails {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("exportFormat")
+        private ExportFormat exportFormat;
+
+        public Builder exportFormat(ExportFormat exportFormat) {
+            this.exportFormat = exportFormat;
+            this.__explicitlySet__.add("exportFormat");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("destinationUri")
         private String destinationUri;
 
@@ -46,14 +55,15 @@ public class ExportImageViaObjectStorageUriDetails extends ExportImageDetails {
 
         public ExportImageViaObjectStorageUriDetails build() {
             ExportImageViaObjectStorageUriDetails __instance__ =
-                    new ExportImageViaObjectStorageUriDetails(destinationUri);
+                    new ExportImageViaObjectStorageUriDetails(exportFormat, destinationUri);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ExportImageViaObjectStorageUriDetails o) {
-            Builder copiedBuilder = destinationUri(o.getDestinationUri());
+            Builder copiedBuilder =
+                    exportFormat(o.getExportFormat()).destinationUri(o.getDestinationUri());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -68,8 +78,8 @@ public class ExportImageViaObjectStorageUriDetails extends ExportImageDetails {
     }
 
     @Deprecated
-    public ExportImageViaObjectStorageUriDetails(String destinationUri) {
-        super();
+    public ExportImageViaObjectStorageUriDetails(ExportFormat exportFormat, String destinationUri) {
+        super(exportFormat);
         this.destinationUri = destinationUri;
     }
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/FastConnectProviderService.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/FastConnectProviderService.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.core.model;
 
 /**
  * A service offering from a supported provider. For more information,
- * see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+ * see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnection.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnection.java
@@ -21,11 +21,11 @@ package com.oracle.bmc.core.model;
  * if that tunnel's `routing` attribute = `STATIC`. Otherwise the static routes are ignored.
  * <p>
  * For more information about the workflow for setting up an IPSec connection, see
- * [IPSec VPN](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPsec.htm).
+ * [IPSec VPN](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPsec.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -318,7 +318,7 @@ public class IPSecConnection {
      * for the {@link Cpe} object specified by `cpeId` is used as the `cpeLocalIdentifier`.
      * <p>
      * For information about why you'd provide this value, see
-     * [If Your CPE Is Behind a NAT Device](https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat).
+     * [If Your CPE Is Behind a NAT Device](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/overviewIPsec.htm#nat).
      * <p>
      * Example IP address: `10.0.3.3`
      * <p>
@@ -393,7 +393,7 @@ public class IPSecConnection {
      * tunnels to use BGP dynamic routing, you can provide an empty list for the static routes.
      * <p>
      * The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-     * in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: `10.0.1.0/24`
      * <p>

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionTunnel.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IPSecConnectionTunnel.java
@@ -199,14 +199,14 @@ public class IPSecConnectionTunnel {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the tunnel.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the tunnel.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the tunnel.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/IngressSecurityRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/IngressSecurityRule.java
@@ -172,7 +172,7 @@ public class IngressSecurityRule {
      * <p>
      * IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`.
      *     Note that IPv6 addressing is currently supported only in certain regions. See
-     *     [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     *     [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
      *     setting up a security list rule for traffic coming from a particular `Service` through

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Instance.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Instance.java
@@ -261,6 +261,15 @@ public class Instance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("platformConfig")
+        private PlatformConfig platformConfig;
+
+        public Builder platformConfig(PlatformConfig platformConfig) {
+            this.platformConfig = platformConfig;
+            this.__explicitlySet__.add("platformConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -291,7 +300,8 @@ public class Instance {
                             systemTags,
                             timeCreated,
                             agentConfig,
-                            timeMaintenanceRebootDue);
+                            timeMaintenanceRebootDue,
+                            platformConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -323,7 +333,8 @@ public class Instance {
                             .systemTags(o.getSystemTags())
                             .timeCreated(o.getTimeCreated())
                             .agentConfig(o.getAgentConfig())
-                            .timeMaintenanceRebootDue(o.getTimeMaintenanceRebootDue());
+                            .timeMaintenanceRebootDue(o.getTimeMaintenanceRebootDue())
+                            .platformConfig(o.getPlatformConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -650,6 +661,9 @@ public class Instance {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeMaintenanceRebootDue")
     java.util.Date timeMaintenanceRebootDue;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("platformConfig")
+    PlatformConfig platformConfig;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The platform configuration used when launching a bare metal instance specific to the AMD Milan platform.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig
+        extends InstanceConfigurationLaunchInstancePlatformConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("numaNodesPerSocket")
+        private NumaNodesPerSocket numaNodesPerSocket;
+
+        public Builder numaNodesPerSocket(NumaNodesPerSocket numaNodesPerSocket) {
+            this.numaNodesPerSocket = numaNodesPerSocket;
+            this.__explicitlySet__.add("numaNodesPerSocket");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig build() {
+            InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig __instance__ =
+                    new InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig(
+                            numaNodesPerSocket);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig o) {
+            Builder copiedBuilder = numaNodesPerSocket(o.getNumaNodesPerSocket());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig(
+            NumaNodesPerSocket numaNodesPerSocket) {
+        super();
+        this.numaNodesPerSocket = numaNodesPerSocket;
+    }
+
+    /**
+     * The number of NUMA nodes per socket.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum NumaNodesPerSocket {
+        Nps0("NPS0"),
+        Nps1("NPS1"),
+        Nps2("NPS2"),
+        Nps4("NPS4"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, NumaNodesPerSocket> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (NumaNodesPerSocket v : NumaNodesPerSocket.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        NumaNodesPerSocket(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static NumaNodesPerSocket create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'NumaNodesPerSocket', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The number of NUMA nodes per socket.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("numaNodesPerSocket")
+    NumaNodesPerSocket numaNodesPerSocket;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchInstanceDetails.java
@@ -131,6 +131,16 @@ public class InstanceConfigurationLaunchInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("platformConfig")
+        private InstanceConfigurationLaunchInstancePlatformConfig platformConfig;
+
+        public Builder platformConfig(
+                InstanceConfigurationLaunchInstancePlatformConfig platformConfig) {
+            this.platformConfig = platformConfig;
+            this.__explicitlySet__.add("platformConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
         private InstanceConfigurationInstanceSourceDetails sourceDetails;
 
@@ -241,6 +251,7 @@ public class InstanceConfigurationLaunchInstanceDetails {
                             metadata,
                             shape,
                             shapeConfig,
+                            platformConfig,
                             sourceDetails,
                             faultDomain,
                             dedicatedVmHostId,
@@ -269,6 +280,7 @@ public class InstanceConfigurationLaunchInstanceDetails {
                             .metadata(o.getMetadata())
                             .shape(o.getShape())
                             .shapeConfig(o.getShapeConfig())
+                            .platformConfig(o.getPlatformConfig())
                             .sourceDetails(o.getSourceDetails())
                             .faultDomain(o.getFaultDomain())
                             .dedicatedVmHostId(o.getDedicatedVmHostId())
@@ -450,6 +462,9 @@ public class InstanceConfigurationLaunchInstanceDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("shapeConfig")
     InstanceConfigurationLaunchInstanceShapeConfigDetails shapeConfig;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("platformConfig")
+    InstanceConfigurationLaunchInstancePlatformConfig platformConfig;
 
     @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
     InstanceConfigurationInstanceSourceDetails sourceDetails;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchInstancePlatformConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationLaunchInstancePlatformConfig.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The platform configuration requested for the instance.
+ * <p>
+ * If the parameter is provided, the instance is created with the platform configured as specified. If some
+ * properties are missing or the entire parameter is not provided, the instance is created
+ * with the default configuration values for the `shape` that you specify.
+ * <p>
+ * Each shape only supports certain configurable values. If the values that you provide are not valid for the
+ * specified `shape`, an error is returned.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type",
+    defaultImpl = InstanceConfigurationLaunchInstancePlatformConfig.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = InstanceConfigurationAmdMilanBmLaunchInstancePlatformConfig.class,
+        name = "AMD_MILAN_BM"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class InstanceConfigurationLaunchInstancePlatformConfig {
+
+    /**
+     * The type of platform being configured. The only supported
+     * `type` is `AMD_MILAN_BM`
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Type {
+        AmdMilanBm("AMD_MILAN_BM"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Type> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Type v : Type.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Type create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Type', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InternetGateway.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InternetGateway.java
@@ -7,11 +7,11 @@ package com.oracle.bmc.core.model;
 /**
  * Represents a router that connects the edge of a VCN with the Internet. For an example scenario
  * that uses an internet gateway, see
- * [Typical Networking Service Scenarios](https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm#scenarios).
+ * [Typical Networking Service Scenarios](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm#scenarios).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Ipv6.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Ipv6.java
@@ -12,7 +12,7 @@ package com.oracle.bmc.core.model;
  * IPv6-enabled VCN.
  * <p>
  **Note:** IPv6 addressing is currently supported only in certain regions. For important
- * details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+ * details about IPv6 addressing in a VCN, see [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -192,7 +192,7 @@ public class Ipv6 {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the IPv6.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the IPv6.
      * This is the same as the VNIC's compartment.
      *
      **/
@@ -228,7 +228,7 @@ public class Ipv6 {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the IPv6.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the IPv6.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -331,7 +331,7 @@ public class Ipv6 {
     String publicIpAddress;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the subnet the VNIC is in.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the subnet the VNIC is in.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
     String subnetId;
@@ -346,7 +346,7 @@ public class Ipv6 {
     java.util.Date timeCreated;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VNIC the IPv6 is assigned to.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VNIC the IPv6 is assigned to.
      * The VNIC and IPv6 must be in the same subnet.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceDetails.java
@@ -228,6 +228,15 @@ public class LaunchInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("platformConfig")
+        private LaunchInstancePlatformConfig platformConfig;
+
+        public Builder platformConfig(LaunchInstancePlatformConfig platformConfig) {
+            this.platformConfig = platformConfig;
+            this.__explicitlySet__.add("platformConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -255,7 +264,8 @@ public class LaunchInstanceDetails {
                             shapeConfig,
                             sourceDetails,
                             subnetId,
-                            isPvEncryptionInTransitEnabled);
+                            isPvEncryptionInTransitEnabled,
+                            platformConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -284,7 +294,8 @@ public class LaunchInstanceDetails {
                             .shapeConfig(o.getShapeConfig())
                             .sourceDetails(o.getSourceDetails())
                             .subnetId(o.getSubnetId())
-                            .isPvEncryptionInTransitEnabled(o.getIsPvEncryptionInTransitEnabled());
+                            .isPvEncryptionInTransitEnabled(o.getIsPvEncryptionInTransitEnabled())
+                            .platformConfig(o.getPlatformConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -530,6 +541,9 @@ public class LaunchInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
     Boolean isPvEncryptionInTransitEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("platformConfig")
+    LaunchInstancePlatformConfig platformConfig;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstancePlatformConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstancePlatformConfig.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The platform configuration requested for the instance.
+ * <p>
+ * If the parameter is provided, the instance is created with the platform configured as specified. If some
+ * properties are missing or the entire parameter is not provided, the instance is created
+ * with the default configuration values for the `shape` that you specify.
+ * <p>
+ * Each shape only supports certain configurable values. If the values that you provide are not valid for the
+ * specified `shape`, an error is returned.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type",
+    defaultImpl = LaunchInstancePlatformConfig.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AmdMilanBmLaunchInstancePlatformConfig.class,
+        name = "AMD_MILAN_BM"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class LaunchInstancePlatformConfig {
+
+    /**
+     * The type of platform being configured. The only supported
+     * `type` is `AMD_MILAN_BM`
+     *
+     **/
+    public enum Type {
+        AmdMilanBm("AMD_MILAN_BM"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Type> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Type v : Type.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Type create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Type: " + key);
+        }
+    };
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LocalPeeringGateway.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LocalPeeringGateway.java
@@ -9,11 +9,11 @@ package com.oracle.bmc.core.model;
  * with another VCN in the same region. *Peering* means that the two VCNs can
  * communicate using private IP addresses, but without the traffic traversing the
  * internet or routing through your on-premises network. For more information,
- * see [VCN Peering](https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm).
+ * see [VCN Peering](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/VCNpeering.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -411,7 +411,7 @@ public class LocalPeeringGateway {
      * The OCID of the route table the LPG is using.
      * <p>
      * For information about why you would associate a route table with an LPG, see
-     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm).
+     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitrouting.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")
@@ -427,7 +427,7 @@ public class LocalPeeringGateway {
     java.util.Date timeCreated;
 
     /**
-     * The OCID of the VCN the LPG belongs to.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN that uses the LPG.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
     String vcnId;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/NatGateway.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/NatGateway.java
@@ -8,13 +8,13 @@ package com.oracle.bmc.core.model;
  * A NAT (Network Address Translation) gateway, which represents a router that lets instances
  * without public IPs contact the public internet without exposing the instance to inbound
  * internet traffic. For more information, see
- * [NAT Gateway](https://docs.cloud.oracle.com/Content/Network/Tasks/NATgateway.htm).
+ * [NAT Gateway](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/NATgateway.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an
  * IAM policy. If you are not authorized, talk to an
  * administrator. If you are an administrator who needs to write
  * policies to give users access, see [Getting Started with
- * Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -183,7 +183,7 @@ public class NatGateway {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment that contains
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains
      * the NAT gateway.
      *
      **/
@@ -219,7 +219,7 @@ public class NatGateway {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the
      * NAT gateway.
      *
      **/
@@ -305,7 +305,7 @@ public class NatGateway {
     java.util.Date timeCreated;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN the NAT gateway
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN the NAT gateway
      * belongs to.
      *
      **/
@@ -313,7 +313,7 @@ public class NatGateway {
     String vcnId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP address associated with the NAT gateway.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP address associated with the NAT gateway.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicIpId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/NetworkSecurityGroup.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/NetworkSecurityGroup.java
@@ -42,7 +42,7 @@ package com.oracle.bmc.core.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -180,7 +180,7 @@ public class NetworkSecurityGroup {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment the network security group is in.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment the network security group is in.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
@@ -215,7 +215,7 @@ public class NetworkSecurityGroup {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -283,7 +283,7 @@ public class NetworkSecurityGroup {
     java.util.Date timeCreated;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group's VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group's VCN.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
     String vcnId;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/NetworkSecurityGroupVnic.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/NetworkSecurityGroupVnic.java
@@ -84,7 +84,7 @@ public class NetworkSecurityGroupVnic {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the parent resource that the VNIC
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the parent resource that the VNIC
      * is attached to (for example, a Compute instance).
      *
      **/
@@ -102,7 +102,7 @@ public class NetworkSecurityGroupVnic {
     java.util.Date timeAssociated;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VNIC.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VNIC.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vnicId")
     String vnicId;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/PlatformConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/PlatformConfig.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The platform configuration for the instance. The type of platform configuration is
+ * determined by the `type`.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type",
+    defaultImpl = PlatformConfig.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AmdMilanBmPlatformConfig.class,
+        name = "AMD_MILAN_BM"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class PlatformConfig {
+
+    /**
+     * The type of platform being configured. The only supported
+     * `type` is `AMD_MILAN_BM`
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Type {
+        AmdMilanBm("AMD_MILAN_BM"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Type> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Type v : Type.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Type create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Type', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/PrivateIp.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/PrivateIp.java
@@ -18,7 +18,7 @@ package com.oracle.bmc.core.model;
  * <p>
  * You can add *secondary private IPs* to a VNIC after it's created. For more
  * information, see the `privateIp` operations and also
- * [IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPaddresses.htm).
+ * [IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPaddresses.htm).
  * <p>
  **Note:** Only
  * {@link #listPrivateIps(ListPrivateIpsRequest) listPrivateIps} and
@@ -38,7 +38,7 @@ package com.oracle.bmc.core.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -281,7 +281,7 @@ public class PrivateIp {
      * [RFC 1123](https://tools.ietf.org/html/rfc1123).
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `bminstance-1`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/PublicIp.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/PublicIp.java
@@ -13,7 +13,7 @@ package com.oracle.bmc.core.model;
  * 2. Reserved
  * <p>
  * For more information and comparison of the two types,
- * see [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+ * see [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -422,7 +422,7 @@ public class PublicIp {
      * whenever you like. It does not need to be assigned to a private IP at all times.
      * <p>
      * For more information and comparison of the two types,
-     * see [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+     * see [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -482,7 +482,7 @@ public class PublicIp {
      * whenever you like. It does not need to be assigned to a private IP at all times.
      * <p>
      * For more information and comparison of the two types,
-     * see [Public IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingpublicIPs.htm).
+     * see [Public IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingpublicIPs.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifetime")
@@ -582,7 +582,7 @@ public class PublicIp {
     java.util.Date timeCreated;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the pool object created in the current tenancy.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the pool object created in the current tenancy.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("publicIpPoolId")
     String publicIpPoolId;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/PublicIpPool.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/PublicIpPool.java
@@ -146,7 +146,7 @@ public class PublicIpPool {
     java.util.List<String> cidrBlocks;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing this pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing this pool.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
@@ -181,7 +181,7 @@ public class PublicIpPool {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP pool.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/PublicIpPoolSummary.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/PublicIpPoolSummary.java
@@ -131,7 +131,7 @@ public class PublicIpPoolSummary {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment containing the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment containing the public IP pool.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
@@ -166,7 +166,7 @@ public class PublicIpPoolSummary {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP pool.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/RemotePeeringConnection.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/RemotePeeringConnection.java
@@ -9,11 +9,11 @@ package com.oracle.bmc.core.model;
  * to the DRG peer with a VCN in a different region. *Peering* means that the two VCNs can
  * communicate using private IP addresses, but without the traffic traversing the internet or
  * routing through your on-premises network. For more information, see
- * [VCN Peering](https://docs.cloud.oracle.com/Content/Network/Tasks/VCNpeering.htm).
+ * [VCN Peering](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/VCNpeering.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteRule.java
@@ -127,7 +127,7 @@ public class RouteRule {
      * IP address range in CIDR notation. Can be an IPv4 or IPv6 CIDR. For example: `192.168.1.0/24`
      *   or `2001:0db8:0123:45::/56`. If you set this to an IPv6 CIDR, the route rule's target
      *   can only be a DRG or internet gateway. Note that IPv6 addressing is currently supported
-     *   only in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     *   only in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
      *     setting up a route rule for traffic destined for a particular `Service` through
@@ -205,7 +205,7 @@ public class RouteRule {
     /**
      * The OCID for the route rule's target. For information about the type of
      * targets you can specify, see
-     * [Route Tables](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm).
+     * [Route Tables](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("networkEntityId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteTable.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/RouteTable.java
@@ -7,11 +7,11 @@ package com.oracle.bmc.core.model;
 /**
  * A collection of `RouteRule` objects, which are used to route packets
  * based on destination IP to a particular network entity. For more information, see
- * [Overview of the Networking Service](https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm).
+ * [Overview of the Networking Service](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/SecurityList.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/SecurityList.java
@@ -8,7 +8,7 @@ package com.oracle.bmc.core.model;
  * A set of virtual firewall rules for your VCN. Security lists are configured at the subnet
  * level, but the rules are applied to the ingress and egress traffic for the individual instances
  * in the subnet. The rules can be stateful or stateless. For more information, see
- * [Security Lists](https://docs.cloud.oracle.com/Content/Network/Concepts/securitylists.htm).
+ * [Security Lists](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/securitylists.htm).
  * **Note:** Compare security lists to {@link NetworkSecurityGroup}s,
  * which let you apply a set of security rules to a *specific set of VNICs* instead of an entire
  * subnet. Oracle recommends using network security groups instead of security lists, although you
@@ -21,7 +21,7 @@ package com.oracle.bmc.core.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/SecurityRule.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/SecurityRule.java
@@ -222,7 +222,7 @@ public class SecurityRule {
      * <p>
      * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
      *     Note that IPv6 addressing is currently supported only in certain regions. See
-     *     [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     *     [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
      *     setting up a security rule for traffic destined for a particular `Service` through
@@ -418,7 +418,7 @@ public class SecurityRule {
      * <p>
      * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
      *     Note that IPv6 addressing is currently supported only in certain regions. See
-     *     [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     *     [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
      *     setting up a security rule for traffic coming from a particular `Service` through

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Service.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Service.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.core.model;
 /**
  * An object that represents one or multiple Oracle services that you can enable for a
  * {@link ServiceGateway}. In the User Guide topic
- * [Access to Oracle Services: Service Gateway](https://docs.cloud.oracle.com/Content/Network/Tasks/servicegateway.htm), the
+ * [Access to Oracle Services: Service Gateway](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/servicegateway.htm), the
  * term *service CIDR label* is used to refer to the string that represents the regional public
  * IP address ranges of the Oracle service or services covered by a given `Service` object. That
  * unique string is the value of the `Service` object's `cidrBlock` attribute.
@@ -122,7 +122,7 @@ public class Service {
     String description;
 
     /**
-     * The `Service` object's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The `Service` object's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceGateway.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceGateway.java
@@ -11,11 +11,11 @@ package com.oracle.bmc.core.model;
  * routed through the service gateway and does not traverse the internet. The instances in the VCN
  * do not need to have public IP addresses nor be in a public subnet. The VCN does not need an internet gateway
  * for this traffic. For more information, see
- * [Access to Oracle Services: Service Gateway](https://docs.cloud.oracle.com/Content/Network/Tasks/servicegateway.htm).
+ * [Access to Oracle Services: Service Gateway](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/servicegateway.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -194,7 +194,7 @@ public class ServiceGateway {
     Boolean blockTraffic;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment that contains the
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment that contains the
      * service gateway.
      *
      **/
@@ -230,7 +230,7 @@ public class ServiceGateway {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the service gateway.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the service gateway.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
@@ -292,7 +292,7 @@ public class ServiceGateway {
     /**
      * The OCID of the route table the service gateway is using.
      * For information about why you would associate a route table with a service gateway, see
-     * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/Content/Network/Tasks/transitroutingoracleservices.htm).
+     * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitroutingoracleservices.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")
@@ -318,7 +318,7 @@ public class ServiceGateway {
     java.util.Date timeCreated;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN the service gateway
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN the service gateway
      * belongs to.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceIdRequestDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceIdRequestDetails.java
@@ -61,7 +61,7 @@ public class ServiceIdRequestDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the {@link Service}.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the {@link Service}.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceIdResponseDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/ServiceIdResponseDetails.java
@@ -71,7 +71,7 @@ public class ServiceIdResponseDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the service.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the service.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serviceId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Subnet.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Subnet.java
@@ -8,12 +8,12 @@ package com.oracle.bmc.core.model;
  * A logical subdivision of a VCN. Each subnet
  * consists of a contiguous range of IP addresses that do not overlap with
  * other subnets in the VCN. Example: 172.16.1.0/24. For more information, see
- * [Overview of the Networking Service](https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm) and
- * [VCNs and Subnets](https://docs.cloud.oracle.com/Content/Network/Tasks/managingVCNs.htm).
+ * [Overview of the Networking Service](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm) and
+ * [VCNs and Subnets](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingVCNs.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -352,7 +352,7 @@ public class Subnet {
      * will not resolve hostnames of instances in this subnet.
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `subnet123`
      *
@@ -379,7 +379,7 @@ public class Subnet {
     /**
      * For an IPv6-enabled subnet, this is the IPv6 CIDR block for the subnet's private IP address
      * space. The subnet size is always /64. Note that IPv6 addressing is currently supported only
-     * in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: `2001:0db8:0123:1111::/64`
      *
@@ -499,7 +499,7 @@ public class Subnet {
      * the VCN's DNS label, and the `oraclevcn.com` domain.
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `subnet123.vcn1.oraclevcn.com`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCpeDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateCpeDetails.java
@@ -120,7 +120,7 @@ public class UpdateCpeDetails {
     java.util.Map<String, String> freeformTags;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device type. You can provide
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the CPE device type. You can provide
      * a value if you want to generate CPE device configuration content for IPSec connections
      * that use this CPE. For a list of possible values, see
      * {@link #listCpeDeviceShapes(ListCpeDeviceShapesRequest) listCpeDeviceShapes}.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateDrgAttachmentDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateDrgAttachmentDetails.java
@@ -84,8 +84,8 @@ public class UpdateDrgAttachmentDetails {
      * <p>
      * For information about why you would associate a route table with a DRG attachment, see:
      * <p>
-     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm)
-     *   * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/Content/Network/Tasks/transitroutingoracleservices.htm)
+     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitrouting.htm)
+     *   * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitroutingoracleservices.htm)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecConnectionDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIPSecConnectionDetails.java
@@ -153,7 +153,7 @@ public class UpdateIPSecConnectionDetails {
      * to the value for `cpeLocalIdentifierType`.
      * <p>
      * For information about why you'd provide this value, see
-     * [If Your CPE Is Behind a NAT Device](https://docs.cloud.oracle.com/Content/Network/Tasks/overviewIPsec.htm#nat).
+     * [If Your CPE Is Behind a NAT Device](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/overviewIPsec.htm#nat).
      * <p>
      * Example IP address: `10.0.3.3`
      * <p>
@@ -211,7 +211,7 @@ public class UpdateIPSecConnectionDetails {
      * Static routes to the CPE. If you provide this attribute, it replaces the entire current set of
      * static routes. A static route's CIDR must not be a multicast address or class E address.
      * The CIDR can be either IPv4 or IPv6. Note that IPv6 addressing is currently supported only
-     * in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * in certain regions. See [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * Example: `10.0.1.0/24`
      * <p>

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIpv6Details.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateIpv6Details.java
@@ -151,7 +151,7 @@ public class UpdateIpv6Details {
     Boolean isInternetAccessAllowed;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VNIC to reassign the IPv6 to.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VNIC to reassign the IPv6 to.
      * The VNIC must be in the same subnet as the current VNIC.
      *
      **/

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateLocalPeeringGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateLocalPeeringGatewayDetails.java
@@ -126,7 +126,7 @@ public class UpdateLocalPeeringGatewayDetails {
      * The OCID of the route table the LPG will use.
      * <p>
      * For information about why you would associate a route table with an LPG, see
-     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/Content/Network/Tasks/transitrouting.htm).
+     * [Transit Routing: Access to Multiple VCNs in Same Region](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitrouting.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdatePrivateIpDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdatePrivateIpDetails.java
@@ -141,7 +141,7 @@ public class UpdatePrivateIpDetails {
      * [RFC 1123](https://tools.ietf.org/html/rfc1123).
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `bminstance-1`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateSecurityRuleDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateSecurityRuleDetails.java
@@ -200,7 +200,7 @@ public class UpdateSecurityRuleDetails {
      * <p>
      * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
      *     Note that IPv6 addressing is currently supported only in certain regions. See
-     *     [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     *     [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
      *     setting up a security rule for traffic destined for a particular `Service` through
@@ -364,7 +364,7 @@ public class UpdateSecurityRuleDetails {
      * <p>
      * An IP address range in CIDR notation. For example: `192.168.1.0/24` or `2001:0db8:0123:45::/56`
      *     Note that IPv6 addressing is currently supported only in certain regions. See
-     *     [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     *     [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * <p>
      * The `cidrBlock` value for a {@link Service}, if you're
      *     setting up a security rule for traffic coming from a particular `Service` through

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateServiceGatewayDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateServiceGatewayDetails.java
@@ -160,7 +160,7 @@ public class UpdateServiceGatewayDetails {
     /**
      * The OCID of the route table the service gateway will use.
      * For information about why you would associate a route table with a service gateway, see
-     * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/Content/Network/Tasks/transitroutingoracleservices.htm).
+     * [Transit Routing: Private Access to Oracle Services](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/transitroutingoracleservices.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVnicDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVnicDetails.java
@@ -160,7 +160,7 @@ public class UpdateVnicDetails {
      * {@link #getPrivateIp(GetPrivateIpRequest) getPrivateIp}.
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("hostnameLabel")
@@ -185,7 +185,7 @@ public class UpdateVnicDetails {
      * Whether the source/destination check is disabled on the VNIC.
      * Defaults to `false`, which means the check is performed. For information about why you would
      * skip the source/destination check, see
-     * [Using a Private IP as a Route Target](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip).
+     * [Using a Private IP as a Route Target](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm#privateip).
      * <p>
      * If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of
      * belonging to a subnet), the value of the `skipSourceDestCheck` attribute is ignored.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Vcn.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Vcn.java
@@ -6,11 +6,11 @@ package com.oracle.bmc.core.model;
 
 /**
  * A virtual cloud network (VCN). For more information, see
- * [Overview of the Networking Service](https://docs.cloud.oracle.com/Content/Network/Concepts/overview.htm).
+ * [Overview of the Networking Service](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/overview.htm).
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -303,7 +303,7 @@ public class Vcn {
      * not work for this VCN.
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `vcn1`
      *
@@ -333,7 +333,7 @@ public class Vcn {
      * provides one and uses that *same* CIDR for the `ipv6PublicCidrBlock`. If you do provide a
      * value, Oracle provides a *different* CIDR for the `ipv6PublicCidrBlock`. Note that IPv6
      * addressing is currently supported only in certain regions. See
-     * [IPv6 Addresses](https://docs.cloud.oracle.com/Content/Network/Concepts/ipv6.htm).
+     * [IPv6 Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/ipv6.htm).
      * Example: `2001:0db8:0123::/48`
      *
      **/
@@ -421,7 +421,7 @@ public class Vcn {
      * `oraclevcn.com` domain.
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `vcn1.oraclevcn.com`
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuit.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuit.java
@@ -11,7 +11,7 @@ package com.oracle.bmc.core.model;
  * network connections to provide a single, logical connection between the edge router
  * on the customer's existing network and Oracle Cloud Infrastructure. *Private*
  * virtual circuits support private peering, and *public* virtual circuits support
- * public peering. For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+ * public peering. For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
  * <p>
  * Each virtual circuit is made up of information shared between a customer, Oracle,
  * and a provider (if the customer is using FastConnect via a provider). Who fills in
@@ -23,7 +23,7 @@ package com.oracle.bmc.core.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -543,7 +543,7 @@ public class VirtualCircuit {
     /**
      * The virtual circuit's current state. For information about
      * the different states, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -598,7 +598,7 @@ public class VirtualCircuit {
     /**
      * The virtual circuit's current state. For information about
      * the different states, see
-     * [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
@@ -788,7 +788,7 @@ public class VirtualCircuit {
     java.util.Date timeCreated;
     /**
      * Whether the virtual circuit supports private or public peering. For more information,
-     * see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -835,7 +835,7 @@ public class VirtualCircuit {
     };
     /**
      * Whether the virtual circuit supports private or public peering. For more information,
-     * see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+     * see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuitPublicPrefix.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VirtualCircuitPublicPrefix.java
@@ -7,7 +7,7 @@ package com.oracle.bmc.core.model;
 /**
  * A public IP prefix and its details. With a public virtual circuit, the customer
  * specifies the customer-owned public IP prefixes to advertise across the connection.
- * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/Content/Network/Concepts/fastconnect.htm).
+ * For more information, see [FastConnect Overview](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/fastconnect.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Vnic.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Vnic.java
@@ -10,12 +10,12 @@ package com.oracle.bmc.core.model;
  * through that subnet. Each instance has a *primary VNIC* that is automatically
  * created and attached during launch. You can add *secondary VNICs* to an
  * instance after it's launched. For more information, see
- * [Virtual Network Interface Cards (VNICs)](https://docs.cloud.oracle.com/Content/Network/Tasks/managingVNICs.htm).
+ * [Virtual Network Interface Cards (VNICs)](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingVNICs.htm).
  * <p>
  * Each VNIC has a *primary private IP* that is automatically assigned during launch.
  * You can add *secondary private IPs* to a VNIC after it's created. For more
  * information, see {@link #createPrivateIp(CreatePrivateIpRequest) createPrivateIp} and
- * [IP Addresses](https://docs.cloud.oracle.com/Content/Network/Tasks/managingIPaddresses.htm).
+ * [IP Addresses](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingIPaddresses.htm).
  * <p>
  *
  * If you are an Oracle Cloud VMware Solution customer, you will have secondary VNICs
@@ -25,7 +25,7 @@ package com.oracle.bmc.core.model;
  * <p>
  * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
  * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
- * [Getting Started with Policies](https://docs.cloud.oracle.com/Content/Identity/Concepts/policygetstarted.htm).
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -311,7 +311,7 @@ public class Vnic {
      * [RFC 1123](https://tools.ietf.org/html/rfc1123).
      * <p>
      * For more information, see
-     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/Content/Network/Concepts/dns.htm).
+     * [DNS in Your Virtual Cloud Network](https://docs.cloud.oracle.com/iaas/Content/Network/Concepts/dns.htm).
      * <p>
      * Example: `bminstance-1`
      *
@@ -443,7 +443,7 @@ public class Vnic {
      * Whether the source/destination check is disabled on the VNIC.
      * Defaults to `false`, which means the check is performed. For information
      * about why you would skip the source/destination check, see
-     * [Using a Private IP as a Route Target](https://docs.cloud.oracle.com/Content/Network/Tasks/managingroutetables.htm#privateip).
+     * [Using a Private IP as a Route Target](https://docs.cloud.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm#privateip).
      * <p>
      *
      * If the VNIC belongs to a VLAN as part of the Oracle Cloud VMware Solution (instead of

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/AddNetworkSecurityGroupSecurityRulesRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/AddNetworkSecurityGroupSecurityRulesRequest.java
@@ -15,7 +15,7 @@ public class AddNetworkSecurityGroupSecurityRulesRequest
         extends com.oracle.bmc.requests.BmcRequest<AddNetworkSecurityGroupSecurityRulesDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      */
     private String networkSecurityGroupId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/AddPublicIpPoolCapacityRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/AddPublicIpPoolCapacityRequest.java
@@ -15,7 +15,7 @@ public class AddPublicIpPoolCapacityRequest
         extends com.oracle.bmc.requests.BmcRequest<AddPublicIpPoolCapacityDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP pool.
      */
     private String publicIpPoolId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/AddVcnCidrRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/AddVcnCidrRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class AddVcnCidrRequest extends com.oracle.bmc.requests.BmcRequest<AddVcnCidrDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/AdvertiseByoipRangeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/AdvertiseByoipRangeRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class AdvertiseByoipRangeRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
      */
     private String byoipRangeId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/AttachServiceIdRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/AttachServiceIdRequest.java
@@ -15,7 +15,7 @@ public class AttachServiceIdRequest
         extends com.oracle.bmc.requests.BmcRequest<ServiceIdRequestDetails> {
 
     /**
-     * The service gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The service gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String serviceGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeByoipRangeCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeByoipRangeCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeByoipRangeCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeByoipRangeCompartmentDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
      */
     private String byoipRangeId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeNatGatewayCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeNatGatewayCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeNatGatewayCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeNatGatewayCompartmentDetails> {
 
     /**
-     * The NAT gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The NAT gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String natGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeNetworkSecurityGroupCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeNetworkSecurityGroupCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeNetworkSecurityGroupCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeNetworkSecurityGroupCompartmentDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      */
     private String networkSecurityGroupId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangePublicIpPoolCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangePublicIpPoolCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangePublicIpPoolCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangePublicIpPoolCompartmentDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP pool.
      */
     private String publicIpPoolId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeServiceGatewayCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeServiceGatewayCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeServiceGatewayCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeServiceGatewayCompartmentDetails> {
 
     /**
-     * The service gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The service gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String serviceGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeVcnCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeVcnCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeVcnCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeVcnCompartmentDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeVlanCompartmentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ChangeVlanCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeVlanCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeVlanCompartmentDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VLAN.
      */
     private String vlanId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteByoipRangeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteByoipRangeRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class DeleteByoipRangeRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
      */
     private String byoipRangeId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteIpv6Request.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteIpv6Request.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class DeleteIpv6Request extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the IPv6.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the IPv6.
      */
     private String ipv6Id;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteNatGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteNatGatewayRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class DeleteNatGatewayRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The NAT gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The NAT gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String natGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteNetworkSecurityGroupRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteNetworkSecurityGroupRequest.java
@@ -15,7 +15,7 @@ public class DeleteNetworkSecurityGroupRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      */
     private String networkSecurityGroupId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeletePublicIpPoolRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeletePublicIpPoolRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class DeletePublicIpPoolRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP pool.
      */
     private String publicIpPoolId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteServiceGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteServiceGatewayRequest.java
@@ -15,7 +15,7 @@ public class DeleteServiceGatewayRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The service gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The service gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String serviceGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteVcnRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteVcnRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class DeleteVcnRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteVlanRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DeleteVlanRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class DeleteVlanRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VLAN.
      */
     private String vlanId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/DetachServiceIdRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/DetachServiceIdRequest.java
@@ -15,7 +15,7 @@ public class DetachServiceIdRequest
         extends com.oracle.bmc.requests.BmcRequest<ServiceIdRequestDetails> {
 
     /**
-     * The service gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The service gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String serviceGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetByoipRangeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetByoipRangeRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class GetByoipRangeRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
      */
     private String byoipRangeId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetCpeDeviceShapeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetCpeDeviceShapeRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class GetCpeDeviceShapeRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the CPE device shape.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the CPE device shape.
      */
     private String cpeDeviceShapeId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIPSecConnectionTunnelRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIPSecConnectionTunnelRequest.java
@@ -20,7 +20,7 @@ public class GetIPSecConnectionTunnelRequest
     private String ipscId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the tunnel.
      */
     private String tunnelId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIPSecConnectionTunnelSharedSecretRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIPSecConnectionTunnelSharedSecretRequest.java
@@ -20,7 +20,7 @@ public class GetIPSecConnectionTunnelSharedSecretRequest
     private String ipscId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the tunnel.
      */
     private String tunnelId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIpv6Request.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetIpv6Request.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class GetIpv6Request extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the IPv6.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the IPv6.
      */
     private String ipv6Id;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetNatGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetNatGatewayRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class GetNatGatewayRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The NAT gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The NAT gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String natGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetNetworkSecurityGroupRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetNetworkSecurityGroupRequest.java
@@ -15,7 +15,7 @@ public class GetNetworkSecurityGroupRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      */
     private String networkSecurityGroupId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetPublicIpPoolRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetPublicIpPoolRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class GetPublicIpPoolRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP pool.
      */
     private String publicIpPoolId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetServiceGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetServiceGatewayRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class GetServiceGatewayRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The service gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The service gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String serviceGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetServiceRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetServiceRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class GetServiceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The service's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The service's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String serviceId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetTunnelCpeDeviceConfigContentRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetTunnelCpeDeviceConfigContentRequest.java
@@ -20,7 +20,7 @@ public class GetTunnelCpeDeviceConfigContentRequest
     private String ipscId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the tunnel.
      */
     private String tunnelId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetTunnelCpeDeviceConfigRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetTunnelCpeDeviceConfigRequest.java
@@ -20,7 +20,7 @@ public class GetTunnelCpeDeviceConfigRequest
     private String ipscId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the tunnel.
      */
     private String tunnelId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVcnDnsResolverAssociationRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVcnDnsResolverAssociationRequest.java
@@ -15,7 +15,7 @@ public class GetVcnDnsResolverAssociationRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVcnRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVcnRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class GetVcnRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVlanRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVlanRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class GetVlanRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VLAN.
      */
     private String vlanId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListByoipAllocatedRangesRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListByoipAllocatedRangesRequest.java
@@ -15,7 +15,7 @@ public class ListByoipAllocatedRangesRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
      */
     private String byoipRangeId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListDhcpOptionsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListDhcpOptionsRequest.java
@@ -19,7 +19,7 @@ public class ListDhcpOptionsRequest extends com.oracle.bmc.requests.BmcRequest<j
     private String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListDrgAttachmentsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListDrgAttachmentsRequest.java
@@ -19,7 +19,7 @@ public class ListDrgAttachmentsRequest extends com.oracle.bmc.requests.BmcReques
     private String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListInternetGatewaysRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListInternetGatewaysRequest.java
@@ -20,7 +20,7 @@ public class ListInternetGatewaysRequest
     private String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListLocalPeeringGatewaysRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListLocalPeeringGatewaysRequest.java
@@ -38,7 +38,7 @@ public class ListLocalPeeringGatewaysRequest
     private String page;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListNatGatewaysRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListNatGatewaysRequest.java
@@ -19,7 +19,7 @@ public class ListNatGatewaysRequest extends com.oracle.bmc.requests.BmcRequest<j
     private String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListNetworkSecurityGroupSecurityRulesRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListNetworkSecurityGroupSecurityRulesRequest.java
@@ -15,7 +15,7 @@ public class ListNetworkSecurityGroupSecurityRulesRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      */
     private String networkSecurityGroupId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListNetworkSecurityGroupVnicsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListNetworkSecurityGroupVnicsRequest.java
@@ -15,7 +15,7 @@ public class ListNetworkSecurityGroupVnicsRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      */
     private String networkSecurityGroupId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListNetworkSecurityGroupsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListNetworkSecurityGroupsRequest.java
@@ -20,7 +20,7 @@ public class ListNetworkSecurityGroupsRequest
     private String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListPrivateIpsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListPrivateIpsRequest.java
@@ -49,7 +49,7 @@ public class ListPrivateIpsRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String vnicId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VLAN.
      */
     private String vlanId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListRouteTablesRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListRouteTablesRequest.java
@@ -37,7 +37,7 @@ public class ListRouteTablesRequest extends com.oracle.bmc.requests.BmcRequest<j
     private String page;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListSecurityListsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListSecurityListsRequest.java
@@ -37,7 +37,7 @@ public class ListSecurityListsRequest extends com.oracle.bmc.requests.BmcRequest
     private String page;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListServiceGatewaysRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListServiceGatewaysRequest.java
@@ -19,7 +19,7 @@ public class ListServiceGatewaysRequest extends com.oracle.bmc.requests.BmcReque
     private String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListSubnetsRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListSubnetsRequest.java
@@ -37,7 +37,7 @@ public class ListSubnetsRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String page;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListVlansRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListVlansRequest.java
@@ -19,7 +19,7 @@ public class ListVlansRequest extends com.oracle.bmc.requests.BmcRequest<java.la
     private String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ModifyVcnCidrRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ModifyVcnCidrRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class ModifyVcnCidrRequest extends com.oracle.bmc.requests.BmcRequest<ModifyVcnCidrDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/RemoveNetworkSecurityGroupSecurityRulesRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/RemoveNetworkSecurityGroupSecurityRulesRequest.java
@@ -15,7 +15,7 @@ public class RemoveNetworkSecurityGroupSecurityRulesRequest
         extends com.oracle.bmc.requests.BmcRequest<RemoveNetworkSecurityGroupSecurityRulesDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      */
     private String networkSecurityGroupId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/RemovePublicIpPoolCapacityRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/RemovePublicIpPoolCapacityRequest.java
@@ -15,7 +15,7 @@ public class RemovePublicIpPoolCapacityRequest
         extends com.oracle.bmc.requests.BmcRequest<RemovePublicIpPoolCapacityDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP pool.
      */
     private String publicIpPoolId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/RemoveVcnCidrRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/RemoveVcnCidrRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class RemoveVcnCidrRequest extends com.oracle.bmc.requests.BmcRequest<RemoveVcnCidrDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateByoipRangeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateByoipRangeRequest.java
@@ -15,7 +15,7 @@ public class UpdateByoipRangeRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateByoipRangeDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
      */
     private String byoipRangeId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIPSecConnectionTunnelRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIPSecConnectionTunnelRequest.java
@@ -20,7 +20,7 @@ public class UpdateIPSecConnectionTunnelRequest
     private String ipscId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the tunnel.
      */
     private String tunnelId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIPSecConnectionTunnelSharedSecretRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIPSecConnectionTunnelSharedSecretRequest.java
@@ -20,7 +20,7 @@ public class UpdateIPSecConnectionTunnelSharedSecretRequest
     private String ipscId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the tunnel.
      */
     private String tunnelId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIpv6Request.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateIpv6Request.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class UpdateIpv6Request extends com.oracle.bmc.requests.BmcRequest<UpdateIpv6Details> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the IPv6.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the IPv6.
      */
     private String ipv6Id;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateNatGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateNatGatewayRequest.java
@@ -15,7 +15,7 @@ public class UpdateNatGatewayRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateNatGatewayDetails> {
 
     /**
-     * The NAT gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The NAT gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String natGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateNetworkSecurityGroupRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateNetworkSecurityGroupRequest.java
@@ -15,7 +15,7 @@ public class UpdateNetworkSecurityGroupRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateNetworkSecurityGroupDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      */
     private String networkSecurityGroupId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateNetworkSecurityGroupSecurityRulesRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateNetworkSecurityGroupSecurityRulesRequest.java
@@ -15,7 +15,7 @@ public class UpdateNetworkSecurityGroupSecurityRulesRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateNetworkSecurityGroupSecurityRulesDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the network security group.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the network security group.
      */
     private String networkSecurityGroupId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdatePublicIpPoolRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdatePublicIpPoolRequest.java
@@ -15,7 +15,7 @@ public class UpdatePublicIpPoolRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdatePublicIpPoolDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the public IP pool.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the public IP pool.
      */
     private String publicIpPoolId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateServiceGatewayRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateServiceGatewayRequest.java
@@ -15,7 +15,7 @@ public class UpdateServiceGatewayRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateServiceGatewayDetails> {
 
     /**
-     * The service gateway's [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * The service gateway's [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
      */
     private String serviceGatewayId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateTunnelCpeDeviceConfigRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateTunnelCpeDeviceConfigRequest.java
@@ -20,7 +20,7 @@ public class UpdateTunnelCpeDeviceConfigRequest
     private String ipscId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the tunnel.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the tunnel.
      */
     private String tunnelId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVcnRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVcnRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class UpdateVcnRequest extends com.oracle.bmc.requests.BmcRequest<UpdateVcnDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
      */
     private String vcnId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVlanRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVlanRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class UpdateVlanRequest extends com.oracle.bmc.requests.BmcRequest<UpdateVlanDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VLAN.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VLAN.
      */
     private String vlanId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ValidateByoipRangeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ValidateByoipRangeRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class ValidateByoipRangeRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
      */
     private String byoipRangeId;
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/WithdrawByoipRangeRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/WithdrawByoipRangeRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.core.model.*;
 public class WithdrawByoipRangeRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the `ByoipRange` resource containing the BYOIP CIDR block.
      */
     private String byoipRangeId;
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -309,6 +309,10 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasemanagement</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-artifacts</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.32.1</version>
+        <version>1.32.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -278,6 +278,10 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-databasemanagement</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-artifacts</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/Optimizer.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/Optimizer.java
@@ -190,6 +190,18 @@ public interface Optimizer extends AutoCloseable {
     ListProfilesResponse listProfiles(ListProfilesRequest request);
 
     /**
+     * Lists the existing strategies.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/optimizer/ListRecommendationStrategiesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListRecommendationStrategies API.
+     */
+    ListRecommendationStrategiesResponse listRecommendationStrategies(
+            ListRecommendationStrategiesRequest request);
+
+    /**
      * Lists the Cloud Advisor recommendations that are currently supported in the specified category.
      *
      * @param request The request object containing the details to send

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/OptimizerAsync.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/OptimizerAsync.java
@@ -257,6 +257,24 @@ public interface OptimizerAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Lists the existing strategies.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListRecommendationStrategiesResponse> listRecommendationStrategies(
+            ListRecommendationStrategiesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListRecommendationStrategiesRequest,
+                            ListRecommendationStrategiesResponse>
+                    handler);
+
+    /**
      * Lists the Cloud Advisor recommendations that are currently supported in the specified category.
      *
      *

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/OptimizerAsyncClient.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/OptimizerAsyncClient.java
@@ -871,6 +871,50 @@ public class OptimizerAsyncClient implements OptimizerAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListRecommendationStrategiesResponse>
+            listRecommendationStrategies(
+                    ListRecommendationStrategiesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListRecommendationStrategiesRequest,
+                                    ListRecommendationStrategiesResponse>
+                            handler) {
+        LOG.trace("Called async listRecommendationStrategies");
+        final ListRecommendationStrategiesRequest interceptedRequest =
+                ListRecommendationStrategiesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListRecommendationStrategiesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListRecommendationStrategiesResponse>
+                transformer = ListRecommendationStrategiesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListRecommendationStrategiesRequest, ListRecommendationStrategiesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListRecommendationStrategiesRequest,
+                                ListRecommendationStrategiesResponse>,
+                        java.util.concurrent.Future<ListRecommendationStrategiesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListRecommendationStrategiesRequest, ListRecommendationStrategiesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListRecommendationsResponse> listRecommendations(
             ListRecommendationsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/OptimizerClient.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/OptimizerClient.java
@@ -817,6 +817,36 @@ public class OptimizerClient implements Optimizer {
     }
 
     @Override
+    public ListRecommendationStrategiesResponse listRecommendationStrategies(
+            ListRecommendationStrategiesRequest request) {
+        LOG.trace("Called listRecommendationStrategies");
+        final ListRecommendationStrategiesRequest interceptedRequest =
+                ListRecommendationStrategiesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListRecommendationStrategiesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListRecommendationStrategiesResponse>
+                transformer = ListRecommendationStrategiesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListRecommendationsResponse listRecommendations(ListRecommendationsRequest request) {
         LOG.trace("Called listRecommendations");
         final ListRecommendationsRequest interceptedRequest =

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/OptimizerPaginators.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/OptimizerPaginators.java
@@ -479,6 +479,130 @@ public class OptimizerPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listRecommendationStrategies operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListRecommendationStrategiesResponse>
+            listRecommendationStrategiesResponseIterator(
+                    final ListRecommendationStrategiesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListRecommendationStrategiesRequest.Builder, ListRecommendationStrategiesRequest,
+                ListRecommendationStrategiesResponse>(
+                new com.google.common.base.Supplier<ListRecommendationStrategiesRequest.Builder>() {
+                    @Override
+                    public ListRecommendationStrategiesRequest.Builder get() {
+                        return ListRecommendationStrategiesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRecommendationStrategiesResponse, String>() {
+                    @Override
+                    public String apply(ListRecommendationStrategiesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListRecommendationStrategiesRequest.Builder>,
+                        ListRecommendationStrategiesRequest>() {
+                    @Override
+                    public ListRecommendationStrategiesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListRecommendationStrategiesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRecommendationStrategiesRequest,
+                        ListRecommendationStrategiesResponse>() {
+                    @Override
+                    public ListRecommendationStrategiesResponse apply(
+                            ListRecommendationStrategiesRequest request) {
+                        return client.listRecommendationStrategies(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.optimizer.model.RecommendationStrategySummary} objects
+     * contained in responses from the listRecommendationStrategies operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.optimizer.model.RecommendationStrategySummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.optimizer.model.RecommendationStrategySummary>
+            listRecommendationStrategiesRecordIterator(
+                    final ListRecommendationStrategiesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListRecommendationStrategiesRequest.Builder, ListRecommendationStrategiesRequest,
+                ListRecommendationStrategiesResponse,
+                com.oracle.bmc.optimizer.model.RecommendationStrategySummary>(
+                new com.google.common.base.Supplier<ListRecommendationStrategiesRequest.Builder>() {
+                    @Override
+                    public ListRecommendationStrategiesRequest.Builder get() {
+                        return ListRecommendationStrategiesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRecommendationStrategiesResponse, String>() {
+                    @Override
+                    public String apply(ListRecommendationStrategiesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListRecommendationStrategiesRequest.Builder>,
+                        ListRecommendationStrategiesRequest>() {
+                    @Override
+                    public ListRecommendationStrategiesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListRecommendationStrategiesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRecommendationStrategiesRequest,
+                        ListRecommendationStrategiesResponse>() {
+                    @Override
+                    public ListRecommendationStrategiesResponse apply(
+                            ListRecommendationStrategiesRequest request) {
+                        return client.listRecommendationStrategies(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRecommendationStrategiesResponse,
+                        java.util.List<
+                                com.oracle.bmc.optimizer.model.RecommendationStrategySummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.optimizer.model.RecommendationStrategySummary>
+                            apply(ListRecommendationStrategiesResponse response) {
+                        return response.getRecommendationStrategyCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listRecommendations operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/internal/http/ListRecommendationStrategiesConverter.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/internal/http/ListRecommendationStrategiesConverter.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.optimizer.model.*;
+import com.oracle.bmc.optimizer.requests.*;
+import com.oracle.bmc.optimizer.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.extern.slf4j.Slf4j
+public class ListRecommendationStrategiesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.optimizer.requests.ListRecommendationStrategiesRequest
+            interceptRequest(
+                    com.oracle.bmc.optimizer.requests.ListRecommendationStrategiesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.optimizer.requests.ListRecommendationStrategiesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+        Validate.notNull(request.getCompartmentIdInSubtree(), "compartmentIdInSubtree is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20200606").path("recommendationStrategies");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        target =
+                target.queryParam(
+                        "compartmentIdInSubtree",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentIdInSubtree()));
+
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getRecommendationName() != null) {
+            target =
+                    target.queryParam(
+                            "recommendationName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getRecommendationName()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.optimizer.responses.ListRecommendationStrategiesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.optimizer.responses.ListRecommendationStrategiesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.optimizer.responses
+                                        .ListRecommendationStrategiesResponse>() {
+                            @Override
+                            public com.oracle.bmc.optimizer.responses
+                                            .ListRecommendationStrategiesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.optimizer.responses.ListRecommendationStrategiesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        RecommendationStrategyCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        RecommendationStrategyCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                RecommendationStrategyCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.optimizer.responses
+                                                .ListRecommendationStrategiesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.optimizer.responses
+                                                        .ListRecommendationStrategiesResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.recommendationStrategyCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.optimizer.responses
+                                                .ListRecommendationStrategiesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Action.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Action.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * Details about the recommended action.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/BulkApplyRecommendationsDetails.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/BulkApplyRecommendationsDetails.java
@@ -35,6 +35,15 @@ public class BulkApplyRecommendationsDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("actions")
+        private java.util.List<BulkApplyResourceAction> actions;
+
+        public Builder actions(java.util.List<BulkApplyResourceAction> actions) {
+            this.actions = actions;
+            this.__explicitlySet__.add("actions");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("status")
         private Status status;
 
@@ -58,7 +67,8 @@ public class BulkApplyRecommendationsDetails {
 
         public BulkApplyRecommendationsDetails build() {
             BulkApplyRecommendationsDetails __instance__ =
-                    new BulkApplyRecommendationsDetails(resourceActionIds, status, timeStatusEnd);
+                    new BulkApplyRecommendationsDetails(
+                            resourceActionIds, actions, status, timeStatusEnd);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -67,6 +77,7 @@ public class BulkApplyRecommendationsDetails {
         public Builder copy(BulkApplyRecommendationsDetails o) {
             Builder copiedBuilder =
                     resourceActionIds(o.getResourceActionIds())
+                            .actions(o.getActions())
                             .status(o.getStatus())
                             .timeStatusEnd(o.getTimeStatusEnd());
 
@@ -84,9 +95,18 @@ public class BulkApplyRecommendationsDetails {
 
     /**
      * The unique OCIDs of the resource actions that recommendations are applied to.
+     * <p>
+     * This field is deprecated.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resourceActionIds")
     java.util.List<String> resourceActionIds;
+
+    /**
+     * The unique resource actions that recommendations are applied to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("actions")
+    java.util.List<BulkApplyResourceAction> actions;
 
     /**
      * The current status of the recommendation.

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/BulkApplyResourceAction.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/BulkApplyResourceAction.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * The resource action that a recommendation will be applied to.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = BulkApplyResourceAction.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BulkApplyResourceAction {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceActionId")
+        private String resourceActionId;
+
+        public Builder resourceActionId(String resourceActionId) {
+            this.resourceActionId = resourceActionId;
+            this.__explicitlySet__.add("resourceActionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStatusEnd")
+        private java.util.Date timeStatusEnd;
+
+        public Builder timeStatusEnd(java.util.Date timeStatusEnd) {
+            this.timeStatusEnd = timeStatusEnd;
+            this.__explicitlySet__.add("timeStatusEnd");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.Map<String, Object> parameters;
+
+        public Builder parameters(java.util.Map<String, Object> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("strategyName")
+        private String strategyName;
+
+        public Builder strategyName(String strategyName) {
+            this.strategyName = strategyName;
+            this.__explicitlySet__.add("strategyName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BulkApplyResourceAction build() {
+            BulkApplyResourceAction __instance__ =
+                    new BulkApplyResourceAction(
+                            resourceActionId, status, timeStatusEnd, parameters, strategyName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BulkApplyResourceAction o) {
+            Builder copiedBuilder =
+                    resourceActionId(o.getResourceActionId())
+                            .status(o.getStatus())
+                            .timeStatusEnd(o.getTimeStatusEnd())
+                            .parameters(o.getParameters())
+                            .strategyName(o.getStrategyName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique OCIDs of the resource actions that recommendations are applied to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceActionId")
+    String resourceActionId;
+
+    /**
+     * The current status of the recommendation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    Status status;
+
+    /**
+     * The date and time the current status will change. The format is defined by RFC3339.
+     * <p>
+     * For example, \"The current `postponed` status of the resource action will end and change to `pending` on this
+     * date and time.\"
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStatusEnd")
+    java.util.Date timeStatusEnd;
+
+    /**
+     * Additional parameter key-value pairs defining the resource action.
+     * For example:
+     * <p>
+     * `{\"timeAmount\": 15, \"timeUnit\": \"seconds\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+    java.util.Map<String, Object> parameters;
+
+    /**
+     * The name of the strategy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("strategyName")
+    String strategyName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Category.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Category.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the category.
- * <p>
- **Caution:** Avoid using any confidential information when you supply string values using the API.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -177,13 +175,13 @@ public class Category {
     String compartmentId;
 
     /**
-     * The name assigned to the category.
+     * The name assigned to the category. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Text describing the category.
+     * Text describing the category. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/CategorySummary.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/CategorySummary.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the category summary.
- * <p>
- **Caution:** Avoid using any confidential information when you supply string values using the API.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -177,13 +175,13 @@ public class CategorySummary {
     String compartmentId;
 
     /**
-     * The name assigned to the category.
+     * The name assigned to the category. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Text describing the category.
+     * Text describing the category. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/CreateProfileDetails.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/CreateProfileDetails.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * Details for creating a profile.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -84,6 +82,24 @@ public class CreateProfileDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("targetCompartments")
+        private TargetCompartments targetCompartments;
+
+        public Builder targetCompartments(TargetCompartments targetCompartments) {
+            this.targetCompartments = targetCompartments;
+            this.__explicitlySet__.add("targetCompartments");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetTags")
+        private TargetTags targetTags;
+
+        public Builder targetTags(TargetTags targetTags) {
+            this.targetTags = targetTags;
+            this.__explicitlySet__.add("targetTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -95,7 +111,9 @@ public class CreateProfileDetails {
                             description,
                             definedTags,
                             freeformTags,
-                            levelsConfiguration);
+                            levelsConfiguration,
+                            targetCompartments,
+                            targetTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -108,7 +126,9 @@ public class CreateProfileDetails {
                             .description(o.getDescription())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags())
-                            .levelsConfiguration(o.getLevelsConfiguration());
+                            .levelsConfiguration(o.getLevelsConfiguration())
+                            .targetCompartments(o.getTargetCompartments())
+                            .targetTags(o.getTargetTags());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -129,13 +149,13 @@ public class CreateProfileDetails {
     String compartmentId;
 
     /**
-     * The name assigned to the profile.
+     * The name assigned to the profile. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Text describing the profile.
+     * Text describing the profile. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
@@ -162,6 +182,12 @@ public class CreateProfileDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("levelsConfiguration")
     LevelsConfiguration levelsConfiguration;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetCompartments")
+    TargetCompartments targetCompartments;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetTags")
+    TargetTags targetTags;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/EnrollmentStatus.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/EnrollmentStatus.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the enrollment status.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/EnrollmentStatusSummary.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/EnrollmentStatusSummary.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the enrollment status summary.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/HistorySummary.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/HistorySummary.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the recommendation history and its related resources.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Profile.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Profile.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the profile.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -91,6 +89,24 @@ public class Profile {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("targetCompartments")
+        private TargetCompartments targetCompartments;
+
+        public Builder targetCompartments(TargetCompartments targetCompartments) {
+            this.targetCompartments = targetCompartments;
+            this.__explicitlySet__.add("targetCompartments");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetTags")
+        private TargetTags targetTags;
+
+        public Builder targetTags(TargetTags targetTags) {
+            this.targetTags = targetTags;
+            this.__explicitlySet__.add("targetTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleState lifecycleState;
 
@@ -131,6 +147,8 @@ public class Profile {
                             definedTags,
                             freeformTags,
                             levelsConfiguration,
+                            targetCompartments,
+                            targetTags,
                             lifecycleState,
                             timeCreated,
                             timeUpdated);
@@ -148,6 +166,8 @@ public class Profile {
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags())
                             .levelsConfiguration(o.getLevelsConfiguration())
+                            .targetCompartments(o.getTargetCompartments())
+                            .targetTags(o.getTargetTags())
                             .lifecycleState(o.getLifecycleState())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated());
@@ -177,13 +197,13 @@ public class Profile {
     String compartmentId;
 
     /**
-     * The name assigned to the profile.
+     * The name assigned to the profile. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
 
     /**
-     * Text describing the profile.
+     * Text describing the profile. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
@@ -210,6 +230,12 @@ public class Profile {
 
     @com.fasterxml.jackson.annotation.JsonProperty("levelsConfiguration")
     LevelsConfiguration levelsConfiguration;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetCompartments")
+    TargetCompartments targetCompartments;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetTags")
+    TargetTags targetTags;
 
     /**
      * The profile's current state.

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/ProfileSummary.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/ProfileSummary.java
@@ -98,6 +98,24 @@ public class ProfileSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("targetCompartments")
+        private TargetCompartments targetCompartments;
+
+        public Builder targetCompartments(TargetCompartments targetCompartments) {
+            this.targetCompartments = targetCompartments;
+            this.__explicitlySet__.add("targetCompartments");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetTags")
+        private TargetTags targetTags;
+
+        public Builder targetTags(TargetTags targetTags) {
+            this.targetTags = targetTags;
+            this.__explicitlySet__.add("targetTags");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -130,6 +148,8 @@ public class ProfileSummary {
                             freeformTags,
                             lifecycleState,
                             levelsConfiguration,
+                            targetCompartments,
+                            targetTags,
                             timeCreated,
                             timeUpdated);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -147,6 +167,8 @@ public class ProfileSummary {
                             .freeformTags(o.getFreeformTags())
                             .lifecycleState(o.getLifecycleState())
                             .levelsConfiguration(o.getLevelsConfiguration())
+                            .targetCompartments(o.getTargetCompartments())
+                            .targetTags(o.getTargetTags())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated());
 
@@ -214,6 +236,12 @@ public class ProfileSummary {
 
     @com.fasterxml.jackson.annotation.JsonProperty("levelsConfiguration")
     LevelsConfiguration levelsConfiguration;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetCompartments")
+    TargetCompartments targetCompartments;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetTags")
+    TargetTags targetTags;
 
     /**
      * The date and time the profile was created, in the format defined by RFC3339.

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Recommendation.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Recommendation.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the recommendation.
- * <p>
- **Caution:** Avoid using any confidential information when you supply string values using the API.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/RecommendationStrategyCollection.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/RecommendationStrategyCollection.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * A list of strategies that match filter criteria, if any. Results contain `RecommendationStrategySummary` objects.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RecommendationStrategyCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RecommendationStrategyCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<RecommendationStrategySummary> items;
+
+        public Builder items(java.util.List<RecommendationStrategySummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RecommendationStrategyCollection build() {
+            RecommendationStrategyCollection __instance__ =
+                    new RecommendationStrategyCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RecommendationStrategyCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A collection of recommendation strategy summaries.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<RecommendationStrategySummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/RecommendationStrategySummary.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/RecommendationStrategySummary.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * The metadata associated with the recommendation strategy.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RecommendationStrategySummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RecommendationStrategySummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("strategies")
+        private java.util.List<Strategy> strategies;
+
+        public Builder strategies(java.util.List<Strategy> strategies) {
+            this.strategies = strategies;
+            this.__explicitlySet__.add("strategies");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RecommendationStrategySummary build() {
+            RecommendationStrategySummary __instance__ =
+                    new RecommendationStrategySummary(name, strategies);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RecommendationStrategySummary o) {
+            Builder copiedBuilder = name(o.getName()).strategies(o.getStrategies());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The display name of the recommendation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The list of strategies used.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("strategies")
+    java.util.List<Strategy> strategies;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/RecommendationSummary.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/RecommendationSummary.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the recommendation summary.
- * <p>
- **Caution:** Avoid using any confidential information when you supply string values using the API.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/ResourceAction.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/ResourceAction.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the resource action.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/ResourceActionSummary.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/ResourceActionSummary.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The metadata associated with the resource action summary.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Strategy.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/Strategy.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * The metadata associated with the strategy. The strategy is the method used to apply the recommendation.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Strategy.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Strategy {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("strategyName")
+        private String strategyName;
+
+        public Builder strategyName(String strategyName) {
+            this.strategyName = strategyName;
+            this.__explicitlySet__.add("strategyName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
+        private Boolean isDefault;
+
+        public Builder isDefault(Boolean isDefault) {
+            this.isDefault = isDefault;
+            this.__explicitlySet__.add("isDefault");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parametersDefinition")
+        private java.util.List<StrategyParameter> parametersDefinition;
+
+        public Builder parametersDefinition(
+                java.util.List<StrategyParameter> parametersDefinition) {
+            this.parametersDefinition = parametersDefinition;
+            this.__explicitlySet__.add("parametersDefinition");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Strategy build() {
+            Strategy __instance__ = new Strategy(strategyName, isDefault, parametersDefinition);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Strategy o) {
+            Builder copiedBuilder =
+                    strategyName(o.getStrategyName())
+                            .isDefault(o.getIsDefault())
+                            .parametersDefinition(o.getParametersDefinition());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the strategy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("strategyName")
+    String strategyName;
+
+    /**
+     * Whether this is the default recommendation strategy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
+    Boolean isDefault;
+
+    /**
+     * The list of strategies for the parameters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parametersDefinition")
+    java.util.List<StrategyParameter> parametersDefinition;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/StrategyParameter.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/StrategyParameter.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * The metadata associated with the strategy parameter.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = StrategyParameter.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class StrategyParameter {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private StrategyParameterType type;
+
+        public Builder type(StrategyParameterType type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isRequired")
+        private Boolean isRequired;
+
+        public Builder isRequired(Boolean isRequired) {
+            this.isRequired = isRequired;
+            this.__explicitlySet__.add("isRequired");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+        private Object defaultValue;
+
+        public Builder defaultValue(Object defaultValue) {
+            this.defaultValue = defaultValue;
+            this.__explicitlySet__.add("defaultValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("possibleValues")
+        private java.util.List<Object> possibleValues;
+
+        public Builder possibleValues(java.util.List<Object> possibleValues) {
+            this.possibleValues = possibleValues;
+            this.__explicitlySet__.add("possibleValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public StrategyParameter build() {
+            StrategyParameter __instance__ =
+                    new StrategyParameter(
+                            name, type, description, isRequired, defaultValue, possibleValues);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(StrategyParameter o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .type(o.getType())
+                            .description(o.getDescription())
+                            .isRequired(o.getIsRequired())
+                            .defaultValue(o.getDefaultValue())
+                            .possibleValues(o.getPossibleValues());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the strategy parameter.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The type of strategy parameter.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    StrategyParameterType type;
+
+    /**
+     * Text describing the strategy parameter.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Whether this parameter is required.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isRequired")
+    Boolean isRequired;
+
+    /**
+     * A default value used for the strategy parameter.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+    Object defaultValue;
+
+    /**
+     * The list of possible values used for these strategy parameters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("possibleValues")
+    java.util.List<Object> possibleValues;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/StrategyParameterType.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/StrategyParameterType.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * Possible strategy types.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.extern.slf4j.Slf4j
+public enum StrategyParameterType {
+    String("STRING"),
+    Boolean("BOOLEAN"),
+    Number("NUMBER"),
+    Datetime("DATETIME"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, StrategyParameterType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (StrategyParameterType v : StrategyParameterType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    StrategyParameterType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static StrategyParameterType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'StrategyParameterType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/TagValueType.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/TagValueType.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * Specifies which tag value types in the TagValues field result in overrides of the recommendation criteria. Allowed values are ANY and VALUE.
+ * <p>
+ * When the TagValueType field value is ANY, the TagValues field should be empty which will in turn enforce overrides to the recommendation for resources with any tag values attached to them.
+ * When the TagValueType field value is VALUE, the TagValues field must include a specific value or list of values. Overrides to the recommendation criteria only occur for resources that match the values in the TagKey and in the TagValues fields.
+ * <p>
+ * For example, if the TagKey value is B, the TagValueType value is ANY, and the TagValues field is empty, overrides to the recommendation criteria occur for any resources that have the tag key B.
+ * If the TagKey value is B, the TagValueType value is VALUE, and the TagValues value is s1, overrides to the recommendation criteria only occur for resources that have the tag key B with the associated tag value s1.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.extern.slf4j.Slf4j
+public enum TagValueType {
+    Value("VALUE"),
+    Any("ANY"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, TagValueType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (TagValueType v : TagValueType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    TagValueType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static TagValueType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'TagValueType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/TargetCompartments.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/TargetCompartments.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * Optional. The target compartments supported by a profile override for a recommendation.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TargetCompartments.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TargetCompartments {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<String> items;
+
+        public Builder items(java.util.List<String> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TargetCompartments build() {
+            TargetCompartments __instance__ = new TargetCompartments(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TargetCompartments o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The list of target compartment OCIDs attached to the current profile override.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<String> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/TargetTag.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/TargetTag.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * A target tag with tag namespace, tag definition, tag value type, and tag values attached to the current profile override.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TargetTag.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TargetTag {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("tagNamespaceName")
+        private String tagNamespaceName;
+
+        public Builder tagNamespaceName(String tagNamespaceName) {
+            this.tagNamespaceName = tagNamespaceName;
+            this.__explicitlySet__.add("tagNamespaceName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("tagDefinitionName")
+        private String tagDefinitionName;
+
+        public Builder tagDefinitionName(String tagDefinitionName) {
+            this.tagDefinitionName = tagDefinitionName;
+            this.__explicitlySet__.add("tagDefinitionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("tagValueType")
+        private TagValueType tagValueType;
+
+        public Builder tagValueType(TagValueType tagValueType) {
+            this.tagValueType = tagValueType;
+            this.__explicitlySet__.add("tagValueType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("tagValues")
+        private java.util.List<String> tagValues;
+
+        public Builder tagValues(java.util.List<String> tagValues) {
+            this.tagValues = tagValues;
+            this.__explicitlySet__.add("tagValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TargetTag build() {
+            TargetTag __instance__ =
+                    new TargetTag(tagNamespaceName, tagDefinitionName, tagValueType, tagValues);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TargetTag o) {
+            Builder copiedBuilder =
+                    tagNamespaceName(o.getTagNamespaceName())
+                            .tagDefinitionName(o.getTagDefinitionName())
+                            .tagValueType(o.getTagValueType())
+                            .tagValues(o.getTagValues());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the tag namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tagNamespaceName")
+    String tagNamespaceName;
+
+    /**
+     * The name of the tag definition.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tagDefinitionName")
+    String tagDefinitionName;
+
+    /**
+     * The tag value type.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tagValueType")
+    TagValueType tagValueType;
+
+    /**
+     * The list of tag values.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tagValues")
+    java.util.List<String> tagValues;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/TargetTags.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/TargetTags.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.model;
+
+/**
+ * Optional. The target tags supported by a profile override for a recommendation.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TargetTags.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TargetTags {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<TargetTag> items;
+
+        public Builder items(java.util.List<TargetTag> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TargetTags build() {
+            TargetTags __instance__ = new TargetTags(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TargetTags o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The list of target tags attached to the current profile override.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<TargetTag> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/UpdateEnrollmentStatusDetails.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/UpdateEnrollmentStatusDetails.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * The request object for updating the enrollment status details.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/UpdateProfileDetails.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/model/UpdateProfileDetails.java
@@ -6,8 +6,6 @@ package com.oracle.bmc.optimizer.model;
 
 /**
  * Details for updating a profile.
- * <p>
- **Caution:** Avoid using any confidential information when you use the API to supply string values.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -66,13 +64,46 @@ public class UpdateProfileDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("targetCompartments")
+        private TargetCompartments targetCompartments;
+
+        public Builder targetCompartments(TargetCompartments targetCompartments) {
+            this.targetCompartments = targetCompartments;
+            this.__explicitlySet__.add("targetCompartments");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetTags")
+        private TargetTags targetTags;
+
+        public Builder targetTags(TargetTags targetTags) {
+            this.targetTags = targetTags;
+            this.__explicitlySet__.add("targetTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateProfileDetails build() {
             UpdateProfileDetails __instance__ =
                     new UpdateProfileDetails(
-                            description, definedTags, freeformTags, levelsConfiguration);
+                            description,
+                            definedTags,
+                            freeformTags,
+                            levelsConfiguration,
+                            targetCompartments,
+                            targetTags,
+                            name);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -83,7 +114,10 @@ public class UpdateProfileDetails {
                     description(o.getDescription())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags())
-                            .levelsConfiguration(o.getLevelsConfiguration());
+                            .levelsConfiguration(o.getLevelsConfiguration())
+                            .targetCompartments(o.getTargetCompartments())
+                            .targetTags(o.getTargetTags())
+                            .name(o.getName());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -98,7 +132,7 @@ public class UpdateProfileDetails {
     }
 
     /**
-     * Text describing the profile.
+     * Text describing the profile. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
@@ -125,6 +159,18 @@ public class UpdateProfileDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("levelsConfiguration")
     LevelsConfiguration levelsConfiguration;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetCompartments")
+    TargetCompartments targetCompartments;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetTags")
+    TargetTags targetTags;
+
+    /**
+     * The name assigned to the profile. Avoid entering confidential information.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/requests/ListRecommendationStrategiesRequest.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/requests/ListRecommendationStrategiesRequest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.requests;
+
+import com.oracle.bmc.optimizer.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/optimizer/ListRecommendationStrategiesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListRecommendationStrategiesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListRecommendationStrategiesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * When set to true, the hierarchy of compartments is traversed and all compartments and subcompartments in the tenancy are returned depending on the the setting of `accessLevel`.
+     * <p>
+     * Can only be set to true when performing ListCompartments on the tenancy (root compartment).
+     *
+     */
+    private Boolean compartmentIdInSubtree;
+
+    /**
+     * Optional. A filter that returns results that match the name specified.
+     */
+    private String name;
+
+    /**
+     * Optional. A filter that returns results that match the recommendation name specified.
+     */
+    private String recommendationName;
+
+    /**
+     * The maximum number of items to return in a paginated \"List\" call.
+     */
+    private Integer limit;
+
+    /**
+     * The value of the `opc-next-page` response header from the previous \"List\" call.
+     *
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`).
+     */
+    private com.oracle.bmc.optimizer.model.SortOrder sortOrder;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for TIMECREATED is descending. Default order for NAME is ascending. The NAME sort order is case sensitive.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for TIMECREATED is descending. Default order for NAME is ascending. The NAME sort order is case sensitive.
+     *
+     **/
+    public enum SortBy {
+        Name("NAME"),
+        Timecreated("TIMECREATED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * Unique Oracle-assigned identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListRecommendationStrategiesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListRecommendationStrategiesRequest o) {
+            compartmentId(o.getCompartmentId());
+            compartmentIdInSubtree(o.getCompartmentIdInSubtree());
+            name(o.getName());
+            recommendationName(o.getRecommendationName());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListRecommendationStrategiesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListRecommendationStrategiesRequest
+         */
+        public ListRecommendationStrategiesRequest build() {
+            ListRecommendationStrategiesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/responses/ListRecommendationStrategiesResponse.java
+++ b/bmc-optimizer/src/main/java/com/oracle/bmc/optimizer/responses/ListRecommendationStrategiesResponse.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.optimizer.responses;
+
+import com.oracle.bmc.optimizer.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200606")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListRecommendationStrategiesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * For list pagination. When this header appears in the response, previous pages of results exist.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * The returned RecommendationStrategyCollection instance.
+     */
+    private RecommendationStrategyCollection recommendationStrategyCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListRecommendationStrategiesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            opcPrevPage(o.getOpcPrevPage());
+            recommendationStrategyCollection(o.getRecommendationStrategyCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.1</version>
+    <version>1.32.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.1</version>
+      <version>1.32.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.32.1</version>
+  <version>1.32.2</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>
@@ -726,6 +726,7 @@
     <module>bmc-tenantmanagercontrolplane</module>
     <module>bmc-rover</module>
     <module>bmc-databasemanagement</module>
+    <module>bmc-artifacts</module>
     <module>bmc-full</module>
     <module>bmc-shaded</module>
   </modules>


### PR DESCRIPTION
### Added

- Support for the OCI Registry service

- Support for exporting an existing running VM, or a copy of VM, into a VMDK, QCOW2, VDI, VHD, or OCI formatted image in the Compute service

- Support for platform configurations on instances in the Compute service

- Support for providing target tags and target compartments on profiles in the Optimizer service

- Support for the 'Fix it' feature in the Optimizer service
