### PR TITLE
Releasing version 1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.33.0 - 2021-03-02
+### Added
+- Support for pipelines, pipeline tasks, and favorites in the Data Integration service
+- Support for publishing tasks to OCI Data Flow in the Data Integration service
+- Support for clones in the File Storage service
+
+### Breaking Changes
+- Removed fields `PrimaryKey` and `UniqueKey` from enum `ModelType` of model `Key` in the Data Integration service
+
 ## 1.32.2 - 2021-02-23
 ### Added
 - Support for the OCI Registry service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,414 +19,414 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegration.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegration.java
@@ -176,6 +176,29 @@ public interface DataIntegration extends AutoCloseable {
     CreatePatchResponse createPatch(CreatePatchRequest request);
 
     /**
+     * Creates a new pipeline in a project or folder ready for performing task orchestration.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/CreatePipelineExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreatePipeline API.
+     */
+    CreatePipelineResponse createPipeline(CreatePipelineRequest request);
+
+    /**
+     * Accepts the data flow definition in the request payload and creates a pipeline validation.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/CreatePipelineValidationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreatePipelineValidation API.
+     */
+    CreatePipelineValidationResponse createPipelineValidation(
+            CreatePipelineValidationRequest request);
+
+    /**
      * Creates a project. Projects are organizational constructs within a workspace that you use to organize your design-time resources, such as tasks or data flows. Projects can be organized into folders.
      *
      * @param request The request object containing the details to send
@@ -332,6 +355,27 @@ public interface DataIntegration extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/DeletePatchExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeletePatch API.
      */
     DeletePatchResponse deletePatch(DeletePatchRequest request);
+
+    /**
+     * Removes a pipeline from a project or folder using the specified identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/DeletePipelineExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeletePipeline API.
+     */
+    DeletePipelineResponse deletePipeline(DeletePipelineRequest request);
+
+    /**
+     * Removes a pipeline validation using the specified identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/DeletePipelineValidationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeletePipelineValidation API.
+     */
+    DeletePipelineValidationResponse deletePipelineValidation(
+            DeletePipelineValidationRequest request);
 
     /**
      * Removes a project from the workspace using the specified identifier.
@@ -516,6 +560,26 @@ public interface DataIntegration extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/GetPatchExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPatch API.
      */
     GetPatchResponse getPatch(GetPatchRequest request);
+
+    /**
+     * Retrieves a pipeline using the specified identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/GetPipelineExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPipeline API.
+     */
+    GetPipelineResponse getPipeline(GetPipelineRequest request);
+
+    /**
+     * Retrieves a pipeline validation using the specified identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/GetPipelineValidationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPipelineValidation API.
+     */
+    GetPipelineValidationResponse getPipelineValidation(GetPipelineValidationRequest request);
 
     /**
      * Retrieves a project using the specified identifier.
@@ -747,6 +811,27 @@ public interface DataIntegration extends AutoCloseable {
     ListPatchesResponse listPatches(ListPatchesRequest request);
 
     /**
+     * Retrieves a list of pipeline validations within the specified workspace.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/ListPipelineValidationsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListPipelineValidations API.
+     */
+    ListPipelineValidationsResponse listPipelineValidations(ListPipelineValidationsRequest request);
+
+    /**
+     * Retrieves a list of pipelines in a project or folder from within a workspace, the query parameter specifies the project or folder.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/ListPipelinesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListPipelines API.
+     */
+    ListPipelinesResponse listPipelines(ListPipelinesRequest request);
+
+    /**
      * Retrieves a lists of projects in a workspace and provides options to filter the list.
      *
      * @param request The request object containing the details to send
@@ -955,6 +1040,16 @@ public interface DataIntegration extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/UpdateFolderExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateFolder API.
      */
     UpdateFolderResponse updateFolder(UpdateFolderRequest request);
+
+    /**
+     * Updates a specific pipeline.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/UpdatePipelineExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdatePipeline API.
+     */
+    UpdatePipelineResponse updatePipeline(UpdatePipelineRequest request);
 
     /**
      * Updates a specific project.

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegrationAsync.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegrationAsync.java
@@ -240,6 +240,39 @@ public interface DataIntegrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<CreatePatchRequest, CreatePatchResponse> handler);
 
     /**
+     * Creates a new pipeline in a project or folder ready for performing task orchestration.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreatePipelineResponse> createPipeline(
+            CreatePipelineRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreatePipelineRequest, CreatePipelineResponse>
+                    handler);
+
+    /**
+     * Accepts the data flow definition in the request payload and creates a pipeline validation.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreatePipelineValidationResponse> createPipelineValidation(
+            CreatePipelineValidationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreatePipelineValidationRequest, CreatePipelineValidationResponse>
+                    handler);
+
+    /**
      * Creates a project. Projects are organizational constructs within a workspace that you use to organize your design-time resources, such as tasks or data flows. Projects can be organized into folders.
      *
      *
@@ -473,6 +506,37 @@ public interface DataIntegrationAsync extends AutoCloseable {
     java.util.concurrent.Future<DeletePatchResponse> deletePatch(
             DeletePatchRequest request,
             com.oracle.bmc.responses.AsyncHandler<DeletePatchRequest, DeletePatchResponse> handler);
+
+    /**
+     * Removes a pipeline from a project or folder using the specified identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeletePipelineResponse> deletePipeline(
+            DeletePipelineRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeletePipelineRequest, DeletePipelineResponse>
+                    handler);
+
+    /**
+     * Removes a pipeline validation using the specified identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeletePipelineValidationResponse> deletePipelineValidation(
+            DeletePipelineValidationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeletePipelineValidationRequest, DeletePipelineValidationResponse>
+                    handler);
 
     /**
      * Removes a project from the workspace using the specified identifier.
@@ -751,6 +815,36 @@ public interface DataIntegrationAsync extends AutoCloseable {
     java.util.concurrent.Future<GetPatchResponse> getPatch(
             GetPatchRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetPatchRequest, GetPatchResponse> handler);
+
+    /**
+     * Retrieves a pipeline using the specified identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetPipelineResponse> getPipeline(
+            GetPipelineRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetPipelineRequest, GetPipelineResponse> handler);
+
+    /**
+     * Retrieves a pipeline validation using the specified identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetPipelineValidationResponse> getPipelineValidation(
+            GetPipelineValidationRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetPipelineValidationRequest, GetPipelineValidationResponse>
+                    handler);
 
     /**
      * Retrieves a project using the specified identifier.
@@ -1092,6 +1186,38 @@ public interface DataIntegrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListPatchesRequest, ListPatchesResponse> handler);
 
     /**
+     * Retrieves a list of pipeline validations within the specified workspace.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListPipelineValidationsResponse> listPipelineValidations(
+            ListPipelineValidationsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListPipelineValidationsRequest, ListPipelineValidationsResponse>
+                    handler);
+
+    /**
+     * Retrieves a list of pipelines in a project or folder from within a workspace, the query parameter specifies the project or folder.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListPipelinesResponse> listPipelines(
+            ListPipelinesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListPipelinesRequest, ListPipelinesResponse>
+                    handler);
+
+    /**
      * Retrieves a lists of projects in a workspace and provides options to filter the list.
      *
      *
@@ -1402,6 +1528,21 @@ public interface DataIntegrationAsync extends AutoCloseable {
     java.util.concurrent.Future<UpdateFolderResponse> updateFolder(
             UpdateFolderRequest request,
             com.oracle.bmc.responses.AsyncHandler<UpdateFolderRequest, UpdateFolderResponse>
+                    handler);
+
+    /**
+     * Updates a specific pipeline.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdatePipelineResponse> updatePipeline(
+            UpdatePipelineRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdatePipelineRequest, UpdatePipelineResponse>
                     handler);
 
     /**

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegrationAsyncClient.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegrationAsyncClient.java
@@ -861,6 +861,88 @@ public class DataIntegrationAsyncClient implements DataIntegrationAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreatePipelineResponse> createPipeline(
+            CreatePipelineRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreatePipelineRequest, CreatePipelineResponse>
+                    handler) {
+        LOG.trace("Called async createPipeline");
+        final CreatePipelineRequest interceptedRequest =
+                CreatePipelineConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreatePipelineConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreatePipelineResponse>
+                transformer = CreatePipelineConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CreatePipelineRequest, CreatePipelineResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreatePipelineRequest, CreatePipelineResponse>,
+                        java.util.concurrent.Future<CreatePipelineResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreatePipelineRequest, CreatePipelineResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreatePipelineValidationResponse> createPipelineValidation(
+            CreatePipelineValidationRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreatePipelineValidationRequest, CreatePipelineValidationResponse>
+                    handler) {
+        LOG.trace("Called async createPipelineValidation");
+        final CreatePipelineValidationRequest interceptedRequest =
+                CreatePipelineValidationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreatePipelineValidationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreatePipelineValidationResponse>
+                transformer = CreatePipelineValidationConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreatePipelineValidationRequest, CreatePipelineValidationResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreatePipelineValidationRequest, CreatePipelineValidationResponse>,
+                        java.util.concurrent.Future<CreatePipelineValidationResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreatePipelineValidationRequest, CreatePipelineValidationResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateProjectResponse> createProject(
             CreateProjectRequest request,
             final com.oracle.bmc.responses.AsyncHandler<CreateProjectRequest, CreateProjectResponse>
@@ -1452,6 +1534,86 @@ public class DataIntegrationAsyncClient implements DataIntegrationAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     DeletePatchRequest, DeletePatchResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeletePipelineResponse> deletePipeline(
+            DeletePipelineRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeletePipelineRequest, DeletePipelineResponse>
+                    handler) {
+        LOG.trace("Called async deletePipeline");
+        final DeletePipelineRequest interceptedRequest =
+                DeletePipelineConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeletePipelineConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeletePipelineResponse>
+                transformer = DeletePipelineConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeletePipelineRequest, DeletePipelineResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeletePipelineRequest, DeletePipelineResponse>,
+                        java.util.concurrent.Future<DeletePipelineResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeletePipelineRequest, DeletePipelineResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeletePipelineValidationResponse> deletePipelineValidation(
+            DeletePipelineValidationRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeletePipelineValidationRequest, DeletePipelineValidationResponse>
+                    handler) {
+        LOG.trace("Called async deletePipelineValidation");
+        final DeletePipelineValidationRequest interceptedRequest =
+                DeletePipelineValidationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeletePipelineValidationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeletePipelineValidationResponse>
+                transformer = DeletePipelineValidationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeletePipelineValidationRequest, DeletePipelineValidationResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeletePipelineValidationRequest, DeletePipelineValidationResponse>,
+                        java.util.concurrent.Future<DeletePipelineValidationResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeletePipelineValidationRequest, DeletePipelineValidationResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -2155,6 +2317,85 @@ public class DataIntegrationAsyncClient implements DataIntegrationAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetPatchRequest, GetPatchResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetPipelineResponse> getPipeline(
+            GetPipelineRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetPipelineRequest, GetPipelineResponse>
+                    handler) {
+        LOG.trace("Called async getPipeline");
+        final GetPipelineRequest interceptedRequest =
+                GetPipelineConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPipelineConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetPipelineResponse>
+                transformer = GetPipelineConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetPipelineRequest, GetPipelineResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetPipelineRequest, GetPipelineResponse>,
+                        java.util.concurrent.Future<GetPipelineResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetPipelineRequest, GetPipelineResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetPipelineValidationResponse> getPipelineValidation(
+            GetPipelineValidationRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetPipelineValidationRequest, GetPipelineValidationResponse>
+                    handler) {
+        LOG.trace("Called async getPipelineValidation");
+        final GetPipelineValidationRequest interceptedRequest =
+                GetPipelineValidationConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPipelineValidationConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetPipelineValidationResponse>
+                transformer = GetPipelineValidationConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetPipelineValidationRequest, GetPipelineValidationResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetPipelineValidationRequest, GetPipelineValidationResponse>,
+                        java.util.concurrent.Future<GetPipelineValidationResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetPipelineValidationRequest, GetPipelineValidationResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -3026,6 +3267,85 @@ public class DataIntegrationAsyncClient implements DataIntegrationAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListPipelineValidationsResponse> listPipelineValidations(
+            ListPipelineValidationsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListPipelineValidationsRequest, ListPipelineValidationsResponse>
+                    handler) {
+        LOG.trace("Called async listPipelineValidations");
+        final ListPipelineValidationsRequest interceptedRequest =
+                ListPipelineValidationsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPipelineValidationsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListPipelineValidationsResponse>
+                transformer = ListPipelineValidationsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListPipelineValidationsRequest, ListPipelineValidationsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListPipelineValidationsRequest, ListPipelineValidationsResponse>,
+                        java.util.concurrent.Future<ListPipelineValidationsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListPipelineValidationsRequest, ListPipelineValidationsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListPipelinesResponse> listPipelines(
+            ListPipelinesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListPipelinesRequest, ListPipelinesResponse>
+                    handler) {
+        LOG.trace("Called async listPipelines");
+        final ListPipelinesRequest interceptedRequest =
+                ListPipelinesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPipelinesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListPipelinesResponse>
+                transformer = ListPipelinesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListPipelinesRequest, ListPipelinesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListPipelinesRequest, ListPipelinesResponse>,
+                        java.util.concurrent.Future<ListPipelinesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListPipelinesRequest, ListPipelinesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListProjectsResponse> listProjects(
             ListProjectsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<ListProjectsRequest, ListProjectsResponse>
@@ -3798,6 +4118,45 @@ public class DataIntegrationAsyncClient implements DataIntegrationAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     UpdateFolderRequest, UpdateFolderResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdatePipelineResponse> updatePipeline(
+            UpdatePipelineRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdatePipelineRequest, UpdatePipelineResponse>
+                    handler) {
+        LOG.trace("Called async updatePipeline");
+        final UpdatePipelineRequest interceptedRequest =
+                UpdatePipelineConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdatePipelineConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdatePipelineResponse>
+                transformer = UpdatePipelineConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdatePipelineRequest, UpdatePipelineResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdatePipelineRequest, UpdatePipelineResponse>,
+                        java.util.concurrent.Future<UpdatePipelineResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdatePipelineRequest, UpdatePipelineResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegrationClient.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegrationClient.java
@@ -849,6 +849,73 @@ public class DataIntegrationClient implements DataIntegration {
     }
 
     @Override
+    public CreatePipelineResponse createPipeline(CreatePipelineRequest request) {
+        LOG.trace("Called createPipeline");
+        final CreatePipelineRequest interceptedRequest =
+                CreatePipelineConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreatePipelineConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreatePipelineResponse>
+                transformer = CreatePipelineConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreatePipelineDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreatePipelineValidationResponse createPipelineValidation(
+            CreatePipelineValidationRequest request) {
+        LOG.trace("Called createPipelineValidation");
+        final CreatePipelineValidationRequest interceptedRequest =
+                CreatePipelineValidationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreatePipelineValidationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreatePipelineValidationResponse>
+                transformer = CreatePipelineValidationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreatePipelineValidationDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateProjectResponse createProject(CreateProjectRequest request) {
         LOG.trace("Called createProject");
         final CreateProjectRequest interceptedRequest =
@@ -1290,6 +1357,65 @@ public class DataIntegrationClient implements DataIntegration {
                 DeletePatchConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, DeletePatchResponse>
                 transformer = DeletePatchConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeletePipelineResponse deletePipeline(DeletePipelineRequest request) {
+        LOG.trace("Called deletePipeline");
+        final DeletePipelineRequest interceptedRequest =
+                DeletePipelineConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeletePipelineConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeletePipelineResponse>
+                transformer = DeletePipelineConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeletePipelineValidationResponse deletePipelineValidation(
+            DeletePipelineValidationRequest request) {
+        LOG.trace("Called deletePipelineValidation");
+        final DeletePipelineValidationRequest interceptedRequest =
+                DeletePipelineValidationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeletePipelineValidationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeletePipelineValidationResponse>
+                transformer = DeletePipelineValidationConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1802,6 +1928,63 @@ public class DataIntegrationClient implements DataIntegration {
                 GetPatchConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetPatchResponse> transformer =
                 GetPatchConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetPipelineResponse getPipeline(GetPipelineRequest request) {
+        LOG.trace("Called getPipeline");
+        final GetPipelineRequest interceptedRequest =
+                GetPipelineConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPipelineConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetPipelineResponse>
+                transformer = GetPipelineConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetPipelineValidationResponse getPipelineValidation(
+            GetPipelineValidationRequest request) {
+        LOG.trace("Called getPipelineValidation");
+        final GetPipelineValidationRequest interceptedRequest =
+                GetPipelineValidationConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPipelineValidationConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetPipelineValidationResponse>
+                transformer = GetPipelineValidationConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -2440,6 +2623,63 @@ public class DataIntegrationClient implements DataIntegration {
     }
 
     @Override
+    public ListPipelineValidationsResponse listPipelineValidations(
+            ListPipelineValidationsRequest request) {
+        LOG.trace("Called listPipelineValidations");
+        final ListPipelineValidationsRequest interceptedRequest =
+                ListPipelineValidationsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPipelineValidationsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListPipelineValidationsResponse>
+                transformer = ListPipelineValidationsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListPipelinesResponse listPipelines(ListPipelinesRequest request) {
+        LOG.trace("Called listPipelines");
+        final ListPipelinesRequest interceptedRequest =
+                ListPipelinesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPipelinesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListPipelinesResponse>
+                transformer = ListPipelinesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListProjectsResponse listProjects(ListProjectsRequest request) {
         LOG.trace("Called listProjects");
         final ListProjectsRequest interceptedRequest =
@@ -3024,6 +3264,38 @@ public class DataIntegrationClient implements DataIntegration {
                                         client.put(
                                                 ib,
                                                 retriedRequest.getUpdateFolderDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdatePipelineResponse updatePipeline(UpdatePipelineRequest request) {
+        LOG.trace("Called updatePipeline");
+        final UpdatePipelineRequest interceptedRequest =
+                UpdatePipelineConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdatePipelineConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdatePipelineResponse>
+                transformer = UpdatePipelineConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdatePipelineDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegrationPaginators.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/DataIntegrationPaginators.java
@@ -1526,6 +1526,234 @@ public class DataIntegrationPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listPipelineValidations operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListPipelineValidationsResponse> listPipelineValidationsResponseIterator(
+            final ListPipelineValidationsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListPipelineValidationsRequest.Builder, ListPipelineValidationsRequest,
+                ListPipelineValidationsResponse>(
+                new com.google.common.base.Supplier<ListPipelineValidationsRequest.Builder>() {
+                    @Override
+                    public ListPipelineValidationsRequest.Builder get() {
+                        return ListPipelineValidationsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListPipelineValidationsResponse, String>() {
+                    @Override
+                    public String apply(ListPipelineValidationsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPipelineValidationsRequest.Builder>,
+                        ListPipelineValidationsRequest>() {
+                    @Override
+                    public ListPipelineValidationsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPipelineValidationsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPipelineValidationsRequest, ListPipelineValidationsResponse>() {
+                    @Override
+                    public ListPipelineValidationsResponse apply(
+                            ListPipelineValidationsRequest request) {
+                        return client.listPipelineValidations(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.dataintegration.model.PipelineValidationSummary} objects
+     * contained in responses from the listPipelineValidations operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.dataintegration.model.PipelineValidationSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.dataintegration.model.PipelineValidationSummary>
+            listPipelineValidationsRecordIterator(final ListPipelineValidationsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListPipelineValidationsRequest.Builder, ListPipelineValidationsRequest,
+                ListPipelineValidationsResponse,
+                com.oracle.bmc.dataintegration.model.PipelineValidationSummary>(
+                new com.google.common.base.Supplier<ListPipelineValidationsRequest.Builder>() {
+                    @Override
+                    public ListPipelineValidationsRequest.Builder get() {
+                        return ListPipelineValidationsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListPipelineValidationsResponse, String>() {
+                    @Override
+                    public String apply(ListPipelineValidationsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPipelineValidationsRequest.Builder>,
+                        ListPipelineValidationsRequest>() {
+                    @Override
+                    public ListPipelineValidationsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPipelineValidationsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPipelineValidationsRequest, ListPipelineValidationsResponse>() {
+                    @Override
+                    public ListPipelineValidationsResponse apply(
+                            ListPipelineValidationsRequest request) {
+                        return client.listPipelineValidations(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPipelineValidationsResponse,
+                        java.util.List<
+                                com.oracle.bmc.dataintegration.model.PipelineValidationSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.dataintegration.model.PipelineValidationSummary>
+                            apply(ListPipelineValidationsResponse response) {
+                        return response.getPipelineValidationSummaryCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listPipelines operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListPipelinesResponse> listPipelinesResponseIterator(
+            final ListPipelinesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListPipelinesRequest.Builder, ListPipelinesRequest, ListPipelinesResponse>(
+                new com.google.common.base.Supplier<ListPipelinesRequest.Builder>() {
+                    @Override
+                    public ListPipelinesRequest.Builder get() {
+                        return ListPipelinesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListPipelinesResponse, String>() {
+                    @Override
+                    public String apply(ListPipelinesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPipelinesRequest.Builder>,
+                        ListPipelinesRequest>() {
+                    @Override
+                    public ListPipelinesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPipelinesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListPipelinesRequest, ListPipelinesResponse>() {
+                    @Override
+                    public ListPipelinesResponse apply(ListPipelinesRequest request) {
+                        return client.listPipelines(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.dataintegration.model.PipelineSummary} objects
+     * contained in responses from the listPipelines operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.dataintegration.model.PipelineSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.dataintegration.model.PipelineSummary>
+            listPipelinesRecordIterator(final ListPipelinesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListPipelinesRequest.Builder, ListPipelinesRequest, ListPipelinesResponse,
+                com.oracle.bmc.dataintegration.model.PipelineSummary>(
+                new com.google.common.base.Supplier<ListPipelinesRequest.Builder>() {
+                    @Override
+                    public ListPipelinesRequest.Builder get() {
+                        return ListPipelinesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListPipelinesResponse, String>() {
+                    @Override
+                    public String apply(ListPipelinesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPipelinesRequest.Builder>,
+                        ListPipelinesRequest>() {
+                    @Override
+                    public ListPipelinesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPipelinesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListPipelinesRequest, ListPipelinesResponse>() {
+                    @Override
+                    public ListPipelinesResponse apply(ListPipelinesRequest request) {
+                        return client.listPipelines(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPipelinesResponse,
+                        java.util.List<com.oracle.bmc.dataintegration.model.PipelineSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.dataintegration.model.PipelineSummary>
+                            apply(ListPipelinesResponse response) {
+                        return response.getPipelineSummaryCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listProjects operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/CreatePipelineConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/CreatePipelineConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dataintegration.model.*;
+import com.oracle.bmc.dataintegration.requests.*;
+import com.oracle.bmc.dataintegration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.extern.slf4j.Slf4j
+public class CreatePipelineConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dataintegration.requests.CreatePipelineRequest interceptRequest(
+            com.oracle.bmc.dataintegration.requests.CreatePipelineRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dataintegration.requests.CreatePipelineRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkspaceId(), "workspaceId must not be blank");
+        Validate.notNull(request.getCreatePipelineDetails(), "createPipelineDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200430")
+                        .path("workspaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkspaceId()))
+                        .path("pipelines");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dataintegration.responses.CreatePipelineResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dataintegration.responses.CreatePipelineResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dataintegration.responses.CreatePipelineResponse>() {
+                            @Override
+                            public com.oracle.bmc.dataintegration.responses.CreatePipelineResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dataintegration.responses.CreatePipelineResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Pipeline>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Pipeline.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Pipeline> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dataintegration.responses.CreatePipelineResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.dataintegration.responses
+                                                        .CreatePipelineResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.pipeline(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dataintegration.responses.CreatePipelineResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/CreatePipelineValidationConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/CreatePipelineValidationConverter.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dataintegration.model.*;
+import com.oracle.bmc.dataintegration.requests.*;
+import com.oracle.bmc.dataintegration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.extern.slf4j.Slf4j
+public class CreatePipelineValidationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dataintegration.requests.CreatePipelineValidationRequest
+            interceptRequest(
+                    com.oracle.bmc.dataintegration.requests.CreatePipelineValidationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dataintegration.requests.CreatePipelineValidationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkspaceId(), "workspaceId must not be blank");
+        Validate.notNull(
+                request.getCreatePipelineValidationDetails(),
+                "createPipelineValidationDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200430")
+                        .path("workspaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkspaceId()))
+                        .path("pipelineValidations");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dataintegration.responses.CreatePipelineValidationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dataintegration.responses.CreatePipelineValidationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dataintegration.responses
+                                        .CreatePipelineValidationResponse>() {
+                            @Override
+                            public com.oracle.bmc.dataintegration.responses
+                                            .CreatePipelineValidationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dataintegration.responses.CreatePipelineValidationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        PipelineValidation>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        PipelineValidation.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<PipelineValidation>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dataintegration.responses
+                                                .CreatePipelineValidationResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dataintegration.responses
+                                                        .CreatePipelineValidationResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.pipelineValidation(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dataintegration.responses
+                                                .CreatePipelineValidationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/DeletePipelineConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/DeletePipelineConverter.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dataintegration.model.*;
+import com.oracle.bmc.dataintegration.requests.*;
+import com.oracle.bmc.dataintegration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.extern.slf4j.Slf4j
+public class DeletePipelineConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dataintegration.requests.DeletePipelineRequest interceptRequest(
+            com.oracle.bmc.dataintegration.requests.DeletePipelineRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dataintegration.requests.DeletePipelineRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkspaceId(), "workspaceId must not be blank");
+        Validate.notBlank(request.getPipelineKey(), "pipelineKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200430")
+                        .path("workspaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkspaceId()))
+                        .path("pipelines")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPipelineKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dataintegration.responses.DeletePipelineResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dataintegration.responses.DeletePipelineResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dataintegration.responses.DeletePipelineResponse>() {
+                            @Override
+                            public com.oracle.bmc.dataintegration.responses.DeletePipelineResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dataintegration.responses.DeletePipelineResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dataintegration.responses.DeletePipelineResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.dataintegration.responses
+                                                        .DeletePipelineResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dataintegration.responses.DeletePipelineResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/DeletePipelineValidationConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/DeletePipelineValidationConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dataintegration.model.*;
+import com.oracle.bmc.dataintegration.requests.*;
+import com.oracle.bmc.dataintegration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.extern.slf4j.Slf4j
+public class DeletePipelineValidationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dataintegration.requests.DeletePipelineValidationRequest
+            interceptRequest(
+                    com.oracle.bmc.dataintegration.requests.DeletePipelineValidationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dataintegration.requests.DeletePipelineValidationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkspaceId(), "workspaceId must not be blank");
+        Validate.notBlank(
+                request.getPipelineValidationKey(), "pipelineValidationKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200430")
+                        .path("workspaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkspaceId()))
+                        .path("pipelineValidations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPipelineValidationKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dataintegration.responses.DeletePipelineValidationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dataintegration.responses.DeletePipelineValidationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dataintegration.responses
+                                        .DeletePipelineValidationResponse>() {
+                            @Override
+                            public com.oracle.bmc.dataintegration.responses
+                                            .DeletePipelineValidationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dataintegration.responses.DeletePipelineValidationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dataintegration.responses
+                                                .DeletePipelineValidationResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dataintegration.responses
+                                                        .DeletePipelineValidationResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dataintegration.responses
+                                                .DeletePipelineValidationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/GetPipelineConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/GetPipelineConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dataintegration.model.*;
+import com.oracle.bmc.dataintegration.requests.*;
+import com.oracle.bmc.dataintegration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.extern.slf4j.Slf4j
+public class GetPipelineConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dataintegration.requests.GetPipelineRequest interceptRequest(
+            com.oracle.bmc.dataintegration.requests.GetPipelineRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dataintegration.requests.GetPipelineRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkspaceId(), "workspaceId must not be blank");
+        Validate.notBlank(request.getPipelineKey(), "pipelineKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200430")
+                        .path("workspaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkspaceId()))
+                        .path("pipelines")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPipelineKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dataintegration.responses.GetPipelineResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dataintegration.responses.GetPipelineResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dataintegration.responses.GetPipelineResponse>() {
+                            @Override
+                            public com.oracle.bmc.dataintegration.responses.GetPipelineResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dataintegration.responses.GetPipelineResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Pipeline>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Pipeline.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Pipeline> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dataintegration.responses.GetPipelineResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dataintegration.responses
+                                                        .GetPipelineResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.pipeline(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dataintegration.responses.GetPipelineResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/GetPipelineValidationConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/GetPipelineValidationConverter.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dataintegration.model.*;
+import com.oracle.bmc.dataintegration.requests.*;
+import com.oracle.bmc.dataintegration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.extern.slf4j.Slf4j
+public class GetPipelineValidationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dataintegration.requests.GetPipelineValidationRequest
+            interceptRequest(
+                    com.oracle.bmc.dataintegration.requests.GetPipelineValidationRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dataintegration.requests.GetPipelineValidationRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkspaceId(), "workspaceId must not be blank");
+        Validate.notBlank(
+                request.getPipelineValidationKey(), "pipelineValidationKey must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200430")
+                        .path("workspaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkspaceId()))
+                        .path("pipelineValidations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPipelineValidationKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dataintegration.responses.GetPipelineValidationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dataintegration.responses.GetPipelineValidationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dataintegration.responses
+                                        .GetPipelineValidationResponse>() {
+                            @Override
+                            public com.oracle.bmc.dataintegration.responses
+                                            .GetPipelineValidationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dataintegration.responses.GetPipelineValidationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        PipelineValidation>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        PipelineValidation.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<PipelineValidation>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dataintegration.responses
+                                                .GetPipelineValidationResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dataintegration.responses
+                                                        .GetPipelineValidationResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.pipelineValidation(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dataintegration.responses
+                                                .GetPipelineValidationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/GetTaskConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/GetTaskConverter.java
@@ -42,6 +42,14 @@ public class GetTaskConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getTaskKey()));
 
+        if (request.getExpandReferences() != null) {
+            target =
+                    target.queryParam(
+                            "expandReferences",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getExpandReferences()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListDataEntitiesConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListDataEntitiesConverter.java
@@ -105,6 +105,23 @@ public class ListDataEntitiesConverter {
                                     request.getSortOrder().getValue()));
         }
 
+        if (request.getNameList() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "nameList",
+                            request.getNameList(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getIsPattern() != null) {
+            target =
+                    target.queryParam(
+                            "isPattern",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsPattern()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListPipelineValidationsConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListPipelineValidationsConverter.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dataintegration.model.*;
+import com.oracle.bmc.dataintegration.requests.*;
+import com.oracle.bmc.dataintegration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.extern.slf4j.Slf4j
+public class ListPipelineValidationsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dataintegration.requests.ListPipelineValidationsRequest
+            interceptRequest(
+                    com.oracle.bmc.dataintegration.requests.ListPipelineValidationsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dataintegration.requests.ListPipelineValidationsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkspaceId(), "workspaceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200430")
+                        .path("workspaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkspaceId()))
+                        .path("pipelineValidations");
+
+        if (request.getKey() != null) {
+            target =
+                    target.queryParam(
+                            "key",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getKey()));
+        }
+
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getIdentifier() != null) {
+            target =
+                    target.queryParam(
+                            "identifier",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIdentifier()));
+        }
+
+        if (request.getFields() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "fields",
+                            request.getFields(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dataintegration.responses.ListPipelineValidationsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dataintegration.responses.ListPipelineValidationsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dataintegration.responses
+                                        .ListPipelineValidationsResponse>() {
+                            @Override
+                            public com.oracle.bmc.dataintegration.responses
+                                            .ListPipelineValidationsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dataintegration.responses.ListPipelineValidationsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        PipelineValidationSummaryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        PipelineValidationSummaryCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                PipelineValidationSummaryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dataintegration.responses
+                                                .ListPipelineValidationsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.dataintegration.responses
+                                                        .ListPipelineValidationsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.pipelineValidationSummaryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcTotalItemsHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-total-items");
+                                if (opcTotalItemsHeader.isPresent()) {
+                                    builder.opcTotalItems(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-total-items",
+                                                    opcTotalItemsHeader.get().get(0),
+                                                    Integer.class));
+                                }
+
+                                com.oracle.bmc.dataintegration.responses
+                                                .ListPipelineValidationsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListPipelinesConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListPipelinesConverter.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dataintegration.model.*;
+import com.oracle.bmc.dataintegration.requests.*;
+import com.oracle.bmc.dataintegration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.extern.slf4j.Slf4j
+public class ListPipelinesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dataintegration.requests.ListPipelinesRequest interceptRequest(
+            com.oracle.bmc.dataintegration.requests.ListPipelinesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dataintegration.requests.ListPipelinesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkspaceId(), "workspaceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200430")
+                        .path("workspaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkspaceId()))
+                        .path("pipelines");
+
+        if (request.getAggregatorKey() != null) {
+            target =
+                    target.queryParam(
+                            "aggregatorKey",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getAggregatorKey()));
+        }
+
+        if (request.getFields() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "fields",
+                            request.getFields(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getIdentifier() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "identifier",
+                            request.getIdentifier(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dataintegration.responses.ListPipelinesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dataintegration.responses.ListPipelinesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dataintegration.responses.ListPipelinesResponse>() {
+                            @Override
+                            public com.oracle.bmc.dataintegration.responses.ListPipelinesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dataintegration.responses.ListPipelinesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        PipelineSummaryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        PipelineSummaryCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<PipelineSummaryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dataintegration.responses.ListPipelinesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.dataintegration.responses
+                                                        .ListPipelinesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.pipelineSummaryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcTotalItemsHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-total-items");
+                                if (opcTotalItemsHeader.isPresent()) {
+                                    builder.opcTotalItems(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-total-items",
+                                                    opcTotalItemsHeader.get().get(0),
+                                                    Integer.class));
+                                }
+
+                                com.oracle.bmc.dataintegration.responses.ListPipelinesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListSchemasConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListSchemasConverter.java
@@ -99,6 +99,15 @@ public class ListSchemasConverter {
                                     request.getName()));
         }
 
+        if (request.getNameList() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "nameList",
+                            request.getNameList(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListTaskRunsConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListTaskRunsConverter.java
@@ -43,6 +43,14 @@ public class ListTaskRunsConverter {
                                         request.getApplicationKey()))
                         .path("taskRuns");
 
+        if (request.getAggregatorKey() != null) {
+            target =
+                    target.queryParam(
+                            "aggregatorKey",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getAggregatorKey()));
+        }
+
         if (request.getFields() != null) {
             target =
                     com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListWorkRequestsConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/ListWorkRequestsConverter.java
@@ -38,6 +38,14 @@ public class ListWorkRequestsConverter {
                         com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
                                 request.getCompartmentId()));
 
+        if (request.getWorkspaceId() != null) {
+            target =
+                    target.queryParam(
+                            "workspaceId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getWorkspaceId()));
+        }
+
         if (request.getWorkRequestStatus() != null) {
             target =
                     target.queryParam(

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/UpdatePipelineConverter.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/internal/http/UpdatePipelineConverter.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.dataintegration.model.*;
+import com.oracle.bmc.dataintegration.requests.*;
+import com.oracle.bmc.dataintegration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.extern.slf4j.Slf4j
+public class UpdatePipelineConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.dataintegration.requests.UpdatePipelineRequest interceptRequest(
+            com.oracle.bmc.dataintegration.requests.UpdatePipelineRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.dataintegration.requests.UpdatePipelineRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkspaceId(), "workspaceId must not be blank");
+        Validate.notBlank(request.getPipelineKey(), "pipelineKey must not be blank");
+        Validate.notNull(request.getUpdatePipelineDetails(), "updatePipelineDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200430")
+                        .path("workspaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkspaceId()))
+                        .path("pipelines")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPipelineKey()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.dataintegration.responses.UpdatePipelineResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.dataintegration.responses.UpdatePipelineResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.dataintegration.responses.UpdatePipelineResponse>() {
+                            @Override
+                            public com.oracle.bmc.dataintegration.responses.UpdatePipelineResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.dataintegration.responses.UpdatePipelineResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Pipeline>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Pipeline.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Pipeline> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.dataintegration.responses.UpdatePipelineResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.dataintegration.responses
+                                                        .UpdatePipelineResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.pipeline(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.dataintegration.responses.UpdatePipelineResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AbstractFrequencyDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AbstractFrequencyDetails.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The model that holds the frequency details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType",
+    defaultImpl = AbstractFrequencyDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = MonthlyFrequencyDetails.class,
+        name = "MONTHLY"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = DailyFrequencyDetails.class,
+        name = "DAILY"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = HourlyFrequencyDetails.class,
+        name = "HOURLY"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class AbstractFrequencyDetails {
+
+    /**
+     * the frequency of the schedule.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Frequency {
+        Hourly("HOURLY"),
+        Daily("DAILY"),
+        Monthly("MONTHLY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Frequency> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Frequency v : Frequency.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Frequency(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Frequency create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Frequency', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * the frequency of the schedule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("frequency")
+    Frequency frequency;
+
+    /**
+     * The type of the model
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ModelType {
+        Hourly("HOURLY"),
+        Daily("DAILY"),
+        Monthly("MONTHLY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ModelType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ModelType v : ModelType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ModelType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ModelType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ModelType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AggregatorSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/AggregatorSummary.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * A summary type containing information about the object's aggregator including its type, key, name and description.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AggregatorSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AggregatorSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private String type;
+
+        public Builder type(String type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AggregatorSummary build() {
+            AggregatorSummary __instance__ =
+                    new AggregatorSummary(type, key, name, identifier, description);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AggregatorSummary o) {
+            Builder copiedBuilder =
+                    type(o.getType())
+                            .key(o.getKey())
+                            .name(o.getName())
+                            .identifier(o.getIdentifier())
+                            .description(o.getDescription());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The type of the aggregator.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    String type;
+
+    /**
+     * The key of the aggregator object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * The name of the aggregator.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The identifier of the aggregator.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * The description of the aggregator.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/BaseType.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/BaseType.java
@@ -94,6 +94,7 @@ public class BaseType {
         JavaType("JAVA_TYPE"),
         ConfiguredType("CONFIGURED_TYPE"),
         CompositeType("COMPOSITE_TYPE"),
+        DerivedType("DERIVED_TYPE"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Compression.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Compression.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The optional compression configuration.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Compression.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Compression {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("codec")
+        private Codec codec;
+
+        public Builder codec(Codec codec) {
+            this.codec = codec;
+            this.__explicitlySet__.add("codec");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Compression build() {
+            Compression __instance__ = new Compression(codec);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Compression o) {
+            Builder copiedBuilder = codec(o.getCodec());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Compression algorithm
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Codec {
+        None("NONE"),
+        Auto("AUTO"),
+        Gzip("GZIP"),
+        Bzip2("BZIP2"),
+        Deflate("DEFLATE"),
+        Lz4("LZ4"),
+        Snappy("SNAPPY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Codec> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Codec v : Codec.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Codec(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Codec create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Codec', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Compression algorithm
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("codec")
+    Codec codec;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConfigParameterValue.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConfigParameterValue.java
@@ -44,6 +44,15 @@ public class ConfigParameterValue {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("objectValue")
+        private Object objectValue;
+
+        public Builder objectValue(Object objectValue) {
+            this.objectValue = objectValue;
+            this.__explicitlySet__.add("objectValue");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("refValue")
         private Object refValue;
 
@@ -67,7 +76,8 @@ public class ConfigParameterValue {
 
         public ConfigParameterValue build() {
             ConfigParameterValue __instance__ =
-                    new ConfigParameterValue(stringValue, intValue, refValue, parameterValue);
+                    new ConfigParameterValue(
+                            stringValue, intValue, objectValue, refValue, parameterValue);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -77,6 +87,7 @@ public class ConfigParameterValue {
             Builder copiedBuilder =
                     stringValue(o.getStringValue())
                             .intValue(o.getIntValue())
+                            .objectValue(o.getObjectValue())
                             .refValue(o.getRefValue())
                             .parameterValue(o.getParameterValue());
 
@@ -103,6 +114,12 @@ public class ConfigParameterValue {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("intValue")
     Integer intValue;
+
+    /**
+     * An object value of the parameter.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectValue")
+    Object objectValue;
 
     /**
      * The root object reference value.

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromAdwc.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromAdwc.java
@@ -168,6 +168,15 @@ public class ConnectionFromAdwc extends Connection {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -188,7 +197,8 @@ public class ConnectionFromAdwc extends Connection {
                             metadata,
                             keyMap,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -210,7 +220,8 @@ public class ConnectionFromAdwc extends Connection {
                             .metadata(o.getMetadata())
                             .keyMap(o.getKeyMap())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -240,7 +251,8 @@ public class ConnectionFromAdwc extends Connection {
             ObjectMetadata metadata,
             java.util.Map<String, String> keyMap,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -257,6 +269,7 @@ public class ConnectionFromAdwc extends Connection {
                 keyMap);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -270,6 +283,9 @@ public class ConnectionFromAdwc extends Connection {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromAdwcDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromAdwcDetails.java
@@ -159,6 +159,15 @@ public class ConnectionFromAdwcDetails extends ConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -178,7 +187,8 @@ public class ConnectionFromAdwcDetails extends ConnectionDetails {
                             isDefault,
                             metadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -199,7 +209,8 @@ public class ConnectionFromAdwcDetails extends ConnectionDetails {
                             .isDefault(o.getIsDefault())
                             .metadata(o.getMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -228,7 +239,8 @@ public class ConnectionFromAdwcDetails extends ConnectionDetails {
             Boolean isDefault,
             ObjectMetadata metadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -244,6 +256,7 @@ public class ConnectionFromAdwcDetails extends ConnectionDetails {
                 metadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -257,6 +270,9 @@ public class ConnectionFromAdwcDetails extends ConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromAtp.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromAtp.java
@@ -168,6 +168,15 @@ public class ConnectionFromAtp extends Connection {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -188,7 +197,8 @@ public class ConnectionFromAtp extends Connection {
                             metadata,
                             keyMap,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -210,7 +220,8 @@ public class ConnectionFromAtp extends Connection {
                             .metadata(o.getMetadata())
                             .keyMap(o.getKeyMap())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -240,7 +251,8 @@ public class ConnectionFromAtp extends Connection {
             ObjectMetadata metadata,
             java.util.Map<String, String> keyMap,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -257,6 +269,7 @@ public class ConnectionFromAtp extends Connection {
                 keyMap);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -270,6 +283,9 @@ public class ConnectionFromAtp extends Connection {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromAtpDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromAtpDetails.java
@@ -159,6 +159,15 @@ public class ConnectionFromAtpDetails extends ConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -178,7 +187,8 @@ public class ConnectionFromAtpDetails extends ConnectionDetails {
                             isDefault,
                             metadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -199,7 +209,8 @@ public class ConnectionFromAtpDetails extends ConnectionDetails {
                             .isDefault(o.getIsDefault())
                             .metadata(o.getMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -228,7 +239,8 @@ public class ConnectionFromAtpDetails extends ConnectionDetails {
             Boolean isDefault,
             ObjectMetadata metadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -244,6 +256,7 @@ public class ConnectionFromAtpDetails extends ConnectionDetails {
                 metadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -257,6 +270,9 @@ public class ConnectionFromAtpDetails extends ConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromOracle.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromOracle.java
@@ -168,6 +168,15 @@ public class ConnectionFromOracle extends Connection {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -188,7 +197,8 @@ public class ConnectionFromOracle extends Connection {
                             metadata,
                             keyMap,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -210,7 +220,8 @@ public class ConnectionFromOracle extends Connection {
                             .metadata(o.getMetadata())
                             .keyMap(o.getKeyMap())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -240,7 +251,8 @@ public class ConnectionFromOracle extends Connection {
             ObjectMetadata metadata,
             java.util.Map<String, String> keyMap,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -257,6 +269,7 @@ public class ConnectionFromOracle extends Connection {
                 keyMap);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -270,6 +283,9 @@ public class ConnectionFromOracle extends Connection {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromOracleDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionFromOracleDetails.java
@@ -159,6 +159,15 @@ public class ConnectionFromOracleDetails extends ConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -178,7 +187,8 @@ public class ConnectionFromOracleDetails extends ConnectionDetails {
                             isDefault,
                             metadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -199,7 +209,8 @@ public class ConnectionFromOracleDetails extends ConnectionDetails {
                             .isDefault(o.getIsDefault())
                             .metadata(o.getMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -228,7 +239,8 @@ public class ConnectionFromOracleDetails extends ConnectionDetails {
             Boolean isDefault,
             ObjectMetadata metadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -244,6 +256,7 @@ public class ConnectionFromOracleDetails extends ConnectionDetails {
                 metadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -257,6 +270,9 @@ public class ConnectionFromOracleDetails extends ConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummaryFromAdwc.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummaryFromAdwc.java
@@ -168,6 +168,15 @@ public class ConnectionSummaryFromAdwc extends ConnectionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -188,7 +197,8 @@ public class ConnectionSummaryFromAdwc extends ConnectionSummary {
                             metadata,
                             keyMap,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -210,7 +220,8 @@ public class ConnectionSummaryFromAdwc extends ConnectionSummary {
                             .metadata(o.getMetadata())
                             .keyMap(o.getKeyMap())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -240,7 +251,8 @@ public class ConnectionSummaryFromAdwc extends ConnectionSummary {
             ObjectMetadata metadata,
             java.util.Map<String, String> keyMap,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -257,6 +269,7 @@ public class ConnectionSummaryFromAdwc extends ConnectionSummary {
                 keyMap);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -270,6 +283,9 @@ public class ConnectionSummaryFromAdwc extends ConnectionSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummaryFromAtp.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummaryFromAtp.java
@@ -168,6 +168,15 @@ public class ConnectionSummaryFromAtp extends ConnectionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -188,7 +197,8 @@ public class ConnectionSummaryFromAtp extends ConnectionSummary {
                             metadata,
                             keyMap,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -210,7 +220,8 @@ public class ConnectionSummaryFromAtp extends ConnectionSummary {
                             .metadata(o.getMetadata())
                             .keyMap(o.getKeyMap())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -240,7 +251,8 @@ public class ConnectionSummaryFromAtp extends ConnectionSummary {
             ObjectMetadata metadata,
             java.util.Map<String, String> keyMap,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -257,6 +269,7 @@ public class ConnectionSummaryFromAtp extends ConnectionSummary {
                 keyMap);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -270,6 +283,9 @@ public class ConnectionSummaryFromAtp extends ConnectionSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummaryFromOracle.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ConnectionSummaryFromOracle.java
@@ -168,6 +168,15 @@ public class ConnectionSummaryFromOracle extends ConnectionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -188,7 +197,8 @@ public class ConnectionSummaryFromOracle extends ConnectionSummary {
                             metadata,
                             keyMap,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -210,7 +220,8 @@ public class ConnectionSummaryFromOracle extends ConnectionSummary {
                             .metadata(o.getMetadata())
                             .keyMap(o.getKeyMap())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -240,7 +251,8 @@ public class ConnectionSummaryFromOracle extends ConnectionSummary {
             ObjectMetadata metadata,
             java.util.Map<String, String> keyMap,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -257,6 +269,7 @@ public class ConnectionSummaryFromOracle extends ConnectionSummary {
                 keyMap);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -270,6 +283,9 @@ public class ConnectionSummaryFromOracle extends ConnectionSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromAdwc.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromAdwc.java
@@ -132,6 +132,15 @@ public class CreateConnectionFromAdwc extends CreateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -148,7 +157,8 @@ public class CreateConnectionFromAdwc extends CreateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -166,7 +176,8 @@ public class CreateConnectionFromAdwc extends CreateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -192,7 +203,8 @@ public class CreateConnectionFromAdwc extends CreateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -205,6 +217,7 @@ public class CreateConnectionFromAdwc extends CreateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -218,6 +231,9 @@ public class CreateConnectionFromAdwc extends CreateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromAtp.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromAtp.java
@@ -132,6 +132,15 @@ public class CreateConnectionFromAtp extends CreateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -148,7 +157,8 @@ public class CreateConnectionFromAtp extends CreateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -166,7 +176,8 @@ public class CreateConnectionFromAtp extends CreateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -192,7 +203,8 @@ public class CreateConnectionFromAtp extends CreateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -205,6 +217,7 @@ public class CreateConnectionFromAtp extends CreateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -218,6 +231,9 @@ public class CreateConnectionFromAtp extends CreateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromJdbc.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromJdbc.java
@@ -132,6 +132,15 @@ public class CreateConnectionFromJdbc extends CreateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -148,7 +157,8 @@ public class CreateConnectionFromJdbc extends CreateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -166,7 +176,8 @@ public class CreateConnectionFromJdbc extends CreateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -192,7 +203,8 @@ public class CreateConnectionFromJdbc extends CreateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -205,6 +217,7 @@ public class CreateConnectionFromJdbc extends CreateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -218,6 +231,9 @@ public class CreateConnectionFromJdbc extends CreateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromMySQL.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromMySQL.java
@@ -132,6 +132,15 @@ public class CreateConnectionFromMySQL extends CreateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -148,7 +157,8 @@ public class CreateConnectionFromMySQL extends CreateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -166,7 +176,8 @@ public class CreateConnectionFromMySQL extends CreateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -192,7 +203,8 @@ public class CreateConnectionFromMySQL extends CreateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -205,6 +217,7 @@ public class CreateConnectionFromMySQL extends CreateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -218,6 +231,9 @@ public class CreateConnectionFromMySQL extends CreateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromOracle.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateConnectionFromOracle.java
@@ -132,6 +132,15 @@ public class CreateConnectionFromOracle extends CreateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -148,7 +157,8 @@ public class CreateConnectionFromOracle extends CreateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -166,7 +176,8 @@ public class CreateConnectionFromOracle extends CreateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -192,7 +203,8 @@ public class CreateConnectionFromOracle extends CreateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -205,6 +217,7 @@ public class CreateConnectionFromOracle extends CreateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -218,6 +231,9 @@ public class CreateConnectionFromOracle extends CreateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateDataAssetFromAdwc.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateDataAssetFromAdwc.java
@@ -140,6 +140,24 @@ public class CreateDataAssetFromAdwc extends CreateDataAssetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+        private SensitiveAttribute walletSecret;
+
+        public Builder walletSecret(SensitiveAttribute walletSecret) {
+            this.walletSecret = walletSecret;
+            this.__explicitlySet__.add("walletSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+        private SensitiveAttribute walletPasswordSecret;
+
+        public Builder walletPasswordSecret(SensitiveAttribute walletPasswordSecret) {
+            this.walletPasswordSecret = walletPasswordSecret;
+            this.__explicitlySet__.add("walletPasswordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
         private CreateConnectionFromAdwc defaultConnection;
 
@@ -167,6 +185,8 @@ public class CreateDataAssetFromAdwc extends CreateDataAssetDetails {
                             serviceName,
                             driverClass,
                             credentialFileContent,
+                            walletSecret,
+                            walletPasswordSecret,
                             defaultConnection);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -187,6 +207,8 @@ public class CreateDataAssetFromAdwc extends CreateDataAssetDetails {
                             .serviceName(o.getServiceName())
                             .driverClass(o.getDriverClass())
                             .credentialFileContent(o.getCredentialFileContent())
+                            .walletSecret(o.getWalletSecret())
+                            .walletPasswordSecret(o.getWalletPasswordSecret())
                             .defaultConnection(o.getDefaultConnection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -215,6 +237,8 @@ public class CreateDataAssetFromAdwc extends CreateDataAssetDetails {
             String serviceName,
             String driverClass,
             String credentialFileContent,
+            SensitiveAttribute walletSecret,
+            SensitiveAttribute walletPasswordSecret,
             CreateConnectionFromAdwc defaultConnection) {
         super(
                 key,
@@ -229,6 +253,8 @@ public class CreateDataAssetFromAdwc extends CreateDataAssetDetails {
         this.serviceName = serviceName;
         this.driverClass = driverClass;
         this.credentialFileContent = credentialFileContent;
+        this.walletSecret = walletSecret;
+        this.walletPasswordSecret = walletPasswordSecret;
         this.defaultConnection = defaultConnection;
     }
 
@@ -249,6 +275,12 @@ public class CreateDataAssetFromAdwc extends CreateDataAssetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("credentialFileContent")
     String credentialFileContent;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+    SensitiveAttribute walletSecret;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+    SensitiveAttribute walletPasswordSecret;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
     CreateConnectionFromAdwc defaultConnection;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateDataAssetFromAtp.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateDataAssetFromAtp.java
@@ -140,6 +140,24 @@ public class CreateDataAssetFromAtp extends CreateDataAssetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+        private SensitiveAttribute walletSecret;
+
+        public Builder walletSecret(SensitiveAttribute walletSecret) {
+            this.walletSecret = walletSecret;
+            this.__explicitlySet__.add("walletSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+        private SensitiveAttribute walletPasswordSecret;
+
+        public Builder walletPasswordSecret(SensitiveAttribute walletPasswordSecret) {
+            this.walletPasswordSecret = walletPasswordSecret;
+            this.__explicitlySet__.add("walletPasswordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
         private CreateConnectionFromAtp defaultConnection;
 
@@ -167,6 +185,8 @@ public class CreateDataAssetFromAtp extends CreateDataAssetDetails {
                             serviceName,
                             driverClass,
                             credentialFileContent,
+                            walletSecret,
+                            walletPasswordSecret,
                             defaultConnection);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -187,6 +207,8 @@ public class CreateDataAssetFromAtp extends CreateDataAssetDetails {
                             .serviceName(o.getServiceName())
                             .driverClass(o.getDriverClass())
                             .credentialFileContent(o.getCredentialFileContent())
+                            .walletSecret(o.getWalletSecret())
+                            .walletPasswordSecret(o.getWalletPasswordSecret())
                             .defaultConnection(o.getDefaultConnection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -215,6 +237,8 @@ public class CreateDataAssetFromAtp extends CreateDataAssetDetails {
             String serviceName,
             String driverClass,
             String credentialFileContent,
+            SensitiveAttribute walletSecret,
+            SensitiveAttribute walletPasswordSecret,
             CreateConnectionFromAtp defaultConnection) {
         super(
                 key,
@@ -229,6 +253,8 @@ public class CreateDataAssetFromAtp extends CreateDataAssetDetails {
         this.serviceName = serviceName;
         this.driverClass = driverClass;
         this.credentialFileContent = credentialFileContent;
+        this.walletSecret = walletSecret;
+        this.walletPasswordSecret = walletPasswordSecret;
         this.defaultConnection = defaultConnection;
     }
 
@@ -249,6 +275,12 @@ public class CreateDataAssetFromAtp extends CreateDataAssetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("credentialFileContent")
     String credentialFileContent;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+    SensitiveAttribute walletSecret;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+    SensitiveAttribute walletPasswordSecret;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
     CreateConnectionFromAtp defaultConnection;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateDataAssetFromOracle.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateDataAssetFromOracle.java
@@ -167,6 +167,24 @@ public class CreateDataAssetFromOracle extends CreateDataAssetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+        private SensitiveAttribute walletSecret;
+
+        public Builder walletSecret(SensitiveAttribute walletSecret) {
+            this.walletSecret = walletSecret;
+            this.__explicitlySet__.add("walletSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+        private SensitiveAttribute walletPasswordSecret;
+
+        public Builder walletPasswordSecret(SensitiveAttribute walletPasswordSecret) {
+            this.walletPasswordSecret = walletPasswordSecret;
+            this.__explicitlySet__.add("walletPasswordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
         private CreateConnectionFromOracle defaultConnection;
 
@@ -197,6 +215,8 @@ public class CreateDataAssetFromOracle extends CreateDataAssetDetails {
                             driverClass,
                             sid,
                             credentialFileContent,
+                            walletSecret,
+                            walletPasswordSecret,
                             defaultConnection);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -220,6 +240,8 @@ public class CreateDataAssetFromOracle extends CreateDataAssetDetails {
                             .driverClass(o.getDriverClass())
                             .sid(o.getSid())
                             .credentialFileContent(o.getCredentialFileContent())
+                            .walletSecret(o.getWalletSecret())
+                            .walletPasswordSecret(o.getWalletPasswordSecret())
                             .defaultConnection(o.getDefaultConnection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -251,6 +273,8 @@ public class CreateDataAssetFromOracle extends CreateDataAssetDetails {
             String driverClass,
             String sid,
             String credentialFileContent,
+            SensitiveAttribute walletSecret,
+            SensitiveAttribute walletPasswordSecret,
             CreateConnectionFromOracle defaultConnection) {
         super(
                 key,
@@ -268,6 +292,8 @@ public class CreateDataAssetFromOracle extends CreateDataAssetDetails {
         this.driverClass = driverClass;
         this.sid = sid;
         this.credentialFileContent = credentialFileContent;
+        this.walletSecret = walletSecret;
+        this.walletPasswordSecret = walletPasswordSecret;
         this.defaultConnection = defaultConnection;
     }
 
@@ -306,6 +332,12 @@ public class CreateDataAssetFromOracle extends CreateDataAssetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("credentialFileContent")
     String credentialFileContent;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+    SensitiveAttribute walletSecret;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+    SensitiveAttribute walletPasswordSecret;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
     CreateConnectionFromOracle defaultConnection;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreatePipelineDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreatePipelineDetails.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Properties used in pipeline create operations
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreatePipelineDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreatePipelineDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+        private java.util.List<FlowNode> nodes;
+
+        public Builder nodes(java.util.List<FlowNode> nodes) {
+            this.nodes = nodes;
+            this.__explicitlySet__.add("nodes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+        private ConfigValues flowConfigValues;
+
+        public Builder flowConfigValues(ConfigValues flowConfigValues) {
+            this.flowConfigValues = flowConfigValues;
+            this.__explicitlySet__.add("flowConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("variables")
+        private java.util.List<Variable> variables;
+
+        public Builder variables(java.util.List<Variable> variables) {
+            this.variables = variables;
+            this.__explicitlySet__.add("variables");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("registryMetadata")
+        private RegistryMetadata registryMetadata;
+
+        public Builder registryMetadata(RegistryMetadata registryMetadata) {
+            this.registryMetadata = registryMetadata;
+            this.__explicitlySet__.add("registryMetadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreatePipelineDetails build() {
+            CreatePipelineDetails __instance__ =
+                    new CreatePipelineDetails(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            modelType,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            nodes,
+                            parameters,
+                            flowConfigValues,
+                            variables,
+                            registryMetadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreatePipelineDetails o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .modelType(o.getModelType())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .nodes(o.getNodes())
+                            .parameters(o.getParameters())
+                            .flowConfigValues(o.getFlowConfigValues())
+                            .variables(o.getVariables())
+                            .registryMetadata(o.getRegistryMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * A list of nodes attached to the pipeline
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+    java.util.List<FlowNode> nodes;
+
+    /**
+     * A list of additional parameters required in pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+    java.util.List<Parameter> parameters;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+    ConfigValues flowConfigValues;
+
+    /**
+     * The list of variables required in pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("variables")
+    java.util.List<Variable> variables;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("registryMetadata")
+    RegistryMetadata registryMetadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreatePipelineValidationDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreatePipelineValidationDetails.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The properties used in create pipeline validation operations.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreatePipelineValidationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreatePipelineValidationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+        private java.util.List<FlowNode> nodes;
+
+        public Builder nodes(java.util.List<FlowNode> nodes) {
+            this.nodes = nodes;
+            this.__explicitlySet__.add("nodes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+        private ConfigValues flowConfigValues;
+
+        public Builder flowConfigValues(ConfigValues flowConfigValues) {
+            this.flowConfigValues = flowConfigValues;
+            this.__explicitlySet__.add("flowConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("variables")
+        private java.util.List<Variable> variables;
+
+        public Builder variables(java.util.List<Variable> variables) {
+            this.variables = variables;
+            this.__explicitlySet__.add("variables");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreatePipelineValidationDetails build() {
+            CreatePipelineValidationDetails __instance__ =
+                    new CreatePipelineValidationDetails(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            modelType,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            nodes,
+                            parameters,
+                            flowConfigValues,
+                            variables,
+                            metadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreatePipelineValidationDetails o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .modelType(o.getModelType())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .nodes(o.getNodes())
+                            .parameters(o.getParameters())
+                            .flowConfigValues(o.getFlowConfigValues())
+                            .variables(o.getVariables())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * A list of nodes attached to the pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+    java.util.List<FlowNode> nodes;
+
+    /**
+     * A list of parameters for the pipeline, this allows certain aspects of the pipeline to be configured when the pipeline is executed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+    java.util.List<Parameter> parameters;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+    ConfigValues flowConfigValues;
+
+    /**
+     * The list of variables required in pipeline, variables can be used to store values that can be used as inputs to tasks in the pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("variables")
+    java.util.List<Variable> variables;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+    ObjectMetadata metadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskDetails.java
@@ -35,6 +35,10 @@ package com.oracle.bmc.dataintegration.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateTaskFromDataLoaderTask.class,
         name = "DATA_LOADER_TASK"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateTaskFromPipelineTask.class,
+        name = "PIPELINE_TASK"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
@@ -112,6 +116,7 @@ public class CreateTaskDetails {
     public enum ModelType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
         ;
 
         private final String value;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskFromPipelineTask.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskFromPipelineTask.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about the pipeline task.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateTaskFromPipelineTask.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateTaskFromPipelineTask extends CreateTaskDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+        private CreateConfigProvider configProviderDelegate;
+
+        public Builder configProviderDelegate(CreateConfigProvider configProviderDelegate) {
+            this.configProviderDelegate = configProviderDelegate;
+            this.__explicitlySet__.add("configProviderDelegate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("registryMetadata")
+        private RegistryMetadata registryMetadata;
+
+        public Builder registryMetadata(RegistryMetadata registryMetadata) {
+            this.registryMetadata = registryMetadata;
+            this.__explicitlySet__.add("registryMetadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+        private Pipeline pipeline;
+
+        public Builder pipeline(Pipeline pipeline) {
+            this.pipeline = pipeline;
+            this.__explicitlySet__.add("pipeline");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateTaskFromPipelineTask build() {
+            CreateTaskFromPipelineTask __instance__ =
+                    new CreateTaskFromPipelineTask(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectStatus,
+                            identifier,
+                            inputPorts,
+                            outputPorts,
+                            parameters,
+                            opConfigValues,
+                            configProviderDelegate,
+                            registryMetadata,
+                            pipeline);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateTaskFromPipelineTask o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .configProviderDelegate(o.getConfigProviderDelegate())
+                            .registryMetadata(o.getRegistryMetadata())
+                            .pipeline(o.getPipeline());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateTaskFromPipelineTask(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            CreateConfigProvider configProviderDelegate,
+            RegistryMetadata registryMetadata,
+            Pipeline pipeline) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectStatus,
+                identifier,
+                inputPorts,
+                outputPorts,
+                parameters,
+                opConfigValues,
+                configProviderDelegate,
+                registryMetadata);
+        this.pipeline = pipeline;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+    Pipeline pipeline;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskValidationDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskValidationDetails.java
@@ -33,6 +33,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "DATA_LOADER_TASK"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateTaskValidationFromPipelineTask.class,
+        name = "PIPELINE_TASK"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = CreateTaskValidationFromIntegrationTask.class,
         name = "INTEGRATION_TASK"
     )
@@ -118,6 +122,7 @@ public class CreateTaskValidationDetails {
     public enum ModelType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
         ;
 
         private final String value;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskValidationFromPipelineTask.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/CreateTaskValidationFromPipelineTask.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about a pipeline task.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateTaskValidationFromPipelineTask.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateTaskValidationFromPipelineTask extends CreateTaskValidationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+        private ConfigProvider configProviderDelegate;
+
+        public Builder configProviderDelegate(ConfigProvider configProviderDelegate) {
+            this.configProviderDelegate = configProviderDelegate;
+            this.__explicitlySet__.add("configProviderDelegate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+        private Pipeline pipeline;
+
+        public Builder pipeline(Pipeline pipeline) {
+            this.pipeline = pipeline;
+            this.__explicitlySet__.add("pipeline");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateTaskValidationFromPipelineTask build() {
+            CreateTaskValidationFromPipelineTask __instance__ =
+                    new CreateTaskValidationFromPipelineTask(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            inputPorts,
+                            outputPorts,
+                            parameters,
+                            opConfigValues,
+                            configProviderDelegate,
+                            metadata,
+                            pipeline);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateTaskValidationFromPipelineTask o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .configProviderDelegate(o.getConfigProviderDelegate())
+                            .metadata(o.getMetadata())
+                            .pipeline(o.getPipeline());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateTaskValidationFromPipelineTask(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            ConfigProvider configProviderDelegate,
+            ObjectMetadata metadata,
+            Pipeline pipeline) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                objectStatus,
+                identifier,
+                inputPorts,
+                outputPorts,
+                parameters,
+                opConfigValues,
+                configProviderDelegate,
+                metadata);
+        this.pipeline = pipeline;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+    Pipeline pipeline;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DailyFrequencyDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DailyFrequencyDetails.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Frequency details model to set daily frequency
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DailyFrequencyDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DailyFrequencyDetails extends AbstractFrequencyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("frequency")
+        private Frequency frequency;
+
+        public Builder frequency(Frequency frequency) {
+            this.frequency = frequency;
+            this.__explicitlySet__.add("frequency");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("interval")
+        private Integer interval;
+
+        public Builder interval(Integer interval) {
+            this.interval = interval;
+            this.__explicitlySet__.add("interval");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("time")
+        private Time time;
+
+        public Builder time(Time time) {
+            this.time = time;
+            this.__explicitlySet__.add("time");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DailyFrequencyDetails build() {
+            DailyFrequencyDetails __instance__ =
+                    new DailyFrequencyDetails(frequency, interval, time);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DailyFrequencyDetails o) {
+            Builder copiedBuilder =
+                    frequency(o.getFrequency()).interval(o.getInterval()).time(o.getTime());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public DailyFrequencyDetails(Frequency frequency, Integer interval, Time time) {
+        super(frequency);
+        this.interval = interval;
+        this.time = time;
+    }
+
+    /**
+     * This hold the repeatability aspect of a schedule. i.e. in a monhtly frequency, a task can be scheduled for every month, once in two months, once in tree months etc.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("interval")
+    Integer interval;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("time")
+    Time time;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataAssetFromOracleDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataAssetFromOracleDetails.java
@@ -203,6 +203,24 @@ public class DataAssetFromOracleDetails extends DataAsset {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+        private SensitiveAttribute walletSecret;
+
+        public Builder walletSecret(SensitiveAttribute walletSecret) {
+            this.walletSecret = walletSecret;
+            this.__explicitlySet__.add("walletSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+        private SensitiveAttribute walletPasswordSecret;
+
+        public Builder walletPasswordSecret(SensitiveAttribute walletPasswordSecret) {
+            this.walletPasswordSecret = walletPasswordSecret;
+            this.__explicitlySet__.add("walletPasswordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
         private ConnectionFromOracleDetails defaultConnection;
 
@@ -237,6 +255,8 @@ public class DataAssetFromOracleDetails extends DataAsset {
                             driverClass,
                             sid,
                             credentialFileContent,
+                            walletSecret,
+                            walletPasswordSecret,
                             defaultConnection);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -264,6 +284,8 @@ public class DataAssetFromOracleDetails extends DataAsset {
                             .driverClass(o.getDriverClass())
                             .sid(o.getSid())
                             .credentialFileContent(o.getCredentialFileContent())
+                            .walletSecret(o.getWalletSecret())
+                            .walletPasswordSecret(o.getWalletPasswordSecret())
                             .defaultConnection(o.getDefaultConnection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -299,6 +321,8 @@ public class DataAssetFromOracleDetails extends DataAsset {
             String driverClass,
             String sid,
             String credentialFileContent,
+            SensitiveAttribute walletSecret,
+            SensitiveAttribute walletPasswordSecret,
             ConnectionFromOracleDetails defaultConnection) {
         super(
                 key,
@@ -320,6 +344,8 @@ public class DataAssetFromOracleDetails extends DataAsset {
         this.driverClass = driverClass;
         this.sid = sid;
         this.credentialFileContent = credentialFileContent;
+        this.walletSecret = walletSecret;
+        this.walletPasswordSecret = walletPasswordSecret;
         this.defaultConnection = defaultConnection;
     }
 
@@ -358,6 +384,12 @@ public class DataAssetFromOracleDetails extends DataAsset {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("credentialFileContent")
     String credentialFileContent;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+    SensitiveAttribute walletSecret;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+    SensitiveAttribute walletPasswordSecret;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
     ConnectionFromOracleDetails defaultConnection;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataAssetSummaryFromOracle.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataAssetSummaryFromOracle.java
@@ -194,6 +194,24 @@ public class DataAssetSummaryFromOracle extends DataAssetSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+        private SensitiveAttribute walletSecret;
+
+        public Builder walletSecret(SensitiveAttribute walletSecret) {
+            this.walletSecret = walletSecret;
+            this.__explicitlySet__.add("walletSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+        private SensitiveAttribute walletPasswordSecret;
+
+        public Builder walletPasswordSecret(SensitiveAttribute walletPasswordSecret) {
+            this.walletPasswordSecret = walletPasswordSecret;
+            this.__explicitlySet__.add("walletPasswordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
         private ConnectionSummaryFromOracle defaultConnection;
 
@@ -227,6 +245,8 @@ public class DataAssetSummaryFromOracle extends DataAssetSummary {
                             driverClass,
                             sid,
                             credentialFileContent,
+                            walletSecret,
+                            walletPasswordSecret,
                             defaultConnection);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -253,6 +273,8 @@ public class DataAssetSummaryFromOracle extends DataAssetSummary {
                             .driverClass(o.getDriverClass())
                             .sid(o.getSid())
                             .credentialFileContent(o.getCredentialFileContent())
+                            .walletSecret(o.getWalletSecret())
+                            .walletPasswordSecret(o.getWalletPasswordSecret())
                             .defaultConnection(o.getDefaultConnection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -287,6 +309,8 @@ public class DataAssetSummaryFromOracle extends DataAssetSummary {
             String driverClass,
             String sid,
             String credentialFileContent,
+            SensitiveAttribute walletSecret,
+            SensitiveAttribute walletPasswordSecret,
             ConnectionSummaryFromOracle defaultConnection) {
         super(
                 key,
@@ -307,6 +331,8 @@ public class DataAssetSummaryFromOracle extends DataAssetSummary {
         this.driverClass = driverClass;
         this.sid = sid;
         this.credentialFileContent = credentialFileContent;
+        this.walletSecret = walletSecret;
+        this.walletPasswordSecret = walletPasswordSecret;
         this.defaultConnection = defaultConnection;
     }
 
@@ -345,6 +371,12 @@ public class DataAssetSummaryFromOracle extends DataAssetSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("credentialFileContent")
     String credentialFileContent;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+    SensitiveAttribute walletSecret;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+    SensitiveAttribute walletPasswordSecret;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
     ConnectionSummaryFromOracle defaultConnection;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataFormat.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DataFormat.java
@@ -42,18 +42,30 @@ public class DataFormat {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("compressionConfig")
+        private Compression compressionConfig;
+
+        public Builder compressionConfig(Compression compressionConfig) {
+            this.compressionConfig = compressionConfig;
+            this.__explicitlySet__.add("compressionConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public DataFormat build() {
-            DataFormat __instance__ = new DataFormat(formatAttribute, type);
+            DataFormat __instance__ = new DataFormat(formatAttribute, type, compressionConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DataFormat o) {
-            Builder copiedBuilder = formatAttribute(o.getFormatAttribute()).type(o.getType());
+            Builder copiedBuilder =
+                    formatAttribute(o.getFormatAttribute())
+                            .type(o.getType())
+                            .compressionConfig(o.getCompressionConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -123,6 +135,9 @@ public class DataFormat {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     Type type;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("compressionConfig")
+    Compression compressionConfig;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DependentObjectSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/DependentObjectSummary.java
@@ -89,6 +89,15 @@ public class DependentObjectSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("aggregator")
+        private AggregatorSummary aggregator;
+
+        public Builder aggregator(AggregatorSummary aggregator) {
+            this.aggregator = aggregator;
+            this.__explicitlySet__.add("aggregator");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("identifierPath")
         private String identifierPath;
 
@@ -147,6 +156,7 @@ public class DependentObjectSummary {
                             timeCreated,
                             timeUpdated,
                             aggregatorKey,
+                            aggregator,
                             identifierPath,
                             infoFields,
                             registryVersion,
@@ -166,6 +176,7 @@ public class DependentObjectSummary {
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .aggregatorKey(o.getAggregatorKey())
+                            .aggregator(o.getAggregator())
                             .identifierPath(o.getIdentifierPath())
                             .infoFields(o.getInfoFields())
                             .registryVersion(o.getRegistryVersion())
@@ -225,6 +236,9 @@ public class DependentObjectSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("aggregatorKey")
     String aggregatorKey;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("aggregator")
+    AggregatorSummary aggregator;
 
     /**
      * The full path to identify this object.

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/EndOperator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/EndOperator.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Represents end of a pipeline
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = EndOperator.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EndOperator extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("triggerRule")
+        private TriggerRule triggerRule;
+
+        public Builder triggerRule(TriggerRule triggerRule) {
+            this.triggerRule = triggerRule;
+            this.__explicitlySet__.add("triggerRule");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EndOperator build() {
+            EndOperator __instance__ =
+                    new EndOperator(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            triggerRule);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EndOperator o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .triggerRule(o.getTriggerRule());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public EndOperator(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            TriggerRule triggerRule) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.triggerRule = triggerRule;
+    }
+
+    /**
+     * The merge condition. The conditions are
+     * ALL_SUCCESS - All the preceeding operators need to be successful.
+     * ALL_FAILED - All the preceeding operators should have failed.
+     * ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum TriggerRule {
+        AllSuccess("ALL_SUCCESS"),
+        AllFailed("ALL_FAILED"),
+        AllComplete("ALL_COMPLETE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, TriggerRule> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (TriggerRule v : TriggerRule.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        TriggerRule(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static TriggerRule create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'TriggerRule', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The merge condition. The conditions are
+     * ALL_SUCCESS - All the preceeding operators need to be successful.
+     * ALL_FAILED - All the preceeding operators should have failed.
+     * ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("triggerRule")
+    TriggerRule triggerRule;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/HourlyFrequencyDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/HourlyFrequencyDetails.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Frequency details model to set hourly frequency
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = HourlyFrequencyDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class HourlyFrequencyDetails extends AbstractFrequencyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("frequency")
+        private Frequency frequency;
+
+        public Builder frequency(Frequency frequency) {
+            this.frequency = frequency;
+            this.__explicitlySet__.add("frequency");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("interval")
+        private Integer interval;
+
+        public Builder interval(Integer interval) {
+            this.interval = interval;
+            this.__explicitlySet__.add("interval");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("time")
+        private Time time;
+
+        public Builder time(Time time) {
+            this.time = time;
+            this.__explicitlySet__.add("time");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public HourlyFrequencyDetails build() {
+            HourlyFrequencyDetails __instance__ =
+                    new HourlyFrequencyDetails(frequency, interval, time);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(HourlyFrequencyDetails o) {
+            Builder copiedBuilder =
+                    frequency(o.getFrequency()).interval(o.getInterval()).time(o.getTime());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public HourlyFrequencyDetails(Frequency frequency, Integer interval, Time time) {
+        super(frequency);
+        this.interval = interval;
+        this.time = time;
+    }
+
+    /**
+     * This hold the repeatability aspect of a schedule. i.e. in a monhtly frequency, a task can be scheduled for every month, once in two months, once in tree months etc.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("interval")
+    Integer interval;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("time")
+    Time time;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Intersect.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Intersect.java
@@ -1,0 +1,306 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about a intersect object.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Intersect.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Intersect extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("intersectType")
+        private IntersectType intersectType;
+
+        public Builder intersectType(IntersectType intersectType) {
+            this.intersectType = intersectType;
+            this.__explicitlySet__.add("intersectType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isAll")
+        private Boolean isAll;
+
+        public Builder isAll(Boolean isAll) {
+            this.isAll = isAll;
+            this.__explicitlySet__.add("isAll");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Intersect build() {
+            Intersect __instance__ =
+                    new Intersect(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            intersectType,
+                            isAll);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Intersect o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .intersectType(o.getIntersectType())
+                            .isAll(o.getIsAll());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public Intersect(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            IntersectType intersectType,
+            Boolean isAll) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.intersectType = intersectType;
+        this.isAll = isAll;
+    }
+
+    /**
+     * intersectType
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum IntersectType {
+        Name("NAME"),
+        Position("POSITION"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, IntersectType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (IntersectType v : IntersectType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        IntersectType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static IntersectType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'IntersectType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * intersectType
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("intersectType")
+    IntersectType intersectType;
+
+    /**
+     * The information about the intersect all.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAll")
+    Boolean isAll;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Key.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Key.java
@@ -29,10 +29,6 @@ package com.oracle.bmc.dataintegration.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = UniqueKey.class,
-        name = "UNIQUE_KEY"
-    ),
-    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = ForeignKey.class,
         name = "FOREIGN_KEY"
     )
@@ -45,8 +41,6 @@ public class Key {
      **/
     public enum ModelType {
         ForeignKey("FOREIGN_KEY"),
-        PrimaryKey("PRIMARY_KEY"),
-        UniqueKey("UNIQUE_KEY"),
         ;
 
         private final String value;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/LastRunDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/LastRunDetails.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The last run details for the task run.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = LastRunDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LastRunDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lastRunTimeMillis")
+        private Long lastRunTimeMillis;
+
+        public Builder lastRunTimeMillis(Long lastRunTimeMillis) {
+            this.lastRunTimeMillis = lastRunTimeMillis;
+            this.__explicitlySet__.add("lastRunTimeMillis");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LastRunDetails build() {
+            LastRunDetails __instance__ =
+                    new LastRunDetails(
+                            key,
+                            modelVersion,
+                            modelType,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            lastRunTimeMillis);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LastRunDetails o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .modelType(o.getModelType())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .lastRunTimeMillis(o.getLastRunTimeMillis());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Generated key that can be used in API calls to identify Last run details of a task schedule. On scenarios where reference to the lastRunDetails is needed, a value can be passed in create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * Time in milliseconds for the pervious schedule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lastRunTimeMillis")
+    Long lastRunTimeMillis;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/MergeOperator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/MergeOperator.java
@@ -1,0 +1,302 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Represents the start of a pipeline.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = MergeOperator.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MergeOperator extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("triggerRule")
+        private TriggerRule triggerRule;
+
+        public Builder triggerRule(TriggerRule triggerRule) {
+            this.triggerRule = triggerRule;
+            this.__explicitlySet__.add("triggerRule");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MergeOperator build() {
+            MergeOperator __instance__ =
+                    new MergeOperator(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            triggerRule);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MergeOperator o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .triggerRule(o.getTriggerRule());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public MergeOperator(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            TriggerRule triggerRule) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.triggerRule = triggerRule;
+    }
+
+    /**
+     * The merge condition. The conditions are
+     * ALL_SUCCESS - All the preceeding operators need to be successful.
+     * ALL_FAILED - All the preceeding operators should have failed.
+     * ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+     * ONE_SUCCESS - Atleast one of the preceeding operators should have succeeded.
+     * ONE_FAILED - Atleast one of the preceeding operators should have failed.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum TriggerRule {
+        AllSuccess("ALL_SUCCESS"),
+        AllFailed("ALL_FAILED"),
+        AllComplete("ALL_COMPLETE"),
+        OneSuccess("ONE_SUCCESS"),
+        OneFailed("ONE_FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, TriggerRule> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (TriggerRule v : TriggerRule.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        TriggerRule(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static TriggerRule create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'TriggerRule', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The merge condition. The conditions are
+     * ALL_SUCCESS - All the preceeding operators need to be successful.
+     * ALL_FAILED - All the preceeding operators should have failed.
+     * ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+     * ONE_SUCCESS - Atleast one of the preceeding operators should have succeeded.
+     * ONE_FAILED - Atleast one of the preceeding operators should have failed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("triggerRule")
+    TriggerRule triggerRule;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Minus.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Minus.java
@@ -1,0 +1,306 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about a minus object.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Minus.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Minus extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("minusType")
+        private MinusType minusType;
+
+        public Builder minusType(MinusType minusType) {
+            this.minusType = minusType;
+            this.__explicitlySet__.add("minusType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isAll")
+        private Boolean isAll;
+
+        public Builder isAll(Boolean isAll) {
+            this.isAll = isAll;
+            this.__explicitlySet__.add("isAll");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Minus build() {
+            Minus __instance__ =
+                    new Minus(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            minusType,
+                            isAll);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Minus o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .minusType(o.getMinusType())
+                            .isAll(o.getIsAll());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public Minus(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            MinusType minusType,
+            Boolean isAll) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.minusType = minusType;
+        this.isAll = isAll;
+    }
+
+    /**
+     * minusType
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum MinusType {
+        Name("NAME"),
+        Position("POSITION"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, MinusType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (MinusType v : MinusType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        MinusType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static MinusType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'MinusType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * minusType
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minusType")
+    MinusType minusType;
+
+    /**
+     * The information about the minus all.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAll")
+    Boolean isAll;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/MonthlyFrequencyDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/MonthlyFrequencyDetails.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Frequency Details model for monthly frequency.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = MonthlyFrequencyDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MonthlyFrequencyDetails extends AbstractFrequencyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("frequency")
+        private Frequency frequency;
+
+        public Builder frequency(Frequency frequency) {
+            this.frequency = frequency;
+            this.__explicitlySet__.add("frequency");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("interval")
+        private Integer interval;
+
+        public Builder interval(Integer interval) {
+            this.interval = interval;
+            this.__explicitlySet__.add("interval");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("time")
+        private Time time;
+
+        public Builder time(Time time) {
+            this.time = time;
+            this.__explicitlySet__.add("time");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("days")
+        private java.util.List<Integer> days;
+
+        public Builder days(java.util.List<Integer> days) {
+            this.days = days;
+            this.__explicitlySet__.add("days");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MonthlyFrequencyDetails build() {
+            MonthlyFrequencyDetails __instance__ =
+                    new MonthlyFrequencyDetails(frequency, interval, time, days);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MonthlyFrequencyDetails o) {
+            Builder copiedBuilder =
+                    frequency(o.getFrequency())
+                            .interval(o.getInterval())
+                            .time(o.getTime())
+                            .days(o.getDays());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public MonthlyFrequencyDetails(
+            Frequency frequency, Integer interval, Time time, java.util.List<Integer> days) {
+        super(frequency);
+        this.interval = interval;
+        this.time = time;
+        this.days = days;
+    }
+
+    /**
+     * This hold the repeatability aspect of a schedule. i.e. in a monhtly frequency, a task can be scheduled for every month, once in two months, once in tree months etc.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("interval")
+    Integer interval;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("time")
+    Time time;
+
+    /**
+     * A list of days of the month to be scheduled. i.e. excute every 2nd,3rd, 10th of the month.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("days")
+    java.util.List<Integer> days;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ObjectMetadata.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/ObjectMetadata.java
@@ -87,6 +87,15 @@ public class ObjectMetadata {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("aggregator")
+        private AggregatorSummary aggregator;
+
+        public Builder aggregator(AggregatorSummary aggregator) {
+            this.aggregator = aggregator;
+            this.__explicitlySet__.add("aggregator");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("identifierPath")
         private String identifierPath;
 
@@ -145,6 +154,7 @@ public class ObjectMetadata {
                             timeCreated,
                             timeUpdated,
                             aggregatorKey,
+                            aggregator,
                             identifierPath,
                             infoFields,
                             registryVersion,
@@ -164,6 +174,7 @@ public class ObjectMetadata {
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .aggregatorKey(o.getAggregatorKey())
+                            .aggregator(o.getAggregator())
                             .identifierPath(o.getIdentifierPath())
                             .infoFields(o.getInfoFields())
                             .registryVersion(o.getRegistryVersion())
@@ -223,6 +234,9 @@ public class ObjectMetadata {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("aggregatorKey")
     String aggregatorKey;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("aggregator")
+    AggregatorSummary aggregator;
 
     /**
      * The full path to identify this object.

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/OciVaultSecretConfig.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/OciVaultSecretConfig.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Properties used for specifying OCI vault configuration
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OciVaultSecretConfig.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OciVaultSecretConfig extends SecretConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("secretId")
+        private String secretId;
+
+        public Builder secretId(String secretId) {
+            this.secretId = secretId;
+            this.__explicitlySet__.add("secretId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OciVaultSecretConfig build() {
+            OciVaultSecretConfig __instance__ = new OciVaultSecretConfig(secretId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OciVaultSecretConfig o) {
+            Builder copiedBuilder = secretId(o.getSecretId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OciVaultSecretConfig(String secretId) {
+        super();
+        this.secretId = secretId;
+    }
+
+    /**
+     * OCID of the OCI vault secret
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("secretId")
+    String secretId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Operator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Operator.java
@@ -29,20 +29,12 @@ package com.oracle.bmc.dataintegration.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = Target.class,
-        name = "TARGET_OPERATOR"
-    ),
-    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = Joiner.class,
         name = "JOINER_OPERATOR"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = Distinct.class,
-        name = "DISTINCT_OPERATOR"
-    ),
-    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
-        value = Filter.class,
-        name = "FILTER_OPERATOR"
+        value = TaskOperator.class,
+        name = "TASK_OPERATOR"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = Aggregator.class,
@@ -57,8 +49,44 @@ package com.oracle.bmc.dataintegration.model;
         name = "PROJECTION_OPERATOR"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = EndOperator.class,
+        name = "END_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = Source.class,
         name = "SOURCE_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Union.class,
+        name = "UNION_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Intersect.class,
+        name = "INTERSECT_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Target.class,
+        name = "TARGET_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Distinct.class,
+        name = "DISTINCT_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Filter.class,
+        name = "FILTER_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = StartOperator.class,
+        name = "START_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = MergeOperator.class,
+        name = "MERGE_OPERATOR"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = Minus.class,
+        name = "MINUS_OPERATOR"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
@@ -143,6 +171,15 @@ public class Operator {
         TargetOperator("TARGET_OPERATOR"),
         DistinctOperator("DISTINCT_OPERATOR"),
         SortOperator("SORT_OPERATOR"),
+        UnionOperator("UNION_OPERATOR"),
+        IntersectOperator("INTERSECT_OPERATOR"),
+        MinusOperator("MINUS_OPERATOR"),
+        MergeOperator("MERGE_OPERATOR"),
+        StartOperator("START_OPERATOR"),
+        EndOperator("END_OPERATOR"),
+        PipelineOperator("PIPELINE_OPERATOR"),
+        RestOperator("REST_OPERATOR"),
+        TaskOperator("TASK_OPERATOR"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PatchChangeSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PatchChangeSummary.java
@@ -147,6 +147,7 @@ public class PatchChangeSummary {
     public enum Type {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PatchObjectMetadata.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PatchObjectMetadata.java
@@ -147,6 +147,7 @@ public class PatchObjectMetadata {
     public enum Type {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Pipeline.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Pipeline.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * A pipeline is a logical grouping of tasks that together perform a higher level operation. For example, a pipeline could contain a set of tasks that load and clean data, then execute a dataflow to analyze the data. The pipeline allows you to manage the activities as a unit instead of individually. Users can also schedule the pipeline instead of the tasks independently.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Pipeline.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Pipeline {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+        private java.util.List<FlowNode> nodes;
+
+        public Builder nodes(java.util.List<FlowNode> nodes) {
+            this.nodes = nodes;
+            this.__explicitlySet__.add("nodes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+        private ConfigValues flowConfigValues;
+
+        public Builder flowConfigValues(ConfigValues flowConfigValues) {
+            this.flowConfigValues = flowConfigValues;
+            this.__explicitlySet__.add("flowConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("variables")
+        private java.util.List<Variable> variables;
+
+        public Builder variables(java.util.List<Variable> variables) {
+            this.variables = variables;
+            this.__explicitlySet__.add("variables");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Pipeline build() {
+            Pipeline __instance__ =
+                    new Pipeline(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            modelType,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            nodes,
+                            parameters,
+                            flowConfigValues,
+                            variables,
+                            metadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Pipeline o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .modelType(o.getModelType())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .nodes(o.getNodes())
+                            .parameters(o.getParameters())
+                            .flowConfigValues(o.getFlowConfigValues())
+                            .variables(o.getVariables())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * A list of nodes attached to the pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+    java.util.List<FlowNode> nodes;
+
+    /**
+     * A list of parameters for the pipeline, this allows certain aspects of the pipeline to be configured when the pipeline is executed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+    java.util.List<Parameter> parameters;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+    ConfigValues flowConfigValues;
+
+    /**
+     * The list of variables required in pipeline, variables can be used to store values that can be used as inputs to tasks in the pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("variables")
+    java.util.List<Variable> variables;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+    ObjectMetadata metadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineSummary.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The pipeline summary type contains the audit summary information and the definition of the pipeline.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PipelineSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PipelineSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+        private java.util.List<FlowNode> nodes;
+
+        public Builder nodes(java.util.List<FlowNode> nodes) {
+            this.nodes = nodes;
+            this.__explicitlySet__.add("nodes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+        private ConfigValues flowConfigValues;
+
+        public Builder flowConfigValues(ConfigValues flowConfigValues) {
+            this.flowConfigValues = flowConfigValues;
+            this.__explicitlySet__.add("flowConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("variables")
+        private java.util.List<Variable> variables;
+
+        public Builder variables(java.util.List<Variable> variables) {
+            this.variables = variables;
+            this.__explicitlySet__.add("variables");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PipelineSummary build() {
+            PipelineSummary __instance__ =
+                    new PipelineSummary(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            modelType,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            nodes,
+                            parameters,
+                            flowConfigValues,
+                            variables,
+                            metadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PipelineSummary o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .modelType(o.getModelType())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .nodes(o.getNodes())
+                            .parameters(o.getParameters())
+                            .flowConfigValues(o.getFlowConfigValues())
+                            .variables(o.getVariables())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * A list of nodes attached to the pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+    java.util.List<FlowNode> nodes;
+
+    /**
+     * A list of parameters for the pipeline, this allows certain aspects of the pipeline to be configured when the pipeline is executed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+    java.util.List<Parameter> parameters;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+    ConfigValues flowConfigValues;
+
+    /**
+     * The list of variables required in pipeline, variables can be used to store values that can be used as inputs to tasks in the pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("variables")
+    java.util.List<Variable> variables;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+    ObjectMetadata metadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineSummaryCollection.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineSummaryCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * This is the collection of pipeline summaries, it may be a collection of lightweight details or full definitions.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PipelineSummaryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PipelineSummaryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<PipelineSummary> items;
+
+        public Builder items(java.util.List<PipelineSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PipelineSummaryCollection build() {
+            PipelineSummaryCollection __instance__ = new PipelineSummaryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PipelineSummaryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The array of pipeline summaries.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<PipelineSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineValidation.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineValidation.java
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about a pipeline validation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PipelineValidation.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PipelineValidation {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("totalMessageCount")
+        private Integer totalMessageCount;
+
+        public Builder totalMessageCount(Integer totalMessageCount) {
+            this.totalMessageCount = totalMessageCount;
+            this.__explicitlySet__.add("totalMessageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorMessageCount")
+        private Integer errorMessageCount;
+
+        public Builder errorMessageCount(Integer errorMessageCount) {
+            this.errorMessageCount = errorMessageCount;
+            this.__explicitlySet__.add("errorMessageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("warnMessageCount")
+        private Integer warnMessageCount;
+
+        public Builder warnMessageCount(Integer warnMessageCount) {
+            this.warnMessageCount = warnMessageCount;
+            this.__explicitlySet__.add("warnMessageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("infoMessageCount")
+        private Integer infoMessageCount;
+
+        public Builder infoMessageCount(Integer infoMessageCount) {
+            this.infoMessageCount = infoMessageCount;
+            this.__explicitlySet__.add("infoMessageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("validationMessages")
+        private java.util.Map<String, java.util.List<ValidationMessage>> validationMessages;
+
+        public Builder validationMessages(
+                java.util.Map<String, java.util.List<ValidationMessage>> validationMessages) {
+            this.validationMessages = validationMessages;
+            this.__explicitlySet__.add("validationMessages");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PipelineValidation build() {
+            PipelineValidation __instance__ =
+                    new PipelineValidation(
+                            totalMessageCount,
+                            errorMessageCount,
+                            warnMessageCount,
+                            infoMessageCount,
+                            validationMessages,
+                            key,
+                            modelType,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            metadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PipelineValidation o) {
+            Builder copiedBuilder =
+                    totalMessageCount(o.getTotalMessageCount())
+                            .errorMessageCount(o.getErrorMessageCount())
+                            .warnMessageCount(o.getWarnMessageCount())
+                            .infoMessageCount(o.getInfoMessageCount())
+                            .validationMessages(o.getValidationMessages())
+                            .key(o.getKey())
+                            .modelType(o.getModelType())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The total number of validation messages.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalMessageCount")
+    Integer totalMessageCount;
+
+    /**
+     * The total number of validation error messages.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorMessageCount")
+    Integer errorMessageCount;
+
+    /**
+     * The total number of validation warning messages.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("warnMessageCount")
+    Integer warnMessageCount;
+
+    /**
+     * The total number of validation information messages.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("infoMessageCount")
+    Integer infoMessageCount;
+
+    /**
+     * The detailed information of the pipeline object validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("validationMessages")
+    java.util.Map<String, java.util.List<ValidationMessage>> validationMessages;
+
+    /**
+     * Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+    ObjectMetadata metadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineValidationSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineValidationSummary.java
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about a pipeline validation.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PipelineValidationSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PipelineValidationSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("totalMessageCount")
+        private Integer totalMessageCount;
+
+        public Builder totalMessageCount(Integer totalMessageCount) {
+            this.totalMessageCount = totalMessageCount;
+            this.__explicitlySet__.add("totalMessageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorMessageCount")
+        private Integer errorMessageCount;
+
+        public Builder errorMessageCount(Integer errorMessageCount) {
+            this.errorMessageCount = errorMessageCount;
+            this.__explicitlySet__.add("errorMessageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("warnMessageCount")
+        private Integer warnMessageCount;
+
+        public Builder warnMessageCount(Integer warnMessageCount) {
+            this.warnMessageCount = warnMessageCount;
+            this.__explicitlySet__.add("warnMessageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("infoMessageCount")
+        private Integer infoMessageCount;
+
+        public Builder infoMessageCount(Integer infoMessageCount) {
+            this.infoMessageCount = infoMessageCount;
+            this.__explicitlySet__.add("infoMessageCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("validationMessages")
+        private java.util.Map<String, java.util.List<ValidationMessage>> validationMessages;
+
+        public Builder validationMessages(
+                java.util.Map<String, java.util.List<ValidationMessage>> validationMessages) {
+            this.validationMessages = validationMessages;
+            this.__explicitlySet__.add("validationMessages");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PipelineValidationSummary build() {
+            PipelineValidationSummary __instance__ =
+                    new PipelineValidationSummary(
+                            totalMessageCount,
+                            errorMessageCount,
+                            warnMessageCount,
+                            infoMessageCount,
+                            validationMessages,
+                            key,
+                            modelType,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            metadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PipelineValidationSummary o) {
+            Builder copiedBuilder =
+                    totalMessageCount(o.getTotalMessageCount())
+                            .errorMessageCount(o.getErrorMessageCount())
+                            .warnMessageCount(o.getWarnMessageCount())
+                            .infoMessageCount(o.getInfoMessageCount())
+                            .validationMessages(o.getValidationMessages())
+                            .key(o.getKey())
+                            .modelType(o.getModelType())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The total number of validation messages.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalMessageCount")
+    Integer totalMessageCount;
+
+    /**
+     * The total number of validation error messages.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorMessageCount")
+    Integer errorMessageCount;
+
+    /**
+     * The total number of validation warning messages.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("warnMessageCount")
+    Integer warnMessageCount;
+
+    /**
+     * The total number of validation information messages.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("infoMessageCount")
+    Integer infoMessageCount;
+
+    /**
+     * The detailed information of the pipeline object validation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("validationMessages")
+    java.util.Map<String, java.util.List<ValidationMessage>> validationMessages;
+
+    /**
+     * Objects will use a 36 character key as unique ID. It is system generated and cannot be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+    ObjectMetadata metadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineValidationSummaryCollection.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PipelineValidationSummaryCollection.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * A list of pipeline validation summaries.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PipelineValidationSummaryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PipelineValidationSummaryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<PipelineValidationSummary> items;
+
+        public Builder items(java.util.List<PipelineValidationSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PipelineValidationSummaryCollection build() {
+            PipelineValidationSummaryCollection __instance__ =
+                    new PipelineValidationSummaryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PipelineValidationSummaryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The array of validation summaries.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<PipelineValidationSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PrimaryKey.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PrimaryKey.java
@@ -15,12 +15,18 @@ package com.oracle.bmc.dataintegration.model;
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
-@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PrimaryKey.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
 @lombok.Builder(builderClassName = "Builder", toBuilder = true)
-public class PrimaryKey {
+public class PrimaryKey extends UniqueKey {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
@@ -110,38 +116,16 @@ public class PrimaryKey {
         return new Builder();
     }
 
-    /**
-     * The object key.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("key")
-    String key;
-
-    /**
-     * The object's model version.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
-    String modelVersion;
-
-    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
-    ParentReference parentRef;
-
-    /**
-     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("name")
-    String name;
-
-    /**
-     * An array of attribute references.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("attributeRefs")
-    java.util.List<KeyAttribute> attributeRefs;
-
-    /**
-     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
-    Integer objectStatus;
+    @Deprecated
+    public PrimaryKey(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            java.util.List<KeyAttribute> attributeRefs,
+            Integer objectStatus) {
+        super(key, modelVersion, parentRef, name, attributeRefs, objectStatus);
+    }
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObject.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObject.java
@@ -33,6 +33,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "DATA_LOADER_TASK"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PublishedObjectFromPipelineTask.class,
+        name = "PIPELINE_TASK"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = PublishedObjectFromIntegrationTask.class,
         name = "INTEGRATION_TASK"
     )
@@ -92,6 +96,7 @@ public class PublishedObject {
     public enum ModelType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObjectFromPipelineTask.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObjectFromPipelineTask.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The pipeline task published object.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PublishedObjectFromPipelineTask.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PublishedObjectFromPipelineTask extends PublishedObject {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+        private ConfigProvider configProviderDelegate;
+
+        public Builder configProviderDelegate(ConfigProvider configProviderDelegate) {
+            this.configProviderDelegate = configProviderDelegate;
+            this.__explicitlySet__.add("configProviderDelegate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+        private Pipeline pipeline;
+
+        public Builder pipeline(Pipeline pipeline) {
+            this.pipeline = pipeline;
+            this.__explicitlySet__.add("pipeline");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PublishedObjectFromPipelineTask build() {
+            PublishedObjectFromPipelineTask __instance__ =
+                    new PublishedObjectFromPipelineTask(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            inputPorts,
+                            outputPorts,
+                            parameters,
+                            opConfigValues,
+                            configProviderDelegate,
+                            pipeline);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PublishedObjectFromPipelineTask o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .configProviderDelegate(o.getConfigProviderDelegate())
+                            .pipeline(o.getPipeline());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PublishedObjectFromPipelineTask(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            ConfigProvider configProviderDelegate,
+            Pipeline pipeline) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                objectStatus,
+                identifier);
+        this.inputPorts = inputPorts;
+        this.outputPorts = outputPorts;
+        this.parameters = parameters;
+        this.opConfigValues = opConfigValues;
+        this.configProviderDelegate = configProviderDelegate;
+        this.pipeline = pipeline;
+    }
+
+    /**
+     * An array of input ports.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+    java.util.List<InputPort> inputPorts;
+
+    /**
+     * An array of output ports.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+    java.util.List<OutputPort> outputPorts;
+
+    /**
+     * An array of parameters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+    java.util.List<Parameter> parameters;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+    ConfigValues opConfigValues;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+    ConfigProvider configProviderDelegate;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+    Pipeline pipeline;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObjectFromPipelineTaskSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObjectFromPipelineTaskSummary.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The pipeline task published object summary.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PublishedObjectFromPipelineTaskSummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PublishedObjectFromPipelineTaskSummary extends PublishedObjectSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+        private ConfigProvider configProviderDelegate;
+
+        public Builder configProviderDelegate(ConfigProvider configProviderDelegate) {
+            this.configProviderDelegate = configProviderDelegate;
+            this.__explicitlySet__.add("configProviderDelegate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+        private Pipeline pipeline;
+
+        public Builder pipeline(Pipeline pipeline) {
+            this.pipeline = pipeline;
+            this.__explicitlySet__.add("pipeline");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PublishedObjectFromPipelineTaskSummary build() {
+            PublishedObjectFromPipelineTaskSummary __instance__ =
+                    new PublishedObjectFromPipelineTaskSummary(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            metadata,
+                            inputPorts,
+                            outputPorts,
+                            parameters,
+                            opConfigValues,
+                            configProviderDelegate,
+                            pipeline);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PublishedObjectFromPipelineTaskSummary o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .metadata(o.getMetadata())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .configProviderDelegate(o.getConfigProviderDelegate())
+                            .pipeline(o.getPipeline());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PublishedObjectFromPipelineTaskSummary(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            Integer objectStatus,
+            String identifier,
+            ObjectMetadata metadata,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            ConfigProvider configProviderDelegate,
+            Pipeline pipeline) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                objectStatus,
+                identifier,
+                metadata);
+        this.inputPorts = inputPorts;
+        this.outputPorts = outputPorts;
+        this.parameters = parameters;
+        this.opConfigValues = opConfigValues;
+        this.configProviderDelegate = configProviderDelegate;
+        this.pipeline = pipeline;
+    }
+
+    /**
+     * An array of input ports.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+    java.util.List<InputPort> inputPorts;
+
+    /**
+     * An array of output ports.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+    java.util.List<OutputPort> outputPorts;
+
+    /**
+     * An array of parameters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+    java.util.List<Parameter> parameters;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+    ConfigValues opConfigValues;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+    ConfigProvider configProviderDelegate;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+    Pipeline pipeline;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObjectSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/PublishedObjectSummary.java
@@ -29,6 +29,10 @@ package com.oracle.bmc.dataintegration.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PublishedObjectFromPipelineTaskSummary.class,
+        name = "PIPELINE_TASK"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = PublishedObjectSummaryFromIntegrationTask.class,
         name = "INTEGRATION_TASK"
     ),
@@ -95,6 +99,7 @@ public class PublishedObjectSummary {
     public enum ModelType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Schedule.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Schedule.java
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The schedule object
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Schedule.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Schedule {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("frequencyDetails")
+        private AbstractFrequencyDetails frequencyDetails;
+
+        public Builder frequencyDetails(AbstractFrequencyDetails frequencyDetails) {
+            this.frequencyDetails = frequencyDetails;
+            this.__explicitlySet__.add("frequencyDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timezone")
+        private String timezone;
+
+        public Builder timezone(String timezone) {
+            this.timezone = timezone;
+            this.__explicitlySet__.add("timezone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDaylightAdjustmentEnabled")
+        private Boolean isDaylightAdjustmentEnabled;
+
+        public Builder isDaylightAdjustmentEnabled(Boolean isDaylightAdjustmentEnabled) {
+            this.isDaylightAdjustmentEnabled = isDaylightAdjustmentEnabled;
+            this.__explicitlySet__.add("isDaylightAdjustmentEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Schedule build() {
+            Schedule __instance__ =
+                    new Schedule(
+                            key,
+                            modelVersion,
+                            modelType,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            frequencyDetails,
+                            timezone,
+                            isDaylightAdjustmentEnabled,
+                            metadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Schedule o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .modelType(o.getModelType())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .frequencyDetails(o.getFrequencyDetails())
+                            .timezone(o.getTimezone())
+                            .isDaylightAdjustmentEnabled(o.getIsDaylightAdjustmentEnabled())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Generated key that can be used in API calls to identify schedule. On scenarios where reference to the schedule is needed, a value can be passed in create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("frequencyDetails")
+    AbstractFrequencyDetails frequencyDetails;
+
+    /**
+     * The timezone for the schedule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timezone")
+    String timezone;
+
+    /**
+     * A flag to indicate daylight saving.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDaylightAdjustmentEnabled")
+    Boolean isDaylightAdjustmentEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+    ObjectMetadata metadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/SchemaDriftConfig.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/SchemaDriftConfig.java
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The configuration for handling schema drift in a Source or Target operator.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = SchemaDriftConfig.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SchemaDriftConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("extraColumnHandling")
+        private ExtraColumnHandling extraColumnHandling;
+
+        public Builder extraColumnHandling(ExtraColumnHandling extraColumnHandling) {
+            this.extraColumnHandling = extraColumnHandling;
+            this.__explicitlySet__.add("extraColumnHandling");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("missingColumnHandling")
+        private MissingColumnHandling missingColumnHandling;
+
+        public Builder missingColumnHandling(MissingColumnHandling missingColumnHandling) {
+            this.missingColumnHandling = missingColumnHandling;
+            this.__explicitlySet__.add("missingColumnHandling");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataTypeChangeHandling")
+        private DataTypeChangeHandling dataTypeChangeHandling;
+
+        public Builder dataTypeChangeHandling(DataTypeChangeHandling dataTypeChangeHandling) {
+            this.dataTypeChangeHandling = dataTypeChangeHandling;
+            this.__explicitlySet__.add("dataTypeChangeHandling");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isValidationWarningIfAllowed")
+        private Boolean isValidationWarningIfAllowed;
+
+        public Builder isValidationWarningIfAllowed(Boolean isValidationWarningIfAllowed) {
+            this.isValidationWarningIfAllowed = isValidationWarningIfAllowed;
+            this.__explicitlySet__.add("isValidationWarningIfAllowed");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SchemaDriftConfig build() {
+            SchemaDriftConfig __instance__ =
+                    new SchemaDriftConfig(
+                            extraColumnHandling,
+                            missingColumnHandling,
+                            dataTypeChangeHandling,
+                            isValidationWarningIfAllowed);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SchemaDriftConfig o) {
+            Builder copiedBuilder =
+                    extraColumnHandling(o.getExtraColumnHandling())
+                            .missingColumnHandling(o.getMissingColumnHandling())
+                            .dataTypeChangeHandling(o.getDataTypeChangeHandling())
+                            .isValidationWarningIfAllowed(o.getIsValidationWarningIfAllowed());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The setting for how to handle extra columns/fields.  NULL_FILLUP means that nulls will be loaded into the target for extra columns.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ExtraColumnHandling {
+        Allow("ALLOW"),
+        NullFillup("NULL_FILLUP"),
+        DoNotAllow("DO_NOT_ALLOW"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ExtraColumnHandling> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ExtraColumnHandling v : ExtraColumnHandling.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ExtraColumnHandling(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ExtraColumnHandling create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ExtraColumnHandling', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The setting for how to handle extra columns/fields.  NULL_FILLUP means that nulls will be loaded into the target for extra columns.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("extraColumnHandling")
+    ExtraColumnHandling extraColumnHandling;
+    /**
+     * The setting for how to handle missing columns/fields.  NULL_SELECT means that null values will be selected from the source for missing columns.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum MissingColumnHandling {
+        Allow("ALLOW"),
+        NullSelect("NULL_SELECT"),
+        DoNotAllow("DO_NOT_ALLOW"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, MissingColumnHandling> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (MissingColumnHandling v : MissingColumnHandling.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        MissingColumnHandling(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static MissingColumnHandling create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'MissingColumnHandling', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The setting for how to handle missing columns/fields.  NULL_SELECT means that null values will be selected from the source for missing columns.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("missingColumnHandling")
+    MissingColumnHandling missingColumnHandling;
+    /**
+     * The setting for how to handle columns/fields with changed data types.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DataTypeChangeHandling {
+        Allow("ALLOW"),
+        DoCastIfPossible("DO_CAST_IF_POSSIBLE"),
+        DoNotAllow("DO_NOT_ALLOW"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DataTypeChangeHandling> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DataTypeChangeHandling v : DataTypeChangeHandling.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DataTypeChangeHandling(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DataTypeChangeHandling create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DataTypeChangeHandling', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The setting for how to handle columns/fields with changed data types.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataTypeChangeHandling")
+    DataTypeChangeHandling dataTypeChangeHandling;
+
+    /**
+     * If true, display a validation warning for schema changes, even if they are allowed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isValidationWarningIfAllowed")
+    Boolean isValidationWarningIfAllowed;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/SecretConfig.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/SecretConfig.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Secret configuration if used for storing sensitive info
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType",
+    defaultImpl = SecretConfig.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OciVaultSecretConfig.class,
+        name = "OCI_VAULT_SECRET_CONFIG"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class SecretConfig {
+
+    /**
+     * If OCI vault is used for storing sensitive info
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ModelType {
+        OciVaultSecretConfig("OCI_VAULT_SECRET_CONFIG"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ModelType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ModelType v : ModelType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ModelType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ModelType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ModelType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/SensitiveAttribute.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/SensitiveAttribute.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The sensitive attribute to be used for sensitive content (for password/wallet).
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = SensitiveAttribute.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SensitiveAttribute {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("secretConfig")
+        private SecretConfig secretConfig;
+
+        public Builder secretConfig(SecretConfig secretConfig) {
+            this.secretConfig = secretConfig;
+            this.__explicitlySet__.add("secretConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            this.__explicitlySet__.add("value");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SensitiveAttribute build() {
+            SensitiveAttribute __instance__ = new SensitiveAttribute(secretConfig, value);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SensitiveAttribute o) {
+            Builder copiedBuilder = secretConfig(o.getSecretConfig()).value(o.getValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("secretConfig")
+    SecretConfig secretConfig;
+
+    /**
+     * Attribute to provide sensitive content.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    String value;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Source.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Source.java
@@ -174,6 +174,24 @@ public class Source extends Operator {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("schemaDriftConfig")
+        private SchemaDriftConfig schemaDriftConfig;
+
+        public Builder schemaDriftConfig(SchemaDriftConfig schemaDriftConfig) {
+            this.schemaDriftConfig = schemaDriftConfig;
+            this.__explicitlySet__.add("schemaDriftConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fixedDataShape")
+        private Shape fixedDataShape;
+
+        public Builder fixedDataShape(Shape fixedDataShape) {
+            this.fixedDataShape = fixedDataShape;
+            this.__explicitlySet__.add("fixedDataShape");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("readOperationConfig")
         private ReadOperationConfig readOperationConfig;
 
@@ -205,6 +223,8 @@ public class Source extends Operator {
                             isReadAccess,
                             isCopyFields,
                             isPredefinedShape,
+                            schemaDriftConfig,
+                            fixedDataShape,
                             readOperationConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -229,6 +249,8 @@ public class Source extends Operator {
                             .isReadAccess(o.getIsReadAccess())
                             .isCopyFields(o.getIsCopyFields())
                             .isPredefinedShape(o.getIsPredefinedShape())
+                            .schemaDriftConfig(o.getSchemaDriftConfig())
+                            .fixedDataShape(o.getFixedDataShape())
                             .readOperationConfig(o.getReadOperationConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -261,6 +283,8 @@ public class Source extends Operator {
             Boolean isReadAccess,
             Boolean isCopyFields,
             Boolean isPredefinedShape,
+            SchemaDriftConfig schemaDriftConfig,
+            Shape fixedDataShape,
             ReadOperationConfig readOperationConfig) {
         super(
                 key,
@@ -279,6 +303,8 @@ public class Source extends Operator {
         this.isReadAccess = isReadAccess;
         this.isCopyFields = isCopyFields;
         this.isPredefinedShape = isPredefinedShape;
+        this.schemaDriftConfig = schemaDriftConfig;
+        this.fixedDataShape = fixedDataShape;
         this.readOperationConfig = readOperationConfig;
     }
 
@@ -302,6 +328,12 @@ public class Source extends Operator {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isPredefinedShape")
     Boolean isPredefinedShape;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("schemaDriftConfig")
+    SchemaDriftConfig schemaDriftConfig;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("fixedDataShape")
+    Shape fixedDataShape;
 
     @com.fasterxml.jackson.annotation.JsonProperty("readOperationConfig")
     ReadOperationConfig readOperationConfig;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/StartOperator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/StartOperator.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Represents the start of a pipeline.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = StartOperator.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class StartOperator extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public StartOperator build() {
+            StartOperator __instance__ =
+                    new StartOperator(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(StartOperator o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public StartOperator(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Target.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Target.java
@@ -183,6 +183,24 @@ public class Target extends Operator {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("schemaDriftConfig")
+        private SchemaDriftConfig schemaDriftConfig;
+
+        public Builder schemaDriftConfig(SchemaDriftConfig schemaDriftConfig) {
+            this.schemaDriftConfig = schemaDriftConfig;
+            this.__explicitlySet__.add("schemaDriftConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("fixedDataShape")
+        private Shape fixedDataShape;
+
+        public Builder fixedDataShape(Shape fixedDataShape) {
+            this.fixedDataShape = fixedDataShape;
+            this.__explicitlySet__.add("fixedDataShape");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("writeOperationConfig")
         private WriteOperationConfig writeOperationConfig;
 
@@ -215,6 +233,8 @@ public class Target extends Operator {
                             isCopyFields,
                             isPredefinedShape,
                             dataProperty,
+                            schemaDriftConfig,
+                            fixedDataShape,
                             writeOperationConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -240,6 +260,8 @@ public class Target extends Operator {
                             .isCopyFields(o.getIsCopyFields())
                             .isPredefinedShape(o.getIsPredefinedShape())
                             .dataProperty(o.getDataProperty())
+                            .schemaDriftConfig(o.getSchemaDriftConfig())
+                            .fixedDataShape(o.getFixedDataShape())
                             .writeOperationConfig(o.getWriteOperationConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -273,6 +295,8 @@ public class Target extends Operator {
             Boolean isCopyFields,
             Boolean isPredefinedShape,
             DataProperty dataProperty,
+            SchemaDriftConfig schemaDriftConfig,
+            Shape fixedDataShape,
             WriteOperationConfig writeOperationConfig) {
         super(
                 key,
@@ -292,6 +316,8 @@ public class Target extends Operator {
         this.isCopyFields = isCopyFields;
         this.isPredefinedShape = isPredefinedShape;
         this.dataProperty = dataProperty;
+        this.schemaDriftConfig = schemaDriftConfig;
+        this.fixedDataShape = fixedDataShape;
         this.writeOperationConfig = writeOperationConfig;
     }
 
@@ -370,6 +396,12 @@ public class Target extends Operator {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dataProperty")
     DataProperty dataProperty;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("schemaDriftConfig")
+    SchemaDriftConfig schemaDriftConfig;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("fixedDataShape")
+    Shape fixedDataShape;
 
     @com.fasterxml.jackson.annotation.JsonProperty("writeOperationConfig")
     WriteOperationConfig writeOperationConfig;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Task.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Task.java
@@ -29,6 +29,10 @@ package com.oracle.bmc.dataintegration.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = TaskFromPipelineTaskDetails.class,
+        name = "PIPELINE_TASK"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = TaskFromIntegrationTaskDetails.class,
         name = "INTEGRATION_TASK"
     ),
@@ -125,6 +129,7 @@ public class Task {
     public enum ModelType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskFromPipelineTaskDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskFromPipelineTaskDetails.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about the pipeline task.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TaskFromPipelineTaskDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TaskFromPipelineTaskDetails extends Task {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+        private ConfigProvider configProviderDelegate;
+
+        public Builder configProviderDelegate(ConfigProvider configProviderDelegate) {
+            this.configProviderDelegate = configProviderDelegate;
+            this.__explicitlySet__.add("configProviderDelegate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keyMap")
+        private java.util.Map<String, String> keyMap;
+
+        public Builder keyMap(java.util.Map<String, String> keyMap) {
+            this.keyMap = keyMap;
+            this.__explicitlySet__.add("keyMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+        private Pipeline pipeline;
+
+        public Builder pipeline(Pipeline pipeline) {
+            this.pipeline = pipeline;
+            this.__explicitlySet__.add("pipeline");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TaskFromPipelineTaskDetails build() {
+            TaskFromPipelineTaskDetails __instance__ =
+                    new TaskFromPipelineTaskDetails(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            inputPorts,
+                            outputPorts,
+                            parameters,
+                            opConfigValues,
+                            configProviderDelegate,
+                            metadata,
+                            keyMap,
+                            pipeline);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TaskFromPipelineTaskDetails o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .configProviderDelegate(o.getConfigProviderDelegate())
+                            .metadata(o.getMetadata())
+                            .keyMap(o.getKeyMap())
+                            .pipeline(o.getPipeline());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public TaskFromPipelineTaskDetails(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            ConfigProvider configProviderDelegate,
+            ObjectMetadata metadata,
+            java.util.Map<String, String> keyMap,
+            Pipeline pipeline) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                objectStatus,
+                identifier,
+                inputPorts,
+                outputPorts,
+                parameters,
+                opConfigValues,
+                configProviderDelegate,
+                metadata,
+                keyMap);
+        this.pipeline = pipeline;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+    Pipeline pipeline;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskOperator.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskOperator.java
@@ -1,0 +1,581 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * An operator for task
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TaskOperator.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TaskOperator extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retryAttempts")
+        private Integer retryAttempts;
+
+        public Builder retryAttempts(Integer retryAttempts) {
+            this.retryAttempts = retryAttempts;
+            this.__explicitlySet__.add("retryAttempts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retryDelayUnit")
+        private RetryDelayUnit retryDelayUnit;
+
+        public Builder retryDelayUnit(RetryDelayUnit retryDelayUnit) {
+            this.retryDelayUnit = retryDelayUnit;
+            this.__explicitlySet__.add("retryDelayUnit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retryDelay")
+        private Double retryDelay;
+
+        public Builder retryDelay(Double retryDelay) {
+            this.retryDelay = retryDelay;
+            this.__explicitlySet__.add("retryDelay");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expectedDuration")
+        private Double expectedDuration;
+
+        public Builder expectedDuration(Double expectedDuration) {
+            this.expectedDuration = expectedDuration;
+            this.__explicitlySet__.add("expectedDuration");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expectedDurationUnit")
+        private ExpectedDurationUnit expectedDurationUnit;
+
+        public Builder expectedDurationUnit(ExpectedDurationUnit expectedDurationUnit) {
+            this.expectedDurationUnit = expectedDurationUnit;
+            this.__explicitlySet__.add("expectedDurationUnit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("taskType")
+        private TaskType taskType;
+
+        public Builder taskType(TaskType taskType) {
+            this.taskType = taskType;
+            this.__explicitlySet__.add("taskType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("task")
+        private Task task;
+
+        public Builder task(Task task) {
+            this.task = task;
+            this.__explicitlySet__.add("task");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("triggerRule")
+        private TriggerRule triggerRule;
+
+        public Builder triggerRule(TriggerRule triggerRule) {
+            this.triggerRule = triggerRule;
+            this.__explicitlySet__.add("triggerRule");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+        private ConfigProvider configProviderDelegate;
+
+        public Builder configProviderDelegate(ConfigProvider configProviderDelegate) {
+            this.configProviderDelegate = configProviderDelegate;
+            this.__explicitlySet__.add("configProviderDelegate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TaskOperator build() {
+            TaskOperator __instance__ =
+                    new TaskOperator(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            retryAttempts,
+                            retryDelayUnit,
+                            retryDelay,
+                            expectedDuration,
+                            expectedDurationUnit,
+                            taskType,
+                            task,
+                            triggerRule,
+                            configProviderDelegate);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TaskOperator o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .retryAttempts(o.getRetryAttempts())
+                            .retryDelayUnit(o.getRetryDelayUnit())
+                            .retryDelay(o.getRetryDelay())
+                            .expectedDuration(o.getExpectedDuration())
+                            .expectedDurationUnit(o.getExpectedDurationUnit())
+                            .taskType(o.getTaskType())
+                            .task(o.getTask())
+                            .triggerRule(o.getTriggerRule())
+                            .configProviderDelegate(o.getConfigProviderDelegate());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public TaskOperator(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            Integer retryAttempts,
+            RetryDelayUnit retryDelayUnit,
+            Double retryDelay,
+            Double expectedDuration,
+            ExpectedDurationUnit expectedDurationUnit,
+            TaskType taskType,
+            Task task,
+            TriggerRule triggerRule,
+            ConfigProvider configProviderDelegate) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.retryAttempts = retryAttempts;
+        this.retryDelayUnit = retryDelayUnit;
+        this.retryDelay = retryDelay;
+        this.expectedDuration = expectedDuration;
+        this.expectedDurationUnit = expectedDurationUnit;
+        this.taskType = taskType;
+        this.task = task;
+        this.triggerRule = triggerRule;
+        this.configProviderDelegate = configProviderDelegate;
+    }
+
+    /**
+     * The number of retry attempts.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retryAttempts")
+    Integer retryAttempts;
+    /**
+     * The unit for the retry delay.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum RetryDelayUnit {
+        Seconds("SECONDS"),
+        Minutes("MINUTES"),
+        Hours("HOURS"),
+        Days("DAYS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, RetryDelayUnit> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RetryDelayUnit v : RetryDelayUnit.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        RetryDelayUnit(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RetryDelayUnit create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'RetryDelayUnit', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The unit for the retry delay.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retryDelayUnit")
+    RetryDelayUnit retryDelayUnit;
+
+    /**
+     * The retry delay, the unit for measurement is in the property retry delay unit.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retryDelay")
+    Double retryDelay;
+
+    /**
+     * The expected duration for the task run.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expectedDuration")
+    Double expectedDuration;
+    /**
+     * The expected duration unit of measure.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ExpectedDurationUnit {
+        Seconds("SECONDS"),
+        Minutes("MINUTES"),
+        Hours("HOURS"),
+        Days("DAYS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ExpectedDurationUnit> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ExpectedDurationUnit v : ExpectedDurationUnit.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ExpectedDurationUnit(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ExpectedDurationUnit create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ExpectedDurationUnit', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The expected duration unit of measure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expectedDurationUnit")
+    ExpectedDurationUnit expectedDurationUnit;
+    /**
+     * The type of the task referenced in the task property.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum TaskType {
+        PipelineTask("PIPELINE_TASK"),
+        IntegrationTask("INTEGRATION_TASK"),
+        DataLoaderTask("DATA_LOADER_TASK"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, TaskType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (TaskType v : TaskType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        TaskType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static TaskType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'TaskType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The type of the task referenced in the task property.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("taskType")
+    TaskType taskType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("task")
+    Task task;
+    /**
+     * The merge condition. The conditions are
+     * ALL_SUCCESS - All the preceeding operators need to be successful.
+     * ALL_FAILED - All the preceeding operators should have failed.
+     * ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum TriggerRule {
+        AllSuccess("ALL_SUCCESS"),
+        AllFailed("ALL_FAILED"),
+        AllComplete("ALL_COMPLETE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, TriggerRule> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (TriggerRule v : TriggerRule.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        TriggerRule(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static TriggerRule create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'TriggerRule', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The merge condition. The conditions are
+     * ALL_SUCCESS - All the preceeding operators need to be successful.
+     * ALL_FAILED - All the preceeding operators should have failed.
+     * ALL_COMPLETE - All the preceeding operators should have completed. It could have executed successfully or failed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("triggerRule")
+    TriggerRule triggerRule;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+    ConfigProvider configProviderDelegate;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRun.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRun.java
@@ -159,6 +159,78 @@ public class TaskRun {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("expectedDuration")
+        private Double expectedDuration;
+
+        public Builder expectedDuration(Double expectedDuration) {
+            this.expectedDuration = expectedDuration;
+            this.__explicitlySet__.add("expectedDuration");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expectedDurationUnit")
+        private ExpectedDurationUnit expectedDurationUnit;
+
+        public Builder expectedDurationUnit(ExpectedDurationUnit expectedDurationUnit) {
+            this.expectedDurationUnit = expectedDurationUnit;
+            this.__explicitlySet__.add("expectedDurationUnit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("taskKey")
+        private String taskKey;
+
+        public Builder taskKey(String taskKey) {
+            this.taskKey = taskKey;
+            this.__explicitlySet__.add("taskKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retryAttempt")
+        private Integer retryAttempt;
+
+        public Builder retryAttempt(Integer retryAttempt) {
+            this.retryAttempt = retryAttempt;
+            this.__explicitlySet__.add("retryAttempt");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("taskSchedule")
+        private TaskSchedule taskSchedule;
+
+        public Builder taskSchedule(TaskSchedule taskSchedule) {
+            this.taskSchedule = taskSchedule;
+            this.__explicitlySet__.add("taskSchedule");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metrics")
+        private java.util.Map<String, Float> metrics;
+
+        public Builder metrics(java.util.Map<String, Float> metrics) {
+            this.metrics = metrics;
+            this.__explicitlySet__.add("metrics");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("executionErrors")
+        private java.util.List<String> executionErrors;
+
+        public Builder executionErrors(java.util.List<String> executionErrors) {
+            this.executionErrors = executionErrors;
+            this.__explicitlySet__.add("executionErrors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("terminationErrors")
+        private java.util.List<String> terminationErrors;
+
+        public Builder terminationErrors(java.util.List<String> terminationErrors) {
+            this.terminationErrors = terminationErrors;
+            this.__explicitlySet__.add("terminationErrors");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("opcRequestId")
         private String opcRequestId;
 
@@ -234,6 +306,14 @@ public class TaskRun {
                             recordsWritten,
                             bytesProcessed,
                             errorMessage,
+                            expectedDuration,
+                            expectedDurationUnit,
+                            taskKey,
+                            retryAttempt,
+                            taskSchedule,
+                            metrics,
+                            executionErrors,
+                            terminationErrors,
                             opcRequestId,
                             objectStatus,
                             taskType,
@@ -262,6 +342,14 @@ public class TaskRun {
                             .recordsWritten(o.getRecordsWritten())
                             .bytesProcessed(o.getBytesProcessed())
                             .errorMessage(o.getErrorMessage())
+                            .expectedDuration(o.getExpectedDuration())
+                            .expectedDurationUnit(o.getExpectedDurationUnit())
+                            .taskKey(o.getTaskKey())
+                            .retryAttempt(o.getRetryAttempt())
+                            .taskSchedule(o.getTaskSchedule())
+                            .metrics(o.getMetrics())
+                            .executionErrors(o.getExecutionErrors())
+                            .terminationErrors(o.getTerminationErrors())
                             .opcRequestId(o.getOpcRequestId())
                             .objectStatus(o.getObjectStatus())
                             .taskType(o.getTaskType())
@@ -416,6 +504,98 @@ public class TaskRun {
     String errorMessage;
 
     /**
+     * The expected duration for the task run.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expectedDuration")
+    Double expectedDuration;
+    /**
+     * The expected duration unit of measure.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ExpectedDurationUnit {
+        Seconds("SECONDS"),
+        Minutes("MINUTES"),
+        Hours("HOURS"),
+        Days("DAYS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ExpectedDurationUnit> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ExpectedDurationUnit v : ExpectedDurationUnit.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ExpectedDurationUnit(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ExpectedDurationUnit create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ExpectedDurationUnit', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The expected duration unit of measure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expectedDurationUnit")
+    ExpectedDurationUnit expectedDurationUnit;
+
+    /**
+     * Task Key of the task for which TaskRun is being created. If not specified, the AggregatorKey in RegistryMetadata will be assumed to be the TaskKey
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("taskKey")
+    String taskKey;
+
+    /**
+     * Holds the particular attempt number.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retryAttempt")
+    Integer retryAttempt;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("taskSchedule")
+    TaskSchedule taskSchedule;
+
+    /**
+     * A map of metrics for the run.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metrics")
+    java.util.Map<String, Float> metrics;
+
+    /**
+     * An array of execution errors from the run.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("executionErrors")
+    java.util.List<String> executionErrors;
+
+    /**
+     * An array of termination errors from the run.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("terminationErrors")
+    java.util.List<String> terminationErrors;
+
+    /**
      * The OPC request ID of execution of the task run.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("opcRequestId")
@@ -433,6 +613,7 @@ public class TaskRun {
     public enum TaskType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRunDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRunDetails.java
@@ -374,6 +374,7 @@ public class TaskRunDetails {
     public enum TaskType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRunSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskRunSummary.java
@@ -374,6 +374,7 @@ public class TaskRunSummary {
     public enum TaskType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskSchedule.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskSchedule.java
@@ -1,0 +1,588 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * A model that holds Schedule and other information required for scheduling a task.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TaskSchedule.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TaskSchedule {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scheduleRef")
+        private Schedule scheduleRef;
+
+        public Builder scheduleRef(Schedule scheduleRef) {
+            this.scheduleRef = scheduleRef;
+            this.__explicitlySet__.add("scheduleRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+        private ConfigProvider configProviderDelegate;
+
+        public Builder configProviderDelegate(ConfigProvider configProviderDelegate) {
+            this.configProviderDelegate = configProviderDelegate;
+            this.__explicitlySet__.add("configProviderDelegate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retryAttempts")
+        private Integer retryAttempts;
+
+        public Builder retryAttempts(Integer retryAttempts) {
+            this.retryAttempts = retryAttempts;
+            this.__explicitlySet__.add("retryAttempts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retryDelayUnit")
+        private RetryDelayUnit retryDelayUnit;
+
+        public Builder retryDelayUnit(RetryDelayUnit retryDelayUnit) {
+            this.retryDelayUnit = retryDelayUnit;
+            this.__explicitlySet__.add("retryDelayUnit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("retryDelay")
+        private Double retryDelay;
+
+        public Builder retryDelay(Double retryDelay) {
+            this.retryDelay = retryDelay;
+            this.__explicitlySet__.add("retryDelay");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("startTimeMillis")
+        private Long startTimeMillis;
+
+        public Builder startTimeMillis(Long startTimeMillis) {
+            this.startTimeMillis = startTimeMillis;
+            this.__explicitlySet__.add("startTimeMillis");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("endTimeMillis")
+        private Long endTimeMillis;
+
+        public Builder endTimeMillis(Long endTimeMillis) {
+            this.endTimeMillis = endTimeMillis;
+            this.__explicitlySet__.add("endTimeMillis");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isConcurrentAllowed")
+        private Boolean isConcurrentAllowed;
+
+        public Builder isConcurrentAllowed(Boolean isConcurrentAllowed) {
+            this.isConcurrentAllowed = isConcurrentAllowed;
+            this.__explicitlySet__.add("isConcurrentAllowed");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBackfillEnabled")
+        private Boolean isBackfillEnabled;
+
+        public Builder isBackfillEnabled(Boolean isBackfillEnabled) {
+            this.isBackfillEnabled = isBackfillEnabled;
+            this.__explicitlySet__.add("isBackfillEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("authMode")
+        private AuthMode authMode;
+
+        public Builder authMode(AuthMode authMode) {
+            this.authMode = authMode;
+            this.__explicitlySet__.add("authMode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expectedDuration")
+        private Double expectedDuration;
+
+        public Builder expectedDuration(Double expectedDuration) {
+            this.expectedDuration = expectedDuration;
+            this.__explicitlySet__.add("expectedDuration");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("expectedDurationUnit")
+        private ExpectedDurationUnit expectedDurationUnit;
+
+        public Builder expectedDurationUnit(ExpectedDurationUnit expectedDurationUnit) {
+            this.expectedDurationUnit = expectedDurationUnit;
+            this.__explicitlySet__.add("expectedDurationUnit");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lastRunDetails")
+        private LastRunDetails lastRunDetails;
+
+        public Builder lastRunDetails(LastRunDetails lastRunDetails) {
+            this.lastRunDetails = lastRunDetails;
+            this.__explicitlySet__.add("lastRunDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TaskSchedule build() {
+            TaskSchedule __instance__ =
+                    new TaskSchedule(
+                            key,
+                            modelVersion,
+                            modelType,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            scheduleRef,
+                            configProviderDelegate,
+                            isEnabled,
+                            retryAttempts,
+                            retryDelayUnit,
+                            retryDelay,
+                            startTimeMillis,
+                            endTimeMillis,
+                            isConcurrentAllowed,
+                            isBackfillEnabled,
+                            authMode,
+                            expectedDuration,
+                            expectedDurationUnit,
+                            lastRunDetails,
+                            metadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TaskSchedule o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .modelType(o.getModelType())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .scheduleRef(o.getScheduleRef())
+                            .configProviderDelegate(o.getConfigProviderDelegate())
+                            .isEnabled(o.getIsEnabled())
+                            .retryAttempts(o.getRetryAttempts())
+                            .retryDelayUnit(o.getRetryDelayUnit())
+                            .retryDelay(o.getRetryDelay())
+                            .startTimeMillis(o.getStartTimeMillis())
+                            .endTimeMillis(o.getEndTimeMillis())
+                            .isConcurrentAllowed(o.getIsConcurrentAllowed())
+                            .isBackfillEnabled(o.getIsBackfillEnabled())
+                            .authMode(o.getAuthMode())
+                            .expectedDuration(o.getExpectedDuration())
+                            .expectedDurationUnit(o.getExpectedDurationUnit())
+                            .lastRunDetails(o.getLastRunDetails())
+                            .metadata(o.getMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Generated key that can be used in API calls to identify taskSchedule. On scenarios where reference to the taskSchedule is needed, a value can be passed in create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scheduleRef")
+    Schedule scheduleRef;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+    ConfigProvider configProviderDelegate;
+
+    /**
+     * Whether the schedule is enabled.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
+
+    /**
+     * The number of retry attempts.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retryAttempts")
+    Integer retryAttempts;
+    /**
+     * The unit for the retry delay.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum RetryDelayUnit {
+        Seconds("SECONDS"),
+        Minutes("MINUTES"),
+        Hours("HOURS"),
+        Days("DAYS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, RetryDelayUnit> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RetryDelayUnit v : RetryDelayUnit.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        RetryDelayUnit(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RetryDelayUnit create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'RetryDelayUnit', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The unit for the retry delay.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retryDelayUnit")
+    RetryDelayUnit retryDelayUnit;
+
+    /**
+     * The retry delay, the unit for measurement is in the property retry delay unit.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("retryDelay")
+    Double retryDelay;
+
+    /**
+     * The start time in milliseconds.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("startTimeMillis")
+    Long startTimeMillis;
+
+    /**
+     * The end time in milliseconds.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("endTimeMillis")
+    Long endTimeMillis;
+
+    /**
+     * Whether the same task can be executed concurrently.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isConcurrentAllowed")
+    Boolean isConcurrentAllowed;
+
+    /**
+     * Whether the backfill is enabled
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBackfillEnabled")
+    Boolean isBackfillEnabled;
+    /**
+     * The authorization mode for the task.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum AuthMode {
+        Obo("OBO"),
+        ResourcePrincipal("RESOURCE_PRINCIPAL"),
+        UserCertificate("USER_CERTIFICATE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, AuthMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AuthMode v : AuthMode.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        AuthMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AuthMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'AuthMode', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The authorization mode for the task.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("authMode")
+    AuthMode authMode;
+
+    /**
+     * The expected duration of the task execution.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expectedDuration")
+    Double expectedDuration;
+    /**
+     * The expected duration unit of the task execution.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ExpectedDurationUnit {
+        Seconds("SECONDS"),
+        Minutes("MINUTES"),
+        Hours("HOURS"),
+        Days("DAYS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ExpectedDurationUnit> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ExpectedDurationUnit v : ExpectedDurationUnit.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ExpectedDurationUnit(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ExpectedDurationUnit create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ExpectedDurationUnit', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The expected duration unit of the task execution.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("expectedDurationUnit")
+    ExpectedDurationUnit expectedDurationUnit;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lastRunDetails")
+    LastRunDetails lastRunDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+    ObjectMetadata metadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskSummary.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskSummary.java
@@ -33,6 +33,10 @@ package com.oracle.bmc.dataintegration.model;
         name = "INTEGRATION_TASK"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = TaskSummaryFromPipelineTask.class,
+        name = "PIPELINE_TASK"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = TaskSummaryFromDataLoaderTask.class,
         name = "DATA_LOADER_TASK"
     )
@@ -125,6 +129,7 @@ public class TaskSummary {
     public enum ModelType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskSummaryFromPipelineTask.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/TaskSummaryFromPipelineTask.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about the pipeline task.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TaskSummaryFromPipelineTask.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TaskSummaryFromPipelineTask extends TaskSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+        private ConfigProvider configProviderDelegate;
+
+        public Builder configProviderDelegate(ConfigProvider configProviderDelegate) {
+            this.configProviderDelegate = configProviderDelegate;
+            this.__explicitlySet__.add("configProviderDelegate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("metadata")
+        private ObjectMetadata metadata;
+
+        public Builder metadata(ObjectMetadata metadata) {
+            this.metadata = metadata;
+            this.__explicitlySet__.add("metadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keyMap")
+        private java.util.Map<String, String> keyMap;
+
+        public Builder keyMap(java.util.Map<String, String> keyMap) {
+            this.keyMap = keyMap;
+            this.__explicitlySet__.add("keyMap");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+        private Pipeline pipeline;
+
+        public Builder pipeline(Pipeline pipeline) {
+            this.pipeline = pipeline;
+            this.__explicitlySet__.add("pipeline");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TaskSummaryFromPipelineTask build() {
+            TaskSummaryFromPipelineTask __instance__ =
+                    new TaskSummaryFromPipelineTask(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            inputPorts,
+                            outputPorts,
+                            parameters,
+                            opConfigValues,
+                            configProviderDelegate,
+                            metadata,
+                            keyMap,
+                            pipeline);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TaskSummaryFromPipelineTask o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .configProviderDelegate(o.getConfigProviderDelegate())
+                            .metadata(o.getMetadata())
+                            .keyMap(o.getKeyMap())
+                            .pipeline(o.getPipeline());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public TaskSummaryFromPipelineTask(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            ConfigProvider configProviderDelegate,
+            ObjectMetadata metadata,
+            java.util.Map<String, String> keyMap,
+            Pipeline pipeline) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                objectStatus,
+                identifier,
+                inputPorts,
+                outputPorts,
+                parameters,
+                opConfigValues,
+                configProviderDelegate,
+                metadata,
+                keyMap);
+        this.pipeline = pipeline;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+    Pipeline pipeline;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Time.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Time.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * A model to hold time in hour:minute:second format.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Time.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Time {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hour")
+        private Integer hour;
+
+        public Builder hour(Integer hour) {
+            this.hour = hour;
+            this.__explicitlySet__.add("hour");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("minute")
+        private Integer minute;
+
+        public Builder minute(Integer minute) {
+            this.minute = minute;
+            this.__explicitlySet__.add("minute");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("second")
+        private Integer second;
+
+        public Builder second(Integer second) {
+            this.second = second;
+            this.__explicitlySet__.add("second");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Time build() {
+            Time __instance__ = new Time(hour, minute, second);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Time o) {
+            Builder copiedBuilder = hour(o.getHour()).minute(o.getMinute()).second(o.getSecond());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The hour value.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hour")
+    Integer hour;
+
+    /**
+     * The minute value.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minute")
+    Integer minute;
+
+    /**
+     * The second value.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("second")
+    Integer second;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Union.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Union.java
@@ -1,0 +1,306 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about a union object.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Union.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Union extends Operator {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("unionType")
+        private UnionType unionType;
+
+        public Builder unionType(UnionType unionType) {
+            this.unionType = unionType;
+            this.__explicitlySet__.add("unionType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isAll")
+        private Boolean isAll;
+
+        public Builder isAll(Boolean isAll) {
+            this.isAll = isAll;
+            this.__explicitlySet__.add("isAll");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Union build() {
+            Union __instance__ =
+                    new Union(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            inputPorts,
+                            outputPorts,
+                            objectStatus,
+                            identifier,
+                            parameters,
+                            opConfigValues,
+                            unionType,
+                            isAll);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Union o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .unionType(o.getUnionType())
+                            .isAll(o.getIsAll());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public Union(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectVersion,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            Integer objectStatus,
+            String identifier,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            UnionType unionType,
+            Boolean isAll) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectVersion,
+                inputPorts,
+                outputPorts,
+                objectStatus,
+                identifier,
+                parameters,
+                opConfigValues);
+        this.unionType = unionType;
+        this.isAll = isAll;
+    }
+
+    /**
+     * unionType
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum UnionType {
+        Name("NAME"),
+        Position("POSITION"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, UnionType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (UnionType v : UnionType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        UnionType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static UnionType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'UnionType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * unionType
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("unionType")
+    UnionType unionType;
+
+    /**
+     * The information about the union all.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAll")
+    Boolean isAll;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UniqueKey.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UniqueKey.java
@@ -15,123 +15,26 @@ package com.oracle.bmc.dataintegration.model;
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
 @lombok.Value
-@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = UniqueKey.Builder.class)
-@lombok.ToString(callSuper = true)
-@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.experimental.NonFinal
 @com.fasterxml.jackson.annotation.JsonTypeInfo(
     use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
     include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
-    property = "modelType"
+    property = "modelType",
+    defaultImpl = UniqueKey.class
 )
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PrimaryKey.class,
+        name = "PRIMARY_KEY"
+    )
+})
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
-@lombok.Builder(builderClassName = "Builder", toBuilder = true)
-public class UniqueKey extends Key {
-    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
-    @lombok.experimental.Accessors(fluent = true)
-    public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("key")
-        private String key;
-
-        public Builder key(String key) {
-            this.key = key;
-            this.__explicitlySet__.add("key");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
-        private String modelVersion;
-
-        public Builder modelVersion(String modelVersion) {
-            this.modelVersion = modelVersion;
-            this.__explicitlySet__.add("modelVersion");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
-        private ParentReference parentRef;
-
-        public Builder parentRef(ParentReference parentRef) {
-            this.parentRef = parentRef;
-            this.__explicitlySet__.add("parentRef");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("name")
-        private String name;
-
-        public Builder name(String name) {
-            this.name = name;
-            this.__explicitlySet__.add("name");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("attributeRefs")
-        private java.util.List<KeyAttribute> attributeRefs;
-
-        public Builder attributeRefs(java.util.List<KeyAttribute> attributeRefs) {
-            this.attributeRefs = attributeRefs;
-            this.__explicitlySet__.add("attributeRefs");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
-        private Integer objectStatus;
-
-        public Builder objectStatus(Integer objectStatus) {
-            this.objectStatus = objectStatus;
-            this.__explicitlySet__.add("objectStatus");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonIgnore
-        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
-
-        public UniqueKey build() {
-            UniqueKey __instance__ =
-                    new UniqueKey(key, modelVersion, parentRef, name, attributeRefs, objectStatus);
-            __instance__.__explicitlySet__.addAll(__explicitlySet__);
-            return __instance__;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonIgnore
-        public Builder copy(UniqueKey o) {
-            Builder copiedBuilder =
-                    key(o.getKey())
-                            .modelVersion(o.getModelVersion())
-                            .parentRef(o.getParentRef())
-                            .name(o.getName())
-                            .attributeRefs(o.getAttributeRefs())
-                            .objectStatus(o.getObjectStatus());
-
-            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
-            return copiedBuilder;
-        }
-    }
-
-    /**
-     * Create a new builder.
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    @Deprecated
-    public UniqueKey(
-            String key,
-            String modelVersion,
-            ParentReference parentRef,
-            String name,
-            java.util.List<KeyAttribute> attributeRefs,
-            Integer objectStatus) {
-        super();
-        this.key = key;
-        this.modelVersion = modelVersion;
-        this.parentRef = parentRef;
-        this.name = name;
-        this.attributeRefs = attributeRefs;
-        this.objectStatus = objectStatus;
-    }
+public class UniqueKey {
 
     /**
      * The object key.
@@ -166,6 +69,50 @@ public class UniqueKey extends Key {
     @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
     Integer objectStatus;
 
-    @com.fasterxml.jackson.annotation.JsonIgnore
-    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+    /**
+     * The key type.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ModelType {
+        PrimaryKey("PRIMARY_KEY"),
+        UniqueKey("UNIQUE_KEY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ModelType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ModelType v : ModelType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ModelType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ModelType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ModelType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
 }

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromAdwc.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromAdwc.java
@@ -141,6 +141,15 @@ public class UpdateConnectionFromAdwc extends UpdateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -158,7 +167,8 @@ public class UpdateConnectionFromAdwc extends UpdateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -177,7 +187,8 @@ public class UpdateConnectionFromAdwc extends UpdateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -204,7 +215,8 @@ public class UpdateConnectionFromAdwc extends UpdateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -218,6 +230,7 @@ public class UpdateConnectionFromAdwc extends UpdateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -231,6 +244,9 @@ public class UpdateConnectionFromAdwc extends UpdateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromAtp.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromAtp.java
@@ -141,6 +141,15 @@ public class UpdateConnectionFromAtp extends UpdateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -158,7 +167,8 @@ public class UpdateConnectionFromAtp extends UpdateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -177,7 +187,8 @@ public class UpdateConnectionFromAtp extends UpdateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -204,7 +215,8 @@ public class UpdateConnectionFromAtp extends UpdateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -218,6 +230,7 @@ public class UpdateConnectionFromAtp extends UpdateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -231,6 +244,9 @@ public class UpdateConnectionFromAtp extends UpdateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromJdbc.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromJdbc.java
@@ -141,6 +141,15 @@ public class UpdateConnectionFromJdbc extends UpdateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -158,7 +167,8 @@ public class UpdateConnectionFromJdbc extends UpdateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -177,7 +187,8 @@ public class UpdateConnectionFromJdbc extends UpdateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -204,7 +215,8 @@ public class UpdateConnectionFromJdbc extends UpdateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -218,6 +230,7 @@ public class UpdateConnectionFromJdbc extends UpdateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -231,6 +244,9 @@ public class UpdateConnectionFromJdbc extends UpdateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromMySQL.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromMySQL.java
@@ -141,6 +141,15 @@ public class UpdateConnectionFromMySQL extends UpdateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -158,7 +167,8 @@ public class UpdateConnectionFromMySQL extends UpdateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -177,7 +187,8 @@ public class UpdateConnectionFromMySQL extends UpdateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -204,7 +215,8 @@ public class UpdateConnectionFromMySQL extends UpdateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -218,6 +230,7 @@ public class UpdateConnectionFromMySQL extends UpdateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -231,6 +244,9 @@ public class UpdateConnectionFromMySQL extends UpdateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromOracle.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateConnectionFromOracle.java
@@ -141,6 +141,15 @@ public class UpdateConnectionFromOracle extends UpdateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+        private SensitiveAttribute passwordSecret;
+
+        public Builder passwordSecret(SensitiveAttribute passwordSecret) {
+            this.passwordSecret = passwordSecret;
+            this.__explicitlySet__.add("passwordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -158,7 +167,8 @@ public class UpdateConnectionFromOracle extends UpdateConnectionDetails {
                             connectionProperties,
                             registryMetadata,
                             username,
-                            password);
+                            password,
+                            passwordSecret);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -177,7 +187,8 @@ public class UpdateConnectionFromOracle extends UpdateConnectionDetails {
                             .connectionProperties(o.getConnectionProperties())
                             .registryMetadata(o.getRegistryMetadata())
                             .username(o.getUsername())
-                            .password(o.getPassword());
+                            .password(o.getPassword())
+                            .passwordSecret(o.getPasswordSecret());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -204,7 +215,8 @@ public class UpdateConnectionFromOracle extends UpdateConnectionDetails {
             java.util.List<ConnectionProperty> connectionProperties,
             RegistryMetadata registryMetadata,
             String username,
-            String password) {
+            String password,
+            SensitiveAttribute passwordSecret) {
         super(
                 key,
                 modelVersion,
@@ -218,6 +230,7 @@ public class UpdateConnectionFromOracle extends UpdateConnectionDetails {
                 registryMetadata);
         this.username = username;
         this.password = password;
+        this.passwordSecret = passwordSecret;
     }
 
     /**
@@ -231,6 +244,9 @@ public class UpdateConnectionFromOracle extends UpdateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")
     String password;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordSecret")
+    SensitiveAttribute passwordSecret;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateDataAssetFromAdwc.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateDataAssetFromAdwc.java
@@ -149,6 +149,24 @@ public class UpdateDataAssetFromAdwc extends UpdateDataAssetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+        private SensitiveAttribute walletSecret;
+
+        public Builder walletSecret(SensitiveAttribute walletSecret) {
+            this.walletSecret = walletSecret;
+            this.__explicitlySet__.add("walletSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+        private SensitiveAttribute walletPasswordSecret;
+
+        public Builder walletPasswordSecret(SensitiveAttribute walletPasswordSecret) {
+            this.walletPasswordSecret = walletPasswordSecret;
+            this.__explicitlySet__.add("walletPasswordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
         private UpdateConnectionFromAdwc defaultConnection;
 
@@ -177,6 +195,8 @@ public class UpdateDataAssetFromAdwc extends UpdateDataAssetDetails {
                             serviceName,
                             driverClass,
                             credentialFileContent,
+                            walletSecret,
+                            walletPasswordSecret,
                             defaultConnection);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -198,6 +218,8 @@ public class UpdateDataAssetFromAdwc extends UpdateDataAssetDetails {
                             .serviceName(o.getServiceName())
                             .driverClass(o.getDriverClass())
                             .credentialFileContent(o.getCredentialFileContent())
+                            .walletSecret(o.getWalletSecret())
+                            .walletPasswordSecret(o.getWalletPasswordSecret())
                             .defaultConnection(o.getDefaultConnection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -227,6 +249,8 @@ public class UpdateDataAssetFromAdwc extends UpdateDataAssetDetails {
             String serviceName,
             String driverClass,
             String credentialFileContent,
+            SensitiveAttribute walletSecret,
+            SensitiveAttribute walletPasswordSecret,
             UpdateConnectionFromAdwc defaultConnection) {
         super(
                 key,
@@ -242,6 +266,8 @@ public class UpdateDataAssetFromAdwc extends UpdateDataAssetDetails {
         this.serviceName = serviceName;
         this.driverClass = driverClass;
         this.credentialFileContent = credentialFileContent;
+        this.walletSecret = walletSecret;
+        this.walletPasswordSecret = walletPasswordSecret;
         this.defaultConnection = defaultConnection;
     }
 
@@ -262,6 +288,12 @@ public class UpdateDataAssetFromAdwc extends UpdateDataAssetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("credentialFileContent")
     String credentialFileContent;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+    SensitiveAttribute walletSecret;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+    SensitiveAttribute walletPasswordSecret;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
     UpdateConnectionFromAdwc defaultConnection;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateDataAssetFromAtp.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateDataAssetFromAtp.java
@@ -149,6 +149,24 @@ public class UpdateDataAssetFromAtp extends UpdateDataAssetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+        private SensitiveAttribute walletSecret;
+
+        public Builder walletSecret(SensitiveAttribute walletSecret) {
+            this.walletSecret = walletSecret;
+            this.__explicitlySet__.add("walletSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+        private SensitiveAttribute walletPasswordSecret;
+
+        public Builder walletPasswordSecret(SensitiveAttribute walletPasswordSecret) {
+            this.walletPasswordSecret = walletPasswordSecret;
+            this.__explicitlySet__.add("walletPasswordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
         private UpdateConnectionFromAtp defaultConnection;
 
@@ -177,6 +195,8 @@ public class UpdateDataAssetFromAtp extends UpdateDataAssetDetails {
                             serviceName,
                             driverClass,
                             credentialFileContent,
+                            walletSecret,
+                            walletPasswordSecret,
                             defaultConnection);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -198,6 +218,8 @@ public class UpdateDataAssetFromAtp extends UpdateDataAssetDetails {
                             .serviceName(o.getServiceName())
                             .driverClass(o.getDriverClass())
                             .credentialFileContent(o.getCredentialFileContent())
+                            .walletSecret(o.getWalletSecret())
+                            .walletPasswordSecret(o.getWalletPasswordSecret())
                             .defaultConnection(o.getDefaultConnection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -227,6 +249,8 @@ public class UpdateDataAssetFromAtp extends UpdateDataAssetDetails {
             String serviceName,
             String driverClass,
             String credentialFileContent,
+            SensitiveAttribute walletSecret,
+            SensitiveAttribute walletPasswordSecret,
             UpdateConnectionFromAtp defaultConnection) {
         super(
                 key,
@@ -242,6 +266,8 @@ public class UpdateDataAssetFromAtp extends UpdateDataAssetDetails {
         this.serviceName = serviceName;
         this.driverClass = driverClass;
         this.credentialFileContent = credentialFileContent;
+        this.walletSecret = walletSecret;
+        this.walletPasswordSecret = walletPasswordSecret;
         this.defaultConnection = defaultConnection;
     }
 
@@ -262,6 +288,12 @@ public class UpdateDataAssetFromAtp extends UpdateDataAssetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("credentialFileContent")
     String credentialFileContent;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+    SensitiveAttribute walletSecret;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+    SensitiveAttribute walletPasswordSecret;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
     UpdateConnectionFromAtp defaultConnection;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateDataAssetFromOracle.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateDataAssetFromOracle.java
@@ -176,6 +176,24 @@ public class UpdateDataAssetFromOracle extends UpdateDataAssetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+        private SensitiveAttribute walletSecret;
+
+        public Builder walletSecret(SensitiveAttribute walletSecret) {
+            this.walletSecret = walletSecret;
+            this.__explicitlySet__.add("walletSecret");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+        private SensitiveAttribute walletPasswordSecret;
+
+        public Builder walletPasswordSecret(SensitiveAttribute walletPasswordSecret) {
+            this.walletPasswordSecret = walletPasswordSecret;
+            this.__explicitlySet__.add("walletPasswordSecret");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
         private UpdateConnectionFromOracle defaultConnection;
 
@@ -207,6 +225,8 @@ public class UpdateDataAssetFromOracle extends UpdateDataAssetDetails {
                             driverClass,
                             sid,
                             credentialFileContent,
+                            walletSecret,
+                            walletPasswordSecret,
                             defaultConnection);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -231,6 +251,8 @@ public class UpdateDataAssetFromOracle extends UpdateDataAssetDetails {
                             .driverClass(o.getDriverClass())
                             .sid(o.getSid())
                             .credentialFileContent(o.getCredentialFileContent())
+                            .walletSecret(o.getWalletSecret())
+                            .walletPasswordSecret(o.getWalletPasswordSecret())
                             .defaultConnection(o.getDefaultConnection());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -263,6 +285,8 @@ public class UpdateDataAssetFromOracle extends UpdateDataAssetDetails {
             String driverClass,
             String sid,
             String credentialFileContent,
+            SensitiveAttribute walletSecret,
+            SensitiveAttribute walletPasswordSecret,
             UpdateConnectionFromOracle defaultConnection) {
         super(
                 key,
@@ -281,6 +305,8 @@ public class UpdateDataAssetFromOracle extends UpdateDataAssetDetails {
         this.driverClass = driverClass;
         this.sid = sid;
         this.credentialFileContent = credentialFileContent;
+        this.walletSecret = walletSecret;
+        this.walletPasswordSecret = walletPasswordSecret;
         this.defaultConnection = defaultConnection;
     }
 
@@ -319,6 +345,12 @@ public class UpdateDataAssetFromOracle extends UpdateDataAssetDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("credentialFileContent")
     String credentialFileContent;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletSecret")
+    SensitiveAttribute walletSecret;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletPasswordSecret")
+    SensitiveAttribute walletPasswordSecret;
 
     @com.fasterxml.jackson.annotation.JsonProperty("defaultConnection")
     UpdateConnectionFromOracle defaultConnection;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdatePipelineDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdatePipelineDetails.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Properties used in pipeline update operations
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdatePipelineDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdatePipelineDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+        private java.util.List<FlowNode> nodes;
+
+        public Builder nodes(java.util.List<FlowNode> nodes) {
+            this.nodes = nodes;
+            this.__explicitlySet__.add("nodes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+        private ConfigValues flowConfigValues;
+
+        public Builder flowConfigValues(ConfigValues flowConfigValues) {
+            this.flowConfigValues = flowConfigValues;
+            this.__explicitlySet__.add("flowConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("variables")
+        private java.util.List<Variable> variables;
+
+        public Builder variables(java.util.List<Variable> variables) {
+            this.variables = variables;
+            this.__explicitlySet__.add("variables");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("registryMetadata")
+        private RegistryMetadata registryMetadata;
+
+        public Builder registryMetadata(RegistryMetadata registryMetadata) {
+            this.registryMetadata = registryMetadata;
+            this.__explicitlySet__.add("registryMetadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdatePipelineDetails build() {
+            UpdatePipelineDetails __instance__ =
+                    new UpdatePipelineDetails(
+                            key,
+                            modelType,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            nodes,
+                            parameters,
+                            flowConfigValues,
+                            variables,
+                            registryMetadata);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdatePipelineDetails o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelType(o.getModelType())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .nodes(o.getNodes())
+                            .parameters(o.getParameters())
+                            .flowConfigValues(o.getFlowConfigValues())
+                            .variables(o.getVariables())
+                            .registryMetadata(o.getRegistryMetadata());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Generated key that can be used in API calls to identify pipeline. On scenarios where reference to the pipeline is needed, a value can be passed in create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * A list of nodes attached to the pipeline
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodes")
+    java.util.List<FlowNode> nodes;
+
+    /**
+     * A list of additional parameters required in pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+    java.util.List<Parameter> parameters;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("flowConfigValues")
+    ConfigValues flowConfigValues;
+
+    /**
+     * The list of variables required in pipeline.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("variables")
+    java.util.List<Variable> variables;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("registryMetadata")
+    RegistryMetadata registryMetadata;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateTaskDetails.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateTaskDetails.java
@@ -29,6 +29,10 @@ package com.oracle.bmc.dataintegration.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateTaskFromPipelineTask.class,
+        name = "PIPELINE_TASK"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = UpdateTaskFromDataLoaderTask.class,
         name = "DATA_LOADER_TASK"
     ),
@@ -118,6 +122,7 @@ public class UpdateTaskDetails {
     public enum ModelType {
         IntegrationTask("INTEGRATION_TASK"),
         DataLoaderTask("DATA_LOADER_TASK"),
+        PipelineTask("PIPELINE_TASK"),
         ;
 
         private final String value;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateTaskFromPipelineTask.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/UpdateTaskFromPipelineTask.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * The information about the pipeline task.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateTaskFromPipelineTask.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "modelType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateTaskFromPipelineTask extends UpdateTaskDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputPorts")
+        private java.util.List<InputPort> inputPorts;
+
+        public Builder inputPorts(java.util.List<InputPort> inputPorts) {
+            this.inputPorts = inputPorts;
+            this.__explicitlySet__.add("inputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputPorts")
+        private java.util.List<OutputPort> outputPorts;
+
+        public Builder outputPorts(java.util.List<OutputPort> outputPorts) {
+            this.outputPorts = outputPorts;
+            this.__explicitlySet__.add("outputPorts");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parameters")
+        private java.util.List<Parameter> parameters;
+
+        public Builder parameters(java.util.List<Parameter> parameters) {
+            this.parameters = parameters;
+            this.__explicitlySet__.add("parameters");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("opConfigValues")
+        private ConfigValues opConfigValues;
+
+        public Builder opConfigValues(ConfigValues opConfigValues) {
+            this.opConfigValues = opConfigValues;
+            this.__explicitlySet__.add("opConfigValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configProviderDelegate")
+        private ConfigProvider configProviderDelegate;
+
+        public Builder configProviderDelegate(ConfigProvider configProviderDelegate) {
+            this.configProviderDelegate = configProviderDelegate;
+            this.__explicitlySet__.add("configProviderDelegate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("registryMetadata")
+        private RegistryMetadata registryMetadata;
+
+        public Builder registryMetadata(RegistryMetadata registryMetadata) {
+            this.registryMetadata = registryMetadata;
+            this.__explicitlySet__.add("registryMetadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+        private Pipeline pipeline;
+
+        public Builder pipeline(Pipeline pipeline) {
+            this.pipeline = pipeline;
+            this.__explicitlySet__.add("pipeline");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateTaskFromPipelineTask build() {
+            UpdateTaskFromPipelineTask __instance__ =
+                    new UpdateTaskFromPipelineTask(
+                            key,
+                            modelVersion,
+                            parentRef,
+                            name,
+                            description,
+                            objectStatus,
+                            objectVersion,
+                            identifier,
+                            inputPorts,
+                            outputPorts,
+                            parameters,
+                            opConfigValues,
+                            configProviderDelegate,
+                            registryMetadata,
+                            pipeline);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateTaskFromPipelineTask o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectStatus(o.getObjectStatus())
+                            .objectVersion(o.getObjectVersion())
+                            .identifier(o.getIdentifier())
+                            .inputPorts(o.getInputPorts())
+                            .outputPorts(o.getOutputPorts())
+                            .parameters(o.getParameters())
+                            .opConfigValues(o.getOpConfigValues())
+                            .configProviderDelegate(o.getConfigProviderDelegate())
+                            .registryMetadata(o.getRegistryMetadata())
+                            .pipeline(o.getPipeline());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateTaskFromPipelineTask(
+            String key,
+            String modelVersion,
+            ParentReference parentRef,
+            String name,
+            String description,
+            Integer objectStatus,
+            Integer objectVersion,
+            String identifier,
+            java.util.List<InputPort> inputPorts,
+            java.util.List<OutputPort> outputPorts,
+            java.util.List<Parameter> parameters,
+            ConfigValues opConfigValues,
+            ConfigProvider configProviderDelegate,
+            RegistryMetadata registryMetadata,
+            Pipeline pipeline) {
+        super(
+                key,
+                modelVersion,
+                parentRef,
+                name,
+                description,
+                objectStatus,
+                objectVersion,
+                identifier,
+                inputPorts,
+                outputPorts,
+                parameters,
+                opConfigValues,
+                configProviderDelegate,
+                registryMetadata);
+        this.pipeline = pipeline;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("pipeline")
+    Pipeline pipeline;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Variable.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/model/Variable.java
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.model;
+
+/**
+ * Variable definitions in the pipeline.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Variable.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Variable {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+        private String modelVersion;
+
+        public Builder modelVersion(String modelVersion) {
+            this.modelVersion = modelVersion;
+            this.__explicitlySet__.add("modelVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+        private String modelType;
+
+        public Builder modelType(String modelType) {
+            this.modelType = modelType;
+            this.__explicitlySet__.add("modelType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+        private ParentReference parentRef;
+
+        public Builder parentRef(ParentReference parentRef) {
+            this.parentRef = parentRef;
+            this.__explicitlySet__.add("parentRef");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+        private Integer objectVersion;
+
+        public Builder objectVersion(Integer objectVersion) {
+            this.objectVersion = objectVersion;
+            this.__explicitlySet__.add("objectVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private Integer objectStatus;
+
+        public Builder objectStatus(Integer objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private BaseType type;
+
+        public Builder type(BaseType type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+        private ConfigValues configValues;
+
+        public Builder configValues(ConfigValues configValues) {
+            this.configValues = configValues;
+            this.__explicitlySet__.add("configValues");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+        private Object defaultValue;
+
+        public Builder defaultValue(Object defaultValue) {
+            this.defaultValue = defaultValue;
+            this.__explicitlySet__.add("defaultValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rootObjectDefaultValue")
+        private RootObject rootObjectDefaultValue;
+
+        public Builder rootObjectDefaultValue(RootObject rootObjectDefaultValue) {
+            this.rootObjectDefaultValue = rootObjectDefaultValue;
+            this.__explicitlySet__.add("rootObjectDefaultValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Variable build() {
+            Variable __instance__ =
+                    new Variable(
+                            key,
+                            modelVersion,
+                            modelType,
+                            parentRef,
+                            name,
+                            description,
+                            objectVersion,
+                            objectStatus,
+                            identifier,
+                            type,
+                            configValues,
+                            defaultValue,
+                            rootObjectDefaultValue);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Variable o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .modelVersion(o.getModelVersion())
+                            .modelType(o.getModelType())
+                            .parentRef(o.getParentRef())
+                            .name(o.getName())
+                            .description(o.getDescription())
+                            .objectVersion(o.getObjectVersion())
+                            .objectStatus(o.getObjectStatus())
+                            .identifier(o.getIdentifier())
+                            .type(o.getType())
+                            .configValues(o.getConfigValues())
+                            .defaultValue(o.getDefaultValue())
+                            .rootObjectDefaultValue(o.getRootObjectDefaultValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Generated key that can be used in API calls to identify variable. On scenarios where reference to the variable is needed, a value can be passed in create.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * This is a version number that is used by the service to upgrade objects if needed through releases of the service.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelVersion")
+    String modelVersion;
+
+    /**
+     * The type of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelType")
+    String modelType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parentRef")
+    ParentReference parentRef;
+
+    /**
+     * Free form text without any restriction on permitted characters. Name can have letters, numbers, and special characters. The value is editable and is restricted to 1000 characters.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * Detailed description for the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * This is used by the service for optimistic locking of the object, to prevent multiple users from simultaneously updating the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectVersion")
+    Integer objectVersion;
+
+    /**
+     * The status of an object that can be set to value 1 for shallow references across objects, other values reserved.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    Integer objectStatus;
+
+    /**
+     * Value can only contain upper case letters, underscore, and numbers. It should begin with upper case letter or underscore. The value can be modified.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    BaseType type;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configValues")
+    ConfigValues configValues;
+
+    /**
+     * A default value for the vairable.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultValue")
+    Object defaultValue;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rootObjectDefaultValue")
+    RootObject rootObjectDefaultValue;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/CreatePipelineRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/CreatePipelineRequest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.requests;
+
+import com.oracle.bmc.dataintegration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/CreatePipelineExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreatePipelineRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreatePipelineRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreatePipelineDetails> {
+
+    /**
+     * The workspace ID.
+     */
+    private String workspaceId;
+
+    /**
+     * The details needed to create a new pipeline.
+     */
+    private CreatePipelineDetails createPipelineDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreatePipelineDetails getBody$() {
+        return createPipelineDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreatePipelineRequest, CreatePipelineDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreatePipelineRequest o) {
+            workspaceId(o.getWorkspaceId());
+            createPipelineDetails(o.getCreatePipelineDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreatePipelineRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreatePipelineRequest
+         */
+        public CreatePipelineRequest build() {
+            CreatePipelineRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreatePipelineDetails body) {
+            createPipelineDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/CreatePipelineValidationRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/CreatePipelineValidationRequest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.requests;
+
+import com.oracle.bmc.dataintegration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/CreatePipelineValidationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreatePipelineValidationRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreatePipelineValidationRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreatePipelineValidationDetails> {
+
+    /**
+     * The workspace ID.
+     */
+    private String workspaceId;
+
+    /**
+     * The information needed to create the data flow validation for the pipeline object.
+     */
+    private CreatePipelineValidationDetails createPipelineValidationDetails;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreatePipelineValidationDetails getBody$() {
+        return createPipelineValidationDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreatePipelineValidationRequest, CreatePipelineValidationDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreatePipelineValidationRequest o) {
+            workspaceId(o.getWorkspaceId());
+            createPipelineValidationDetails(o.getCreatePipelineValidationDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreatePipelineValidationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreatePipelineValidationRequest
+         */
+        public CreatePipelineValidationRequest build() {
+            CreatePipelineValidationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreatePipelineValidationDetails body) {
+            createPipelineValidationDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/DeletePipelineRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/DeletePipelineRequest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.requests;
+
+import com.oracle.bmc.dataintegration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/DeletePipelineExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeletePipelineRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeletePipelineRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The workspace ID.
+     */
+    private String workspaceId;
+
+    /**
+     * The pipeline key.
+     */
+    private String pipelineKey;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+     * When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeletePipelineRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeletePipelineRequest o) {
+            workspaceId(o.getWorkspaceId());
+            pipelineKey(o.getPipelineKey());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeletePipelineRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeletePipelineRequest
+         */
+        public DeletePipelineRequest build() {
+            DeletePipelineRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/DeletePipelineValidationRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/DeletePipelineValidationRequest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.requests;
+
+import com.oracle.bmc.dataintegration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/DeletePipelineValidationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeletePipelineValidationRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeletePipelineValidationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The workspace ID.
+     */
+    private String workspaceId;
+
+    /**
+     * The key of the pipeline validation.
+     */
+    private String pipelineValidationKey;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+     * When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeletePipelineValidationRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeletePipelineValidationRequest o) {
+            workspaceId(o.getWorkspaceId());
+            pipelineValidationKey(o.getPipelineValidationKey());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeletePipelineValidationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeletePipelineValidationRequest
+         */
+        public DeletePipelineValidationRequest build() {
+            DeletePipelineValidationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/GetPipelineRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/GetPipelineRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.requests;
+
+import com.oracle.bmc.dataintegration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/GetPipelineExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetPipelineRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetPipelineRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The workspace ID.
+     */
+    private String workspaceId;
+
+    /**
+     * The pipeline key.
+     */
+    private String pipelineKey;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetPipelineRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPipelineRequest o) {
+            workspaceId(o.getWorkspaceId());
+            pipelineKey(o.getPipelineKey());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetPipelineRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetPipelineRequest
+         */
+        public GetPipelineRequest build() {
+            GetPipelineRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/GetPipelineValidationRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/GetPipelineValidationRequest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.requests;
+
+import com.oracle.bmc.dataintegration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/GetPipelineValidationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetPipelineValidationRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetPipelineValidationRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The workspace ID.
+     */
+    private String workspaceId;
+
+    /**
+     * The key of the pipeline validation.
+     */
+    private String pipelineValidationKey;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetPipelineValidationRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPipelineValidationRequest o) {
+            workspaceId(o.getWorkspaceId());
+            pipelineValidationKey(o.getPipelineValidationKey());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetPipelineValidationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetPipelineValidationRequest
+         */
+        public GetPipelineValidationRequest build() {
+            GetPipelineValidationRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/GetTaskRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/GetTaskRequest.java
@@ -31,6 +31,11 @@ public class GetTaskRequest extends com.oracle.bmc.requests.BmcRequest<java.lang
      */
     private String opcRequestId;
 
+    /**
+     * Used to expand references of the object. If value is true, then all referenced objects are expanded. If value is false, then shallow objects are returned in place of references. Default is false. <br><br><B>Example:</B><br> <ul> <li><B>?expandReferences=true</B> returns all objects of type data loader task</li> </ul>
+     */
+    private String expandReferences;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<GetTaskRequest, java.lang.Void> {
         private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
@@ -68,6 +73,7 @@ public class GetTaskRequest extends com.oracle.bmc.requests.BmcRequest<java.lang
             workspaceId(o.getWorkspaceId());
             taskKey(o.getTaskKey());
             opcRequestId(o.getOpcRequestId());
+            expandReferences(o.getExpandReferences());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListDataEntitiesRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListDataEntitiesRequest.java
@@ -141,6 +141,16 @@ public class ListDataEntitiesRequest extends com.oracle.bmc.requests.BmcRequest<
      */
     private String opcRequestId;
 
+    /**
+     * Used to filter by the name of the object.
+     */
+    private java.util.List<String> nameList;
+
+    /**
+     * This parameter can be used to specify whether entity search type is pattern search or not.
+     */
+    private Boolean isPattern;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListDataEntitiesRequest, java.lang.Void> {
@@ -187,6 +197,8 @@ public class ListDataEntitiesRequest extends com.oracle.bmc.requests.BmcRequest<
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
             opcRequestId(o.getOpcRequestId());
+            nameList(o.getNameList());
+            isPattern(o.getIsPattern());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListPipelineValidationsRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListPipelineValidationsRequest.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.requests;
+
+import com.oracle.bmc.dataintegration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/ListPipelineValidationsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListPipelineValidationsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListPipelineValidationsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The workspace ID.
+     */
+    private String workspaceId;
+
+    /**
+     * Used to filter by the key of the object.
+     */
+    private String key;
+
+    /**
+     * Used to filter by the name of the object.
+     */
+    private String name;
+
+    /**
+     * Used to filter by the identifier of the object.
+     */
+    private String identifier;
+
+    /**
+     * Specifies the fields to get for an object.
+     */
+    private java.util.List<String> fields;
+
+    /**
+     * For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     */
+    private String page;
+
+    /**
+     * Sets the maximum number of results per page, or items to return in a paginated `List` call. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     */
+    private Integer limit;
+
+    /**
+     * Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+     */
+    private SortBy sortBy;
+
+    /**
+     * Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+     **/
+    public enum SortBy {
+        TimeCreated("TIME_CREATED"),
+        DisplayName("DISPLAY_NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListPipelineValidationsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPipelineValidationsRequest o) {
+            workspaceId(o.getWorkspaceId());
+            key(o.getKey());
+            name(o.getName());
+            identifier(o.getIdentifier());
+            fields(o.getFields());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListPipelineValidationsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListPipelineValidationsRequest
+         */
+        public ListPipelineValidationsRequest build() {
+            ListPipelineValidationsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListPipelinesRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListPipelinesRequest.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.requests;
+
+import com.oracle.bmc.dataintegration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/ListPipelinesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListPipelinesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListPipelinesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The workspace ID.
+     */
+    private String workspaceId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Used to filter by the project or the folder object.
+     *
+     */
+    private String aggregatorKey;
+
+    /**
+     * Specifies the fields to get for an object.
+     */
+    private java.util.List<String> fields;
+
+    /**
+     * Used to filter by the name of the object.
+     */
+    private String name;
+
+    /**
+     * Used to filter by the identifier of the object.
+     */
+    private java.util.List<String> identifier;
+
+    /**
+     * Sets the maximum number of results per page, or items to return in a paginated `List` call. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value for this parameter is the `opc-next-page` or the `opc-prev-page` response header from the previous `List` call. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     */
+    private String page;
+
+    /**
+     * Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+     */
+    private SortBy sortBy;
+
+    /**
+     * Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order. Sorting related parameters are ignored when parameter `query` is present (search operation and sorting order is by relevance score in descending order).
+     **/
+    public enum SortBy {
+        TimeCreated("TIME_CREATED"),
+        DisplayName("DISPLAY_NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListPipelinesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPipelinesRequest o) {
+            workspaceId(o.getWorkspaceId());
+            opcRequestId(o.getOpcRequestId());
+            aggregatorKey(o.getAggregatorKey());
+            fields(o.getFields());
+            name(o.getName());
+            identifier(o.getIdentifier());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListPipelinesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListPipelinesRequest
+         */
+        public ListPipelinesRequest build() {
+            ListPipelinesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListSchemasRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListSchemasRequest.java
@@ -136,6 +136,11 @@ public class ListSchemasRequest extends com.oracle.bmc.requests.BmcRequest<java.
      */
     private String opcRequestId;
 
+    /**
+     * Used to filter by the name of the object.
+     */
+    private java.util.List<String> nameList;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListSchemasRequest, java.lang.Void> {
@@ -181,6 +186,7 @@ public class ListSchemasRequest extends com.oracle.bmc.requests.BmcRequest<java.
             sortOrder(o.getSortOrder());
             name(o.getName());
             opcRequestId(o.getOpcRequestId());
+            nameList(o.getNameList());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListTaskRunsRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListTaskRunsRequest.java
@@ -32,6 +32,12 @@ public class ListTaskRunsRequest extends com.oracle.bmc.requests.BmcRequest<java
     private String opcRequestId;
 
     /**
+     * Used to filter by the project or the folder object.
+     *
+     */
+    private String aggregatorKey;
+
+    /**
      * Specifies the fields to get for an object.
      */
     private java.util.List<String> fields;
@@ -175,6 +181,7 @@ public class ListTaskRunsRequest extends com.oracle.bmc.requests.BmcRequest<java
             workspaceId(o.getWorkspaceId());
             applicationKey(o.getApplicationKey());
             opcRequestId(o.getOpcRequestId());
+            aggregatorKey(o.getAggregatorKey());
             fields(o.getFields());
             name(o.getName());
             identifier(o.getIdentifier());

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListWorkRequestsRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/ListWorkRequestsRequest.java
@@ -27,6 +27,11 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
     private String opcRequestId;
 
     /**
+     * DIS workspace id
+     */
+    private String workspaceId;
+
+    /**
      * The work request status.
      */
     private WorkRequestStatus workRequestStatus;
@@ -198,6 +203,7 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
         public Builder copy(ListWorkRequestsRequest o) {
             compartmentId(o.getCompartmentId());
             opcRequestId(o.getOpcRequestId());
+            workspaceId(o.getWorkspaceId());
             workRequestStatus(o.getWorkRequestStatus());
             page(o.getPage());
             limit(o.getLimit());

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/UpdatePipelineRequest.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/requests/UpdatePipelineRequest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.requests;
+
+import com.oracle.bmc.dataintegration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/dataintegration/UpdatePipelineExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdatePipelineRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdatePipelineRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdatePipelineDetails> {
+
+    /**
+     * The workspace ID.
+     */
+    private String workspaceId;
+
+    /**
+     * The pipeline key.
+     */
+    private String pipelineKey;
+
+    /**
+     * The details needed to updated a pipeline.
+     */
+    private UpdatePipelineDetails updatePipelineDetails;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value.
+     * When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdatePipelineDetails getBody$() {
+        return updatePipelineDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdatePipelineRequest, UpdatePipelineDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdatePipelineRequest o) {
+            workspaceId(o.getWorkspaceId());
+            pipelineKey(o.getPipelineKey());
+            updatePipelineDetails(o.getUpdatePipelineDetails());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdatePipelineRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdatePipelineRequest
+         */
+        public UpdatePipelineRequest build() {
+            UpdatePipelineRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdatePipelineDetails body) {
+            updatePipelineDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/CreatePipelineResponse.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/CreatePipelineResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.responses;
+
+import com.oracle.bmc.dataintegration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreatePipelineResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Pipeline instance.
+     */
+    private Pipeline pipeline;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreatePipelineResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            pipeline(o.getPipeline());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/CreatePipelineValidationResponse.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/CreatePipelineValidationResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.responses;
+
+import com.oracle.bmc.dataintegration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreatePipelineValidationResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned PipelineValidation instance.
+     */
+    private PipelineValidation pipelineValidation;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreatePipelineValidationResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            pipelineValidation(o.getPipelineValidation());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/DeletePipelineResponse.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/DeletePipelineResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.responses;
+
+import com.oracle.bmc.dataintegration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeletePipelineResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeletePipelineResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/DeletePipelineValidationResponse.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/DeletePipelineValidationResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.responses;
+
+import com.oracle.bmc.dataintegration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeletePipelineValidationResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeletePipelineValidationResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/GetPipelineResponse.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/GetPipelineResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.responses;
+
+import com.oracle.bmc.dataintegration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetPipelineResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Pipeline instance.
+     */
+    private Pipeline pipeline;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPipelineResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            pipeline(o.getPipeline());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/GetPipelineValidationResponse.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/GetPipelineValidationResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.responses;
+
+import com.oracle.bmc.dataintegration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetPipelineValidationResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned PipelineValidation instance.
+     */
+    private PipelineValidation pipelineValidation;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPipelineValidationResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            pipelineValidation(o.getPipelineValidation());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/ListPipelineValidationsResponse.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/ListPipelineValidationsResponse.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.responses;
+
+import com.oracle.bmc.dataintegration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListPipelineValidationsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * Total items in the entire list.
+     *
+     */
+    private Integer opcTotalItems;
+
+    /**
+     * The returned PipelineValidationSummaryCollection instance.
+     */
+    private PipelineValidationSummaryCollection pipelineValidationSummaryCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPipelineValidationsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            opcPrevPage(o.getOpcPrevPage());
+            opcTotalItems(o.getOpcTotalItems());
+            pipelineValidationSummaryCollection(o.getPipelineValidationSummaryCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/ListPipelinesResponse.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/ListPipelinesResponse.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.responses;
+
+import com.oracle.bmc.dataintegration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListPipelinesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * Total items in the entire list.
+     *
+     */
+    private Integer opcTotalItems;
+
+    /**
+     * The returned PipelineSummaryCollection instance.
+     */
+    private PipelineSummaryCollection pipelineSummaryCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPipelinesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            opcPrevPage(o.getOpcPrevPage());
+            opcTotalItems(o.getOpcTotalItems());
+            pipelineSummaryCollection(o.getPipelineSummaryCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/UpdatePipelineResponse.java
+++ b/bmc-dataintegration/src/main/java/com/oracle/bmc/dataintegration/responses/UpdatePipelineResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.dataintegration.responses;
+
+import com.oracle.bmc.dataintegration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200430")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdatePipelineResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Pipeline instance.
+     */
+    private Pipeline pipeline;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdatePipelineResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            pipeline(o.getPipeline());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/FileStorage.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/FileStorage.java
@@ -108,9 +108,9 @@ public interface FileStorage extends AutoCloseable {
      * <p>
      * All Oracle Cloud Infrastructure resources, including
      * file systems, get an Oracle-assigned, unique ID called an Oracle
-     * Cloud Identifier (OCID).  When you create a resource, you can
-     * find its OCID in the response. You can also retrieve a
-     * resource's OCID by using a List API operation on that resource
+     * Cloud Identifier ([OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)).
+     * When you create a resource, you can find its OCID in the response.
+     * You can also retrieve a resource's OCID by using a List API operation on that resource
      * type or by viewing the resource in the Console.
      *
      * @param request The request object containing the details to send
@@ -150,9 +150,9 @@ public interface FileStorage extends AutoCloseable {
      * <p>
      * All Oracle Cloud Infrastructure Services resources, including
      * mount targets, get an Oracle-assigned, unique ID called an
-     * Oracle Cloud Identifier (OCID).  When you create a resource,
-     * you can find its OCID in the response. You can also retrieve a
-     * resource's OCID by using a List API operation on that resource
+     * Oracle Cloud Identifier ([OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)).
+     * When you create a resource, you can find its OCID in the response.
+     * You can also retrieve a resource's OCID by using a List API operation on that resource
      * type, or by viewing the resource in the Console.
      *
      * @param request The request object containing the details to send

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/FileStorageAsync.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/FileStorageAsync.java
@@ -124,9 +124,9 @@ public interface FileStorageAsync extends AutoCloseable {
      * <p>
      * All Oracle Cloud Infrastructure resources, including
      * file systems, get an Oracle-assigned, unique ID called an Oracle
-     * Cloud Identifier (OCID).  When you create a resource, you can
-     * find its OCID in the response. You can also retrieve a
-     * resource's OCID by using a List API operation on that resource
+     * Cloud Identifier ([OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)).
+     * When you create a resource, you can find its OCID in the response.
+     * You can also retrieve a resource's OCID by using a List API operation on that resource
      * type or by viewing the resource in the Console.
      *
      *
@@ -171,9 +171,9 @@ public interface FileStorageAsync extends AutoCloseable {
      * <p>
      * All Oracle Cloud Infrastructure Services resources, including
      * mount targets, get an Oracle-assigned, unique ID called an
-     * Oracle Cloud Identifier (OCID).  When you create a resource,
-     * you can find its OCID in the response. You can also retrieve a
-     * resource's OCID by using a List API operation on that resource
+     * Oracle Cloud Identifier ([OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm)).
+     * When you create a resource, you can find its OCID in the response.
+     * You can also retrieve a resource's OCID by using a List API operation on that resource
      * type, or by viewing the resource in the Console.
      *
      *

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/internal/http/ListFileSystemsConverter.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/internal/http/ListFileSystemsConverter.java
@@ -85,6 +85,22 @@ public class ListFileSystemsConverter {
                                     request.getId()));
         }
 
+        if (request.getSourceSnapshotId() != null) {
+            target =
+                    target.queryParam(
+                            "sourceSnapshotId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSourceSnapshotId()));
+        }
+
+        if (request.getParentFileSystemId() != null) {
+            target =
+                    target.queryParam(
+                            "parentFileSystemId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getParentFileSystemId()));
+        }
+
         if (request.getSortBy() != null) {
             target =
                     target.queryParam(

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/CreateExportDetails.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/CreateExportDetails.java
@@ -121,13 +121,13 @@ public class CreateExportDetails {
     java.util.List<ClientOptions> exportOptions;
 
     /**
-     * The OCID of this export's export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of this export's export set.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("exportSetId")
     String exportSetId;
 
     /**
-     * The OCID of this export's file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of this export's file system.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fileSystemId")
     String fileSystemId;

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/CreateFileSystemDetails.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/CreateFileSystemDetails.java
@@ -81,6 +81,15 @@ public class CreateFileSystemDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceSnapshotId")
+        private String sourceSnapshotId;
+
+        public Builder sourceSnapshotId(String sourceSnapshotId) {
+            this.sourceSnapshotId = sourceSnapshotId;
+            this.__explicitlySet__.add("sourceSnapshotId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -92,7 +101,8 @@ public class CreateFileSystemDetails {
                             displayName,
                             freeformTags,
                             definedTags,
-                            kmsKeyId);
+                            kmsKeyId,
+                            sourceSnapshotId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -105,7 +115,8 @@ public class CreateFileSystemDetails {
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
-                            .kmsKeyId(o.getKmsKeyId());
+                            .kmsKeyId(o.getKmsKeyId())
+                            .sourceSnapshotId(o.getSourceSnapshotId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -129,7 +140,7 @@ public class CreateFileSystemDetails {
     String availabilityDomain;
 
     /**
-     * The OCID of the compartment to create the file system in.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to create the file system in.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -164,11 +175,19 @@ public class CreateFileSystemDetails {
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * The OCID of KMS key used to encrypt the encryption keys associated with this file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the KMS key used to encrypt the encryption keys associated with this file system.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
     String kmsKeyId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the snapshot used to create a cloned file system.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceSnapshotId")
+    String sourceSnapshotId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/CreateMountTargetDetails.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/CreateMountTargetDetails.java
@@ -162,7 +162,7 @@ public class CreateMountTargetDetails {
     String availabilityDomain;
 
     /**
-     * The OCID of the compartment in which to create the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment in which to create the mount target.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -207,7 +207,7 @@ public class CreateMountTargetDetails {
     String ipAddress;
 
     /**
-     * The OCID of the subnet in which to create the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the subnet in which to create the mount target.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/CreateSnapshotDetails.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/CreateSnapshotDetails.java
@@ -94,7 +94,7 @@ public class CreateSnapshotDetails {
     }
 
     /**
-     * The OCID of the file system to take a snapshot of.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system to take a snapshot of.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fileSystemId")
     String fileSystemId;

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/Export.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/Export.java
@@ -194,19 +194,19 @@ public class Export {
     java.util.List<ClientOptions> exportOptions;
 
     /**
-     * The OCID of this export's export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of this export's export set.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("exportSetId")
     String exportSetId;
 
     /**
-     * The OCID of this export's file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of this export's file system.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fileSystemId")
     String fileSystemId;
 
     /**
-     * The OCID of this export.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of this export.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/ExportSet.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/ExportSet.java
@@ -164,7 +164,7 @@ public class ExportSet {
     String availabilityDomain;
 
     /**
-     * The OCID of the compartment that contains the export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment that contains the export set.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -180,7 +180,7 @@ public class ExportSet {
     String displayName;
 
     /**
-     * The OCID of the export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the export set.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -279,7 +279,7 @@ public class ExportSet {
     java.util.Date timeCreated;
 
     /**
-     * The OCID of the virtual cloud network (VCN) the export set is in.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the virtual cloud network (VCN) the export set is in.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
     String vcnId;

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/ExportSetSummary.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/ExportSetSummary.java
@@ -139,7 +139,7 @@ public class ExportSetSummary {
     String availabilityDomain;
 
     /**
-     * The OCID of the compartment that contains the export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment that contains the export set.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -155,7 +155,7 @@ public class ExportSetSummary {
     String displayName;
 
     /**
-     * The OCID of the export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the export set.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -224,7 +224,7 @@ public class ExportSetSummary {
     java.util.Date timeCreated;
 
     /**
-     * The OCID of the virtual cloud network (VCN) the export set is in.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the virtual cloud network (VCN) the export set is in.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
     String vcnId;

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/ExportSummary.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/ExportSummary.java
@@ -113,19 +113,19 @@ public class ExportSummary {
     }
 
     /**
-     * The OCID of this export's export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of this export's export set.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("exportSetId")
     String exportSetId;
 
     /**
-     * The OCID of this export's file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of this export's file system.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fileSystemId")
     String fileSystemId;
 
     /**
-     * The OCID of this export.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of this export.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/FileSystem.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/FileSystem.java
@@ -127,6 +127,42 @@ public class FileSystem {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
+        private SourceDetails sourceDetails;
+
+        public Builder sourceDetails(SourceDetails sourceDetails) {
+            this.sourceDetails = sourceDetails;
+            this.__explicitlySet__.add("sourceDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCloneParent")
+        private Boolean isCloneParent;
+
+        public Builder isCloneParent(Boolean isCloneParent) {
+            this.isCloneParent = isCloneParent;
+            this.__explicitlySet__.add("isCloneParent");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHydrated")
+        private Boolean isHydrated;
+
+        public Builder isHydrated(Boolean isHydrated) {
+            this.isHydrated = isHydrated;
+            this.__explicitlySet__.add("isHydrated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -142,7 +178,11 @@ public class FileSystem {
                             timeCreated,
                             freeformTags,
                             definedTags,
-                            kmsKeyId);
+                            kmsKeyId,
+                            sourceDetails,
+                            isCloneParent,
+                            isHydrated,
+                            lifecycleDetails);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -159,7 +199,11 @@ public class FileSystem {
                             .timeCreated(o.getTimeCreated())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
-                            .kmsKeyId(o.getKmsKeyId());
+                            .kmsKeyId(o.getKmsKeyId())
+                            .sourceDetails(o.getSourceDetails())
+                            .isCloneParent(o.getIsCloneParent())
+                            .isHydrated(o.getIsHydrated())
+                            .lifecycleDetails(o.getLifecycleDetails());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -188,13 +232,14 @@ public class FileSystem {
      * any snapshots. This number reflects the metered size of the file
      * system and is updated asynchronously with respect to
      * updates to the file system.
+     * For more information, see [File System Usage and Metering](https://docs.cloud.oracle.com/Content/File/Concepts/FSutilization.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("meteredBytes")
     Long meteredBytes;
 
     /**
-     * The OCID of the compartment that contains the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment that contains the file system.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -210,7 +255,7 @@ public class FileSystem {
     String displayName;
 
     /**
-     * The OCID of the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -298,11 +343,38 @@ public class FileSystem {
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * The OCID of the KMS key which is the master encryption key for the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the KMS key which is the master encryption key for the file system.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
     String kmsKeyId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
+    SourceDetails sourceDetails;
+
+    /**
+     * Specifies whether the file system has been cloned.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCloneParent")
+    Boolean isCloneParent;
+
+    /**
+     * Specifies whether the data has finished copying from the source to the clone.
+     * Hydration can take up to several hours to complete depending on the size of the source.
+     * The source and clone remain available during hydration, but there may be some performance impact.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm#hydration).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHydrated")
+    Boolean isHydrated;
+
+    /**
+     * Additional information about the current 'lifecycleState'.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/FileSystemSummary.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/FileSystemSummary.java
@@ -118,6 +118,42 @@ public class FileSystemSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
+        private SourceDetails sourceDetails;
+
+        public Builder sourceDetails(SourceDetails sourceDetails) {
+            this.sourceDetails = sourceDetails;
+            this.__explicitlySet__.add("sourceDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCloneParent")
+        private Boolean isCloneParent;
+
+        public Builder isCloneParent(Boolean isCloneParent) {
+            this.isCloneParent = isCloneParent;
+            this.__explicitlySet__.add("isCloneParent");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHydrated")
+        private Boolean isHydrated;
+
+        public Builder isHydrated(Boolean isHydrated) {
+            this.isHydrated = isHydrated;
+            this.__explicitlySet__.add("isHydrated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -133,7 +169,11 @@ public class FileSystemSummary {
                             timeCreated,
                             freeformTags,
                             definedTags,
-                            kmsKeyId);
+                            kmsKeyId,
+                            sourceDetails,
+                            isCloneParent,
+                            isHydrated,
+                            lifecycleDetails);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -150,7 +190,11 @@ public class FileSystemSummary {
                             .timeCreated(o.getTimeCreated())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
-                            .kmsKeyId(o.getKmsKeyId());
+                            .kmsKeyId(o.getKmsKeyId())
+                            .sourceDetails(o.getSourceDetails())
+                            .isCloneParent(o.getIsCloneParent())
+                            .isHydrated(o.getIsHydrated())
+                            .lifecycleDetails(o.getLifecycleDetails());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -185,7 +229,7 @@ public class FileSystemSummary {
     Long meteredBytes;
 
     /**
-     * The OCID of the compartment that contains the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment that contains the file system.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -201,7 +245,7 @@ public class FileSystemSummary {
     String displayName;
 
     /**
-     * The OCID of the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -289,11 +333,38 @@ public class FileSystemSummary {
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * The OCID of KMS key used to encrypt the encryption keys associated with this file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the KMS key used to encrypt the encryption keys associated with this file system.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
     String kmsKeyId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
+    SourceDetails sourceDetails;
+
+    /**
+     * Specifies whether the file system has been cloned.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCloneParent")
+    Boolean isCloneParent;
+
+    /**
+     * Specifies whether the data has finished copying from the source to the clone.
+     * Hydration can take up to several hours to complete depending on the size of the source.
+     * The source and clone remain available during hydration, but there may be some performance impact.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm#hydration).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHydrated")
+    Boolean isHydrated;
+
+    /**
+     * Additional information about the current 'lifecycleState'.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/MountTarget.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/MountTarget.java
@@ -210,7 +210,7 @@ public class MountTarget {
     String availabilityDomain;
 
     /**
-     * The OCID of the compartment that contains the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment that contains the mount target.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -226,7 +226,7 @@ public class MountTarget {
     String displayName;
 
     /**
-     * The OCID of the associated export set. Controls what file
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the associated export set. Controls what file
      * systems will be exported through Network File System (NFS) protocol on this
      * mount target.
      *
@@ -235,7 +235,7 @@ public class MountTarget {
     String exportSetId;
 
     /**
-     * The OCID of the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the mount target.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -307,7 +307,7 @@ public class MountTarget {
     java.util.List<String> privateIpIds;
 
     /**
-     * The OCID of the subnet the mount target is in.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the subnet the mount target is in.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
     String subnetId;

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/MountTargetSummary.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/MountTargetSummary.java
@@ -197,7 +197,7 @@ public class MountTargetSummary {
     String availabilityDomain;
 
     /**
-     * The OCID of the compartment that contains the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment that contains the mount target.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -213,7 +213,7 @@ public class MountTargetSummary {
     String displayName;
 
     /**
-     * The OCID of the associated export set. Controls what file
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the associated export set. Controls what file
      * systems will be exported using Network File System (NFS) protocol on
      * this mount target.
      *
@@ -222,7 +222,7 @@ public class MountTargetSummary {
     String exportSetId;
 
     /**
-     * The OCID of the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the mount target.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -288,7 +288,7 @@ public class MountTargetSummary {
     java.util.List<String> privateIpIds;
 
     /**
-     * The OCID of the subnet the mount target is in.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the subnet the mount target is in.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
     String subnetId;

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/Snapshot.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/Snapshot.java
@@ -72,6 +72,33 @@ public class Snapshot {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("provenanceId")
+        private String provenanceId;
+
+        public Builder provenanceId(String provenanceId) {
+            this.provenanceId = provenanceId;
+            this.__explicitlySet__.add("provenanceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCloneSource")
+        private Boolean isCloneSource;
+
+        public Builder isCloneSource(Boolean isCloneSource) {
+            this.isCloneSource = isCloneSource;
+            this.__explicitlySet__.add("isCloneSource");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -102,6 +129,9 @@ public class Snapshot {
                             lifecycleState,
                             name,
                             timeCreated,
+                            provenanceId,
+                            isCloneSource,
+                            lifecycleDetails,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -116,6 +146,9 @@ public class Snapshot {
                             .lifecycleState(o.getLifecycleState())
                             .name(o.getName())
                             .timeCreated(o.getTimeCreated())
+                            .provenanceId(o.getProvenanceId())
+                            .isCloneSource(o.getIsCloneSource())
+                            .lifecycleDetails(o.getLifecycleDetails())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -132,7 +165,7 @@ public class Snapshot {
     }
 
     /**
-     * The OCID of the file system from which the snapshot
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system from which the snapshot
      * was created.
      *
      **/
@@ -140,7 +173,7 @@ public class Snapshot {
     String fileSystemId;
 
     /**
-     * The OCID of the snapshot.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the snapshot.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -218,6 +251,30 @@ public class Snapshot {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * An [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) identifying the parent from which this snapshot was cloned.
+     * If this snapshot was not cloned, then the `provenanceId` is the same as the snapshot `id` value.
+     * If this snapshot was cloned, then the `provenanceId` value is the parent's `provenanceId`.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("provenanceId")
+    String provenanceId;
+
+    /**
+     * Specifies whether the snapshot has been cloned.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCloneSource")
+    Boolean isCloneSource;
+
+    /**
+     * Additional information about the current 'lifecycleState'.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/SnapshotSummary.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/SnapshotSummary.java
@@ -70,6 +70,33 @@ public class SnapshotSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("provenanceId")
+        private String provenanceId;
+
+        public Builder provenanceId(String provenanceId) {
+            this.provenanceId = provenanceId;
+            this.__explicitlySet__.add("provenanceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCloneSource")
+        private Boolean isCloneSource;
+
+        public Builder isCloneSource(Boolean isCloneSource) {
+            this.isCloneSource = isCloneSource;
+            this.__explicitlySet__.add("isCloneSource");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -100,6 +127,9 @@ public class SnapshotSummary {
                             lifecycleState,
                             name,
                             timeCreated,
+                            provenanceId,
+                            isCloneSource,
+                            lifecycleDetails,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -114,6 +144,9 @@ public class SnapshotSummary {
                             .lifecycleState(o.getLifecycleState())
                             .name(o.getName())
                             .timeCreated(o.getTimeCreated())
+                            .provenanceId(o.getProvenanceId())
+                            .isCloneSource(o.getIsCloneSource())
+                            .lifecycleDetails(o.getLifecycleDetails())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -130,15 +163,14 @@ public class SnapshotSummary {
     }
 
     /**
-     * The OCID of the file system from which the
-     * snapshot was created.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system from which the snapshot was created.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("fileSystemId")
     String fileSystemId;
 
     /**
-     * The OCID of the snapshot.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the snapshot.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -216,6 +248,30 @@ public class SnapshotSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * An [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) identifying the parent from which this snapshot was cloned.
+     * If this snapshot was not cloned, then the `provenanceId` is the same as the snapshot `id` value.
+     * If this snapshot was cloned, then the `provenanceId` value is the parent's `provenanceId`.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("provenanceId")
+    String provenanceId;
+
+    /**
+     * Specifies whether the snapshot has been cloned.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCloneSource")
+    Boolean isCloneSource;
+
+    /**
+     * Additional information about the current 'lifecycleState'.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/SourceDetails.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/SourceDetails.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.filestorage.model;
+
+/**
+ * Source information for the file system.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20171215")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = SourceDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("parentFileSystemId")
+        private String parentFileSystemId;
+
+        public Builder parentFileSystemId(String parentFileSystemId) {
+            this.parentFileSystemId = parentFileSystemId;
+            this.__explicitlySet__.add("parentFileSystemId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceSnapshotId")
+        private String sourceSnapshotId;
+
+        public Builder sourceSnapshotId(String sourceSnapshotId) {
+            this.sourceSnapshotId = sourceSnapshotId;
+            this.__explicitlySet__.add("sourceSnapshotId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SourceDetails build() {
+            SourceDetails __instance__ = new SourceDetails(parentFileSystemId, sourceSnapshotId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SourceDetails o) {
+            Builder copiedBuilder =
+                    parentFileSystemId(o.getParentFileSystemId())
+                            .sourceSnapshotId(o.getSourceSnapshotId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system that contains the source snapshot of a cloned file system.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("parentFileSystemId")
+    String parentFileSystemId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the source snapshot used to create a cloned file system.
+     * See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceSnapshotId")
+    String sourceSnapshotId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/UpdateFileSystemDetails.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/model/UpdateFileSystemDetails.java
@@ -123,11 +123,10 @@ public class UpdateFileSystemDetails {
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * The OCID of the Key Management master encryption key to associate with the specified file system. If this value is empty, the Update operation will remove the associated key, if there is one, from the file system. (The file system will continue to be encrypted, but with an encryption key managed by Oracle.)
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Key Management master encryption key to associate with the specified file system. If this value is empty, the Update operation will remove the associated key, if there is one, from the file system. (The file system will continue to be encrypted, but with an encryption key managed by Oracle.)
      * <p>
      * If updating to a new Key Management key, the old key must remain enabled so that files previously encrypted continue
-     * to be accessible. For more information, see [Overview of Key
-     * Management](https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm).
+     * to be accessible. For more information, see [Overview of Key Management](https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ChangeFileSystemCompartmentRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ChangeFileSystemCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeFileSystemCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeFileSystemCompartmentDetails> {
 
     /**
-     * The OCID of the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system.
      */
     private String fileSystemId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ChangeMountTargetCompartmentRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ChangeMountTargetCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeMountTargetCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeMountTargetCompartmentDetails> {
 
     /**
-     * The OCID of the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the mount target.
      */
     private String mountTargetId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/DeleteExportRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/DeleteExportRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class DeleteExportRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the export.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the export.
      */
     private String exportId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/DeleteFileSystemRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/DeleteFileSystemRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class DeleteFileSystemRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system.
      */
     private String fileSystemId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/DeleteMountTargetRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/DeleteMountTargetRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class DeleteMountTargetRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the mount target.
      */
     private String mountTargetId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/DeleteSnapshotRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/DeleteSnapshotRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class DeleteSnapshotRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the snapshot.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the snapshot.
      */
     private String snapshotId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetExportRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetExportRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class GetExportRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the export.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the export.
      */
     private String exportId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetExportSetRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetExportSetRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class GetExportSetRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the export set.
      */
     private String exportSetId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetFileSystemRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetFileSystemRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class GetFileSystemRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system.
      */
     private String fileSystemId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetMountTargetRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetMountTargetRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class GetMountTargetRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the mount target.
      */
     private String mountTargetId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetSnapshotRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/GetSnapshotRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class GetSnapshotRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the snapshot.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the snapshot.
      */
     private String snapshotId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListExportSetsRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListExportSetsRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class ListExportSetsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the compartment.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
@@ -105,7 +105,7 @@ public class ListExportSetsRequest extends com.oracle.bmc.requests.BmcRequest<ja
         }
     };
     /**
-     * Filter results by OCID. Must be an OCID of the correct type for
+     * Filter results by [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for
      * the resouce type.
      *
      */

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListExportsRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListExportsRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class ListExportsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the compartment.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
@@ -42,12 +42,12 @@ public class ListExportsRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String page;
 
     /**
-     * The OCID of the export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the export set.
      */
     private String exportSetId;
 
     /**
-     * The OCID of the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system.
      */
     private String fileSystemId;
 
@@ -99,7 +99,7 @@ public class ListExportsRequest extends com.oracle.bmc.requests.BmcRequest<java.
         }
     };
     /**
-     * Filter results by OCID. Must be an OCID of the correct type for
+     * Filter results by [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for
      * the resouce type.
      *
      */

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListFileSystemsRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListFileSystemsRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class ListFileSystemsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the compartment.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
@@ -105,11 +105,21 @@ public class ListFileSystemsRequest extends com.oracle.bmc.requests.BmcRequest<j
         }
     };
     /**
-     * Filter results by OCID. Must be an OCID of the correct type for
+     * Filter results by [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for
      * the resouce type.
      *
      */
     private String id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the snapshot used to create a cloned file system. See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     */
+    private String sourceSnapshotId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system that contains the source snapshot of a cloned file system. See [Cloning a File System](https://docs.cloud.oracle.com/iaas/Content/File/Tasks/cloningafilesystem.htm).
+     */
+    private String parentFileSystemId;
 
     /**
      * The field to sort by. You can provide either value, but not both.
@@ -254,6 +264,8 @@ public class ListFileSystemsRequest extends com.oracle.bmc.requests.BmcRequest<j
             displayName(o.getDisplayName());
             lifecycleState(o.getLifecycleState());
             id(o.getId());
+            sourceSnapshotId(o.getSourceSnapshotId());
+            parentFileSystemId(o.getParentFileSystemId());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
             opcRequestId(o.getOpcRequestId());

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListMountTargetsRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListMountTargetsRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class ListMountTargetsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the compartment.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
@@ -58,7 +58,7 @@ public class ListMountTargetsRequest extends com.oracle.bmc.requests.BmcRequest<
     private String displayName;
 
     /**
-     * The OCID of the export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the export set.
      */
     private String exportSetId;
 
@@ -110,7 +110,7 @@ public class ListMountTargetsRequest extends com.oracle.bmc.requests.BmcRequest<
         }
     };
     /**
-     * Filter results by OCID. Must be an OCID of the correct type for
+     * Filter results by [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for
      * the resouce type.
      *
      */

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListSnapshotsRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/ListSnapshotsRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class ListSnapshotsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system.
      */
     private String fileSystemId;
 
@@ -89,7 +89,7 @@ public class ListSnapshotsRequest extends com.oracle.bmc.requests.BmcRequest<jav
         }
     };
     /**
-     * Filter results by OCID. Must be an OCID of the correct type for
+     * Filter results by [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for
      * the resouce type.
      *
      */

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateExportRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateExportRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.filestorage.model.*;
 public class UpdateExportRequest extends com.oracle.bmc.requests.BmcRequest<UpdateExportDetails> {
 
     /**
-     * The OCID of the export.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the export.
      */
     private String exportId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateExportSetRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateExportSetRequest.java
@@ -15,7 +15,7 @@ public class UpdateExportSetRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateExportSetDetails> {
 
     /**
-     * The OCID of the export set.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the export set.
      */
     private String exportSetId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateFileSystemRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateFileSystemRequest.java
@@ -15,7 +15,7 @@ public class UpdateFileSystemRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateFileSystemDetails> {
 
     /**
-     * The OCID of the file system.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the file system.
      */
     private String fileSystemId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateMountTargetRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateMountTargetRequest.java
@@ -15,7 +15,7 @@ public class UpdateMountTargetRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateMountTargetDetails> {
 
     /**
-     * The OCID of the mount target.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the mount target.
      */
     private String mountTargetId;
 

--- a/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateSnapshotRequest.java
+++ b/bmc-filestorage/src/main/java/com/oracle/bmc/filestorage/requests/UpdateSnapshotRequest.java
@@ -15,7 +15,7 @@ public class UpdateSnapshotRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateSnapshotDetails> {
 
     /**
-     * The OCID of the snapshot.
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the snapshot.
      */
     private String snapshotId;
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.32.2</version>
+        <version>1.33.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.32.2</version>
+    <version>1.33.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.32.2</version>
+      <version>1.33.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.32.2</version>
+  <version>1.33.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for pipelines, pipeline tasks, and favorites in the Data Integration service

- Support for publishing tasks to OCI Data Flow in the Data Integration service

- Support for clones in the File Storage service



### Breaking Changes

- Removed fields `PrimaryKey` and `UniqueKey` from enum `ModelType` of model `Key` in the Data Integration service