### PR TITLE
Releasing version 1.33.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.33.2 - 2021-03-16
+### Added
+- Support for routing policies and HTTP2 listener protocols in the Load Balancing service
+- Support for model deployments in the Data Science service
+- Support for private clusters in the Container Engine for Kubernetes service
+- Support for updating an instance's usage type in the Content and Experience service
+
 ## 1.33.1 - 2021-03-09
 ### Added
 - Support for the Application Performance Monitoring service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -15,7 +15,7 @@
   <url>https://docs.cloud.oracle.com/Content/API/SDKDocs/javasdk.htm</url>
 
   <properties>
-    <resteasy.version>3.13.2.Final</resteasy.version>
+    <resteasy.version>3.15.1.Final</resteasy.version>
   </properties>
 
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,438 +19,438 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngine.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngine.java
@@ -219,6 +219,17 @@ public interface ContainerEngine extends AutoCloseable {
     UpdateClusterResponse updateCluster(UpdateClusterRequest request);
 
     /**
+     * Update the details of the cluster endpoint configuration.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/UpdateClusterEndpointConfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateClusterEndpointConfig API.
+     */
+    UpdateClusterEndpointConfigResponse updateClusterEndpointConfig(
+            UpdateClusterEndpointConfigRequest request);
+
+    /**
      * Update the details of a node pool.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineAsync.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineAsync.java
@@ -307,6 +307,22 @@ public interface ContainerEngineAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Update the details of the cluster endpoint configuration.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateClusterEndpointConfigResponse> updateClusterEndpointConfig(
+            UpdateClusterEndpointConfigRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateClusterEndpointConfigRequest, UpdateClusterEndpointConfigResponse>
+                    handler);
+
+    /**
      * Update the details of a node pool.
      *
      * @param request The request object containing the details to send

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineAsyncClient.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineAsyncClient.java
@@ -1026,6 +1026,50 @@ public class ContainerEngineAsyncClient implements ContainerEngineAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<UpdateClusterEndpointConfigResponse>
+            updateClusterEndpointConfig(
+                    UpdateClusterEndpointConfigRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateClusterEndpointConfigRequest,
+                                    UpdateClusterEndpointConfigResponse>
+                            handler) {
+        LOG.trace("Called async updateClusterEndpointConfig");
+        final UpdateClusterEndpointConfigRequest interceptedRequest =
+                UpdateClusterEndpointConfigConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateClusterEndpointConfigConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateClusterEndpointConfigResponse>
+                transformer = UpdateClusterEndpointConfigConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateClusterEndpointConfigRequest, UpdateClusterEndpointConfigResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateClusterEndpointConfigRequest,
+                                UpdateClusterEndpointConfigResponse>,
+                        java.util.concurrent.Future<UpdateClusterEndpointConfigResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateClusterEndpointConfigRequest, UpdateClusterEndpointConfigResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<UpdateNodePoolResponse> updateNodePool(
             UpdateNodePoolRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineClient.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineClient.java
@@ -940,6 +940,41 @@ public class ContainerEngineClient implements ContainerEngine {
     }
 
     @Override
+    public UpdateClusterEndpointConfigResponse updateClusterEndpointConfig(
+            UpdateClusterEndpointConfigRequest request) {
+        LOG.trace("Called updateClusterEndpointConfig");
+        final UpdateClusterEndpointConfigRequest interceptedRequest =
+                UpdateClusterEndpointConfigConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateClusterEndpointConfigConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateClusterEndpointConfigResponse>
+                transformer = UpdateClusterEndpointConfigConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getUpdateClusterEndpointConfigDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public UpdateNodePoolResponse updateNodePool(UpdateNodePoolRequest request) {
         LOG.trace("Called updateNodePool");
         final UpdateNodePoolRequest interceptedRequest =

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/internal/http/UpdateClusterEndpointConfigConverter.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/internal/http/UpdateClusterEndpointConfigConverter.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.containerengine.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.containerengine.model.*;
+import com.oracle.bmc.containerengine.requests.*;
+import com.oracle.bmc.containerengine.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180222")
+@lombok.extern.slf4j.Slf4j
+public class UpdateClusterEndpointConfigConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.containerengine.requests.UpdateClusterEndpointConfigRequest
+            interceptRequest(
+                    com.oracle.bmc.containerengine.requests.UpdateClusterEndpointConfigRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.containerengine.requests.UpdateClusterEndpointConfigRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getClusterId(), "clusterId must not be blank");
+        Validate.notNull(
+                request.getUpdateClusterEndpointConfigDetails(),
+                "updateClusterEndpointConfigDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20180222")
+                        .path("clusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getClusterId()))
+                        .path("actions")
+                        .path("updateEndpointConfig");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.containerengine.responses.UpdateClusterEndpointConfigResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.containerengine.responses
+                                .UpdateClusterEndpointConfigResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.containerengine.responses
+                                        .UpdateClusterEndpointConfigResponse>() {
+                            @Override
+                            public com.oracle.bmc.containerengine.responses
+                                            .UpdateClusterEndpointConfigResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.containerengine.responses.UpdateClusterEndpointConfigResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.containerengine.responses
+                                                .UpdateClusterEndpointConfigResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.containerengine.responses
+                                                        .UpdateClusterEndpointConfigResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.containerengine.responses
+                                                .UpdateClusterEndpointConfigResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/Cluster.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/Cluster.java
@@ -51,6 +51,15 @@ public class Cluster {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("endpointConfig")
+        private ClusterEndpointConfig endpointConfig;
+
+        public Builder endpointConfig(ClusterEndpointConfig endpointConfig) {
+            this.endpointConfig = endpointConfig;
+            this.__explicitlySet__.add("endpointConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
         private String vcnId;
 
@@ -142,6 +151,7 @@ public class Cluster {
                             id,
                             name,
                             compartmentId,
+                            endpointConfig,
                             vcnId,
                             kubernetesVersion,
                             kmsKeyId,
@@ -161,6 +171,7 @@ public class Cluster {
                     id(o.getId())
                             .name(o.getName())
                             .compartmentId(o.getCompartmentId())
+                            .endpointConfig(o.getEndpointConfig())
                             .vcnId(o.getVcnId())
                             .kubernetesVersion(o.getKubernetesVersion())
                             .kmsKeyId(o.getKmsKeyId())
@@ -200,6 +211,13 @@ public class Cluster {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * The network configuration for access to the Cluster control plane.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("endpointConfig")
+    ClusterEndpointConfig endpointConfig;
 
     /**
      * The OCID of the virtual cloud network (VCN) in which the cluster exists.

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/ClusterEndpointConfig.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/ClusterEndpointConfig.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.containerengine.model;
+
+/**
+ * The properties that define the network configuration for the Cluster endpoint.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180222")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ClusterEndpointConfig.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ClusterEndpointConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPublicIpEnabled")
+        private Boolean isPublicIpEnabled;
+
+        public Builder isPublicIpEnabled(Boolean isPublicIpEnabled) {
+            this.isPublicIpEnabled = isPublicIpEnabled;
+            this.__explicitlySet__.add("isPublicIpEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ClusterEndpointConfig build() {
+            ClusterEndpointConfig __instance__ =
+                    new ClusterEndpointConfig(subnetId, nsgIds, isPublicIpEnabled);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ClusterEndpointConfig o) {
+            Builder copiedBuilder =
+                    subnetId(o.getSubnetId())
+                            .nsgIds(o.getNsgIds())
+                            .isPublicIpEnabled(o.getIsPublicIpEnabled());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the regional subnet in which to place the Cluster endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see {@link NetworkSecurityGroup}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    /**
+     * Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPublicIpEnabled")
+    Boolean isPublicIpEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/ClusterEndpoints.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/ClusterEndpoints.java
@@ -33,18 +33,40 @@ public class ClusterEndpoints {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("publicEndpoint")
+        private String publicEndpoint;
+
+        public Builder publicEndpoint(String publicEndpoint) {
+            this.publicEndpoint = publicEndpoint;
+            this.__explicitlySet__.add("publicEndpoint");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("privateEndpoint")
+        private String privateEndpoint;
+
+        public Builder privateEndpoint(String privateEndpoint) {
+            this.privateEndpoint = privateEndpoint;
+            this.__explicitlySet__.add("privateEndpoint");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ClusterEndpoints build() {
-            ClusterEndpoints __instance__ = new ClusterEndpoints(kubernetes);
+            ClusterEndpoints __instance__ =
+                    new ClusterEndpoints(kubernetes, publicEndpoint, privateEndpoint);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ClusterEndpoints o) {
-            Builder copiedBuilder = kubernetes(o.getKubernetes());
+            Builder copiedBuilder =
+                    kubernetes(o.getKubernetes())
+                            .publicEndpoint(o.getPublicEndpoint())
+                            .privateEndpoint(o.getPrivateEndpoint());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -59,10 +81,22 @@ public class ClusterEndpoints {
     }
 
     /**
-     * The Kubernetes API server endpoint.
+     * The non-native networking Kubernetes API server endpoint.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kubernetes")
     String kubernetes;
+
+    /**
+     * The public native networking Kubernetes API server endpoint, if one was requested.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("publicEndpoint")
+    String publicEndpoint;
+
+    /**
+     * The private native networking Kubernetes API server endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("privateEndpoint")
+    String privateEndpoint;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/ClusterSummary.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/ClusterSummary.java
@@ -51,6 +51,15 @@ public class ClusterSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("endpointConfig")
+        private ClusterEndpointConfig endpointConfig;
+
+        public Builder endpointConfig(ClusterEndpointConfig endpointConfig) {
+            this.endpointConfig = endpointConfig;
+            this.__explicitlySet__.add("endpointConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
         private String vcnId;
 
@@ -133,6 +142,7 @@ public class ClusterSummary {
                             id,
                             name,
                             compartmentId,
+                            endpointConfig,
                             vcnId,
                             kubernetesVersion,
                             options,
@@ -151,6 +161,7 @@ public class ClusterSummary {
                     id(o.getId())
                             .name(o.getName())
                             .compartmentId(o.getCompartmentId())
+                            .endpointConfig(o.getEndpointConfig())
                             .vcnId(o.getVcnId())
                             .kubernetesVersion(o.getKubernetesVersion())
                             .options(o.getOptions())
@@ -189,6 +200,13 @@ public class ClusterSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * The network configuration for access to the Cluster control plane.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("endpointConfig")
+    ClusterEndpointConfig endpointConfig;
 
     /**
      * The OCID of the virtual cloud network (VCN) in which the cluster exists

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateClusterDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateClusterDetails.java
@@ -44,6 +44,15 @@ public class CreateClusterDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("endpointConfig")
+        private CreateClusterEndpointConfigDetails endpointConfig;
+
+        public Builder endpointConfig(CreateClusterEndpointConfigDetails endpointConfig) {
+            this.endpointConfig = endpointConfig;
+            this.__explicitlySet__.add("endpointConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
         private String vcnId;
 
@@ -86,7 +95,13 @@ public class CreateClusterDetails {
         public CreateClusterDetails build() {
             CreateClusterDetails __instance__ =
                     new CreateClusterDetails(
-                            name, compartmentId, vcnId, kubernetesVersion, kmsKeyId, options);
+                            name,
+                            compartmentId,
+                            endpointConfig,
+                            vcnId,
+                            kubernetesVersion,
+                            kmsKeyId,
+                            options);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -96,6 +111,7 @@ public class CreateClusterDetails {
             Builder copiedBuilder =
                     name(o.getName())
                             .compartmentId(o.getCompartmentId())
+                            .endpointConfig(o.getEndpointConfig())
                             .vcnId(o.getVcnId())
                             .kubernetesVersion(o.getKubernetesVersion())
                             .kmsKeyId(o.getKmsKeyId())
@@ -124,6 +140,13 @@ public class CreateClusterDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * The network configuration for access to the Cluster control plane.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("endpointConfig")
+    CreateClusterEndpointConfigDetails endpointConfig;
 
     /**
      * The OCID of the virtual cloud network (VCN) in which to create the cluster.

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateClusterEndpointConfigDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateClusterEndpointConfigDetails.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.containerengine.model;
+
+/**
+ * The properties that define the network configuration for the Cluster endpoint.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180222")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateClusterEndpointConfigDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateClusterEndpointConfigDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPublicIpEnabled")
+        private Boolean isPublicIpEnabled;
+
+        public Builder isPublicIpEnabled(Boolean isPublicIpEnabled) {
+            this.isPublicIpEnabled = isPublicIpEnabled;
+            this.__explicitlySet__.add("isPublicIpEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateClusterEndpointConfigDetails build() {
+            CreateClusterEndpointConfigDetails __instance__ =
+                    new CreateClusterEndpointConfigDetails(subnetId, nsgIds, isPublicIpEnabled);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateClusterEndpointConfigDetails o) {
+            Builder copiedBuilder =
+                    subnetId(o.getSubnetId())
+                            .nsgIds(o.getNsgIds())
+                            .isPublicIpEnabled(o.getIsPublicIpEnabled());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the regional subnet in which to place the Cluster endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    /**
+     * A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see {@link NetworkSecurityGroup}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    /**
+     * Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster provisioning will fail.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPublicIpEnabled")
+    Boolean isPublicIpEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateClusterKubeconfigContentDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateClusterKubeconfigContentDetails.java
@@ -44,19 +44,31 @@ public class CreateClusterKubeconfigContentDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("endpoint")
+        private Endpoint endpoint;
+
+        public Builder endpoint(Endpoint endpoint) {
+            this.endpoint = endpoint;
+            this.__explicitlySet__.add("endpoint");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateClusterKubeconfigContentDetails build() {
             CreateClusterKubeconfigContentDetails __instance__ =
-                    new CreateClusterKubeconfigContentDetails(tokenVersion, expiration);
+                    new CreateClusterKubeconfigContentDetails(tokenVersion, expiration, endpoint);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateClusterKubeconfigContentDetails o) {
-            Builder copiedBuilder = tokenVersion(o.getTokenVersion()).expiration(o.getExpiration());
+            Builder copiedBuilder =
+                    tokenVersion(o.getTokenVersion())
+                            .expiration(o.getExpiration())
+                            .endpoint(o.getEndpoint());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -83,6 +95,47 @@ public class CreateClusterKubeconfigContentDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("expiration")
     Integer expiration;
+    /**
+     * The endpoint to target. A cluster may have multiple endpoints exposed but the kubeconfig can only target one at a time.
+     **/
+    public enum Endpoint {
+        LegacyKubernetes("LEGACY_KUBERNETES"),
+        PublicEndpoint("PUBLIC_ENDPOINT"),
+        PrivateEndpoint("PRIVATE_ENDPOINT"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Endpoint> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Endpoint v : Endpoint.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Endpoint(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Endpoint create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Endpoint: " + key);
+        }
+    };
+    /**
+     * The endpoint to target. A cluster may have multiple endpoints exposed but the kubeconfig can only target one at a time.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("endpoint")
+    Endpoint endpoint;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/UpdateClusterEndpointConfigDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/UpdateClusterEndpointConfigDetails.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.containerengine.model;
+
+/**
+ * The properties that define a request to update a cluster endpoint config.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180222")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateClusterEndpointConfigDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateClusterEndpointConfigDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+        private java.util.List<String> nsgIds;
+
+        public Builder nsgIds(java.util.List<String> nsgIds) {
+            this.nsgIds = nsgIds;
+            this.__explicitlySet__.add("nsgIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPublicIpEnabled")
+        private Boolean isPublicIpEnabled;
+
+        public Builder isPublicIpEnabled(Boolean isPublicIpEnabled) {
+            this.isPublicIpEnabled = isPublicIpEnabled;
+            this.__explicitlySet__.add("isPublicIpEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateClusterEndpointConfigDetails build() {
+            UpdateClusterEndpointConfigDetails __instance__ =
+                    new UpdateClusterEndpointConfigDetails(nsgIds, isPublicIpEnabled);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateClusterEndpointConfigDetails o) {
+            Builder copiedBuilder =
+                    nsgIds(o.getNsgIds()).isPublicIpEnabled(o.getIsPublicIpEnabled());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A list of the OCIDs of the network security groups (NSGs) to apply to the cluster endpoint. For more information about NSGs, see {@link NetworkSecurityGroup}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
+    java.util.List<String> nsgIds;
+
+    /**
+     * Whether the cluster should be assigned a public IP address. Defaults to false. If set to true on a private subnet, the cluster update will fail.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPublicIpEnabled")
+    Boolean isPublicIpEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/WorkRequestResource.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/WorkRequestResource.java
@@ -103,6 +103,9 @@ public class WorkRequestResource {
         Related("RELATED"),
         InProgress("IN_PROGRESS"),
         Failed("FAILED"),
+        CanceledCreate("CANCELED_CREATE"),
+        CanceledUpdate("CANCELED_UPDATE"),
+        CanceledDelete("CANCELED_DELETE"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/GetClusterOptionsRequest.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/GetClusterOptionsRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.containerengine.model.*;
 public class GetClusterOptionsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The id of the option set to retrieve. Only \"all\" is supported.
+     * The id of the option set to retrieve. Use \"all\" get all options, or use a cluster ID to get options specific to the provided cluster.
      */
     private String clusterOptionId;
 

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/UpdateClusterEndpointConfigRequest.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/requests/UpdateClusterEndpointConfigRequest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.containerengine.requests;
+
+import com.oracle.bmc.containerengine.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/UpdateClusterEndpointConfigExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateClusterEndpointConfigRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180222")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateClusterEndpointConfigRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateClusterEndpointConfigDetails> {
+
+    /**
+     * The OCID of the cluster.
+     */
+    private String clusterId;
+
+    /**
+     * The details of the cluster's endpoint to update.
+     */
+    private UpdateClusterEndpointConfigDetails updateClusterEndpointConfigDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateClusterEndpointConfigDetails getBody$() {
+        return updateClusterEndpointConfigDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateClusterEndpointConfigRequest, UpdateClusterEndpointConfigDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateClusterEndpointConfigRequest o) {
+            clusterId(o.getClusterId());
+            updateClusterEndpointConfigDetails(o.getUpdateClusterEndpointConfigDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateClusterEndpointConfigRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateClusterEndpointConfigRequest
+         */
+        public UpdateClusterEndpointConfigRequest build() {
+            UpdateClusterEndpointConfigRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateClusterEndpointConfigDetails body) {
+            updateClusterEndpointConfigDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/responses/UpdateClusterEndpointConfigResponse.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/responses/UpdateClusterEndpointConfigResponse.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.containerengine.responses;
+
+import com.oracle.bmc.containerengine.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20180222")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateClusterEndpointConfigResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * The OCID of the work request handling the operation.
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateClusterEndpointConfigResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScience.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScience.java
@@ -57,6 +57,16 @@ public interface DataScience extends AutoCloseable {
     ActivateModelResponse activateModel(ActivateModelRequest request);
 
     /**
+     * Activates the model deployment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/ActivateModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ActivateModelDeployment API.
+     */
+    ActivateModelDeploymentResponse activateModelDeployment(ActivateModelDeploymentRequest request);
+
+    /**
      * Activates the notebook session.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -85,6 +95,17 @@ public interface DataScience extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/ChangeModelCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeModelCompartment API.
      */
     ChangeModelCompartmentResponse changeModelCompartment(ChangeModelCompartmentRequest request);
+
+    /**
+     * Moves a model deployment into a different compartment. When provided, If-Match is checked against ETag values of the resource.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/ChangeModelDeploymentCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeModelDeploymentCompartment API.
+     */
+    ChangeModelDeploymentCompartmentResponse changeModelDeploymentCompartment(
+            ChangeModelDeploymentCompartmentRequest request);
 
     /**
      * Moves a notebook session resource into a different compartment.
@@ -156,6 +177,16 @@ public interface DataScience extends AutoCloseable {
     CreateModelArtifactResponse createModelArtifact(CreateModelArtifactRequest request);
 
     /**
+     * Creates a new model deployment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/CreateModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateModelDeployment API.
+     */
+    CreateModelDeploymentResponse createModelDeployment(CreateModelDeploymentRequest request);
+
+    /**
      * Creates provenance information for the specified model.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -196,6 +227,17 @@ public interface DataScience extends AutoCloseable {
     DeactivateModelResponse deactivateModel(DeactivateModelRequest request);
 
     /**
+     * Deactivates the model deployment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/DeactivateModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeactivateModelDeployment API.
+     */
+    DeactivateModelDeploymentResponse deactivateModelDeployment(
+            DeactivateModelDeploymentRequest request);
+
+    /**
      * Deactivates the notebook session.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -217,7 +259,17 @@ public interface DataScience extends AutoCloseable {
     DeleteModelResponse deleteModel(DeleteModelRequest request);
 
     /**
-     * Deletes the specified notebook session. Any unsaved work in this notebook session will be lost.
+     * Deletes the specified model deployment. Any unsaved work in this model deployment is lost.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/DeleteModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteModelDeployment API.
+     */
+    DeleteModelDeploymentResponse deleteModelDeployment(DeleteModelDeploymentRequest request);
+
+    /**
+     * Deletes the specified notebook session. Any unsaved work in this notebook session are lost.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -227,7 +279,7 @@ public interface DataScience extends AutoCloseable {
     DeleteNotebookSessionResponse deleteNotebookSession(DeleteNotebookSessionRequest request);
 
     /**
-     * Deletes the specified project. This operation will fail unless all associated resources (such as notebook sessions or models) are in a DELETED state. You must delete all associated resources before deleting a project.
+     * Deletes the specified project. This operation fails unless all associated resources (notebook sessions or models) are in a DELETED state. You must delete all associated resources before deleting a project.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -255,6 +307,16 @@ public interface DataScience extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/GetModelArtifactContentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetModelArtifactContent API.
      */
     GetModelArtifactContentResponse getModelArtifactContent(GetModelArtifactContentRequest request);
+
+    /**
+     * Retrieves the model deployment for the specified `modelDeploymentId`.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/GetModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetModelDeployment API.
+     */
+    GetModelDeploymentResponse getModelDeployment(GetModelDeploymentRequest request);
 
     /**
      * Gets provenance information for specified model.
@@ -307,6 +369,28 @@ public interface DataScience extends AutoCloseable {
     HeadModelArtifactResponse headModelArtifact(HeadModelArtifactRequest request);
 
     /**
+     * Lists the valid model deployment shapes.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/ListModelDeploymentShapesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListModelDeploymentShapes API.
+     */
+    ListModelDeploymentShapesResponse listModelDeploymentShapes(
+            ListModelDeploymentShapesRequest request);
+
+    /**
+     * Lists all model deployments in the specified compartment. Only one parameter other than compartmentId may also be included in a query. The query must include compartmentId. If the query does not include compartmentId, or includes compartmentId but two or more other parameters an error is returned.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/ListModelDeploymentsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListModelDeployments API.
+     */
+    ListModelDeploymentsResponse listModelDeployments(ListModelDeploymentsRequest request);
+
+    /**
      * Lists models in the specified compartment.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -328,7 +412,7 @@ public interface DataScience extends AutoCloseable {
             ListNotebookSessionShapesRequest request);
 
     /**
-     * Lists notebook sessions in the specified compartment.
+     * Lists the notebook sessions in the specified compartment.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -388,7 +472,21 @@ public interface DataScience extends AutoCloseable {
     UpdateModelResponse updateModel(UpdateModelRequest request);
 
     /**
-     * Updates provenance information for the specified model.
+     * Updates the properties of a model deployment. You can update the `displayName`.
+     * When the model deployment is in the ACTIVE lifecycle state, you can update `modelDeploymentConfigurationDetails` and  change `instanceShapeName` and `modelId`. Any update to
+     * `bandwidthMbps` or `instanceCount` can be done when the model deployment is in the INACTIVE lifecycle state. Changes to the `bandwidthMbps` or `instanceCount` will take effect
+     * the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/UpdateModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateModelDeployment API.
+     */
+    UpdateModelDeploymentResponse updateModelDeployment(UpdateModelDeploymentRequest request);
+
+    /**
+     * Updates the provenance information for the specified model.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -400,7 +498,7 @@ public interface DataScience extends AutoCloseable {
     /**
      * Updates the properties of a notebook session. You can update the `displayName`, `freeformTags`, and `definedTags` properties.
      * When the notebook session is in the INACTIVE lifecycle state, you can update `notebookSessionConfigurationDetails` and change `shape`, `subnetId`, and `blockStorageSizeInGBs`.
-     * Changes to the `notebookSessionConfigurationDetails` will take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
+     * Changes to the `notebookSessionConfigurationDetails` take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceAsync.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceAsync.java
@@ -62,6 +62,22 @@ public interface DataScienceAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Activates the model deployment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ActivateModelDeploymentResponse> activateModelDeployment(
+            ActivateModelDeploymentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ActivateModelDeploymentRequest, ActivateModelDeploymentResponse>
+                    handler);
+
+    /**
      * Activates the notebook session.
      *
      * @param request The request object containing the details to send
@@ -108,6 +124,24 @@ public interface DataScienceAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             ChangeModelCompartmentRequest, ChangeModelCompartmentResponse>
                     handler);
+
+    /**
+     * Moves a model deployment into a different compartment. When provided, If-Match is checked against ETag values of the resource.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeModelDeploymentCompartmentResponse>
+            changeModelDeploymentCompartment(
+                    ChangeModelDeploymentCompartmentRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeModelDeploymentCompartmentRequest,
+                                    ChangeModelDeploymentCompartmentResponse>
+                            handler);
 
     /**
      * Moves a notebook session resource into a different compartment.
@@ -174,6 +208,22 @@ public interface DataScienceAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Creates a new model deployment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateModelDeploymentResponse> createModelDeployment(
+            CreateModelDeploymentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateModelDeploymentRequest, CreateModelDeploymentResponse>
+                    handler);
+
+    /**
      * Creates provenance information for the specified model.
      *
      * @param request The request object containing the details to send
@@ -236,6 +286,22 @@ public interface DataScienceAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Deactivates the model deployment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeactivateModelDeploymentResponse> deactivateModelDeployment(
+            DeactivateModelDeploymentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeactivateModelDeploymentRequest, DeactivateModelDeploymentResponse>
+                    handler);
+
+    /**
      * Deactivates the notebook session.
      *
      * @param request The request object containing the details to send
@@ -266,7 +332,23 @@ public interface DataScienceAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<DeleteModelRequest, DeleteModelResponse> handler);
 
     /**
-     * Deletes the specified notebook session. Any unsaved work in this notebook session will be lost.
+     * Deletes the specified model deployment. Any unsaved work in this model deployment is lost.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteModelDeploymentResponse> deleteModelDeployment(
+            DeleteModelDeploymentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteModelDeploymentRequest, DeleteModelDeploymentResponse>
+                    handler);
+
+    /**
+     * Deletes the specified notebook session. Any unsaved work in this notebook session are lost.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -282,7 +364,7 @@ public interface DataScienceAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes the specified project. This operation will fail unless all associated resources (such as notebook sessions or models) are in a DELETED state. You must delete all associated resources before deleting a project.
+     * Deletes the specified project. This operation fails unless all associated resources (notebook sessions or models) are in a DELETED state. You must delete all associated resources before deleting a project.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -324,6 +406,22 @@ public interface DataScienceAsync extends AutoCloseable {
             GetModelArtifactContentRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             GetModelArtifactContentRequest, GetModelArtifactContentResponse>
+                    handler);
+
+    /**
+     * Retrieves the model deployment for the specified `modelDeploymentId`.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetModelDeploymentResponse> getModelDeployment(
+            GetModelDeploymentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetModelDeploymentRequest, GetModelDeploymentResponse>
                     handler);
 
     /**
@@ -404,6 +502,39 @@ public interface DataScienceAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Lists the valid model deployment shapes.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListModelDeploymentShapesResponse> listModelDeploymentShapes(
+            ListModelDeploymentShapesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListModelDeploymentShapesRequest, ListModelDeploymentShapesResponse>
+                    handler);
+
+    /**
+     * Lists all model deployments in the specified compartment. Only one parameter other than compartmentId may also be included in a query. The query must include compartmentId. If the query does not include compartmentId, or includes compartmentId but two or more other parameters an error is returned.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListModelDeploymentsResponse> listModelDeployments(
+            ListModelDeploymentsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListModelDeploymentsRequest, ListModelDeploymentsResponse>
+                    handler);
+
+    /**
      * Lists models in the specified compartment.
      *
      * @param request The request object containing the details to send
@@ -434,7 +565,7 @@ public interface DataScienceAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Lists notebook sessions in the specified compartment.
+     * Lists the notebook sessions in the specified compartment.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -526,7 +657,27 @@ public interface DataScienceAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<UpdateModelRequest, UpdateModelResponse> handler);
 
     /**
-     * Updates provenance information for the specified model.
+     * Updates the properties of a model deployment. You can update the `displayName`.
+     * When the model deployment is in the ACTIVE lifecycle state, you can update `modelDeploymentConfigurationDetails` and  change `instanceShapeName` and `modelId`. Any update to
+     * `bandwidthMbps` or `instanceCount` can be done when the model deployment is in the INACTIVE lifecycle state. Changes to the `bandwidthMbps` or `instanceCount` will take effect
+     * the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateModelDeploymentResponse> updateModelDeployment(
+            UpdateModelDeploymentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateModelDeploymentRequest, UpdateModelDeploymentResponse>
+                    handler);
+
+    /**
+     * Updates the provenance information for the specified model.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -544,7 +695,7 @@ public interface DataScienceAsync extends AutoCloseable {
     /**
      * Updates the properties of a notebook session. You can update the `displayName`, `freeformTags`, and `definedTags` properties.
      * When the notebook session is in the INACTIVE lifecycle state, you can update `notebookSessionConfigurationDetails` and change `shape`, `subnetId`, and `blockStorageSizeInGBs`.
-     * Changes to the `notebookSessionConfigurationDetails` will take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
+     * Changes to the `notebookSessionConfigurationDetails` take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceAsyncClient.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceAsyncClient.java
@@ -401,6 +401,47 @@ public class DataScienceAsyncClient implements DataScienceAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ActivateModelDeploymentResponse> activateModelDeployment(
+            ActivateModelDeploymentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ActivateModelDeploymentRequest, ActivateModelDeploymentResponse>
+                    handler) {
+        LOG.trace("Called async activateModelDeployment");
+        final ActivateModelDeploymentRequest interceptedRequest =
+                ActivateModelDeploymentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ActivateModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ActivateModelDeploymentResponse>
+                transformer = ActivateModelDeploymentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ActivateModelDeploymentRequest, ActivateModelDeploymentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ActivateModelDeploymentRequest, ActivateModelDeploymentResponse>,
+                        java.util.concurrent.Future<ActivateModelDeploymentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ActivateModelDeploymentRequest, ActivateModelDeploymentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ActivateNotebookSessionResponse> activateNotebookSession(
             ActivateNotebookSessionRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -510,6 +551,53 @@ public class DataScienceAsyncClient implements DataScienceAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ChangeModelCompartmentRequest, ChangeModelCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ChangeModelDeploymentCompartmentResponse>
+            changeModelDeploymentCompartment(
+                    ChangeModelDeploymentCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeModelDeploymentCompartmentRequest,
+                                    ChangeModelDeploymentCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeModelDeploymentCompartment");
+        final ChangeModelDeploymentCompartmentRequest interceptedRequest =
+                ChangeModelDeploymentCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeModelDeploymentCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeModelDeploymentCompartmentResponse>
+                transformer = ChangeModelDeploymentCompartmentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeModelDeploymentCompartmentRequest,
+                        ChangeModelDeploymentCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeModelDeploymentCompartmentRequest,
+                                ChangeModelDeploymentCompartmentResponse>,
+                        java.util.concurrent.Future<ChangeModelDeploymentCompartmentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeModelDeploymentCompartmentRequest,
+                    ChangeModelDeploymentCompartmentResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -709,6 +797,48 @@ public class DataScienceAsyncClient implements DataScienceAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreateModelDeploymentResponse> createModelDeployment(
+            CreateModelDeploymentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateModelDeploymentRequest, CreateModelDeploymentResponse>
+                    handler) {
+        LOG.trace("Called async createModelDeployment");
+        final CreateModelDeploymentRequest interceptedRequest =
+                CreateModelDeploymentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateModelDeploymentResponse>
+                transformer = CreateModelDeploymentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateModelDeploymentRequest, CreateModelDeploymentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateModelDeploymentRequest, CreateModelDeploymentResponse>,
+                        java.util.concurrent.Future<CreateModelDeploymentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateModelDeploymentRequest, CreateModelDeploymentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateModelProvenanceResponse> createModelProvenance(
             CreateModelProvenanceRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -871,6 +1001,48 @@ public class DataScienceAsyncClient implements DataScienceAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<DeactivateModelDeploymentResponse> deactivateModelDeployment(
+            DeactivateModelDeploymentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeactivateModelDeploymentRequest, DeactivateModelDeploymentResponse>
+                    handler) {
+        LOG.trace("Called async deactivateModelDeployment");
+        final DeactivateModelDeploymentRequest interceptedRequest =
+                DeactivateModelDeploymentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeactivateModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeactivateModelDeploymentResponse>
+                transformer = DeactivateModelDeploymentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeactivateModelDeploymentRequest, DeactivateModelDeploymentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeactivateModelDeploymentRequest,
+                                DeactivateModelDeploymentResponse>,
+                        java.util.concurrent.Future<DeactivateModelDeploymentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeactivateModelDeploymentRequest, DeactivateModelDeploymentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<DeactivateNotebookSessionResponse> deactivateNotebookSession(
             DeactivateNotebookSessionRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -938,6 +1110,47 @@ public class DataScienceAsyncClient implements DataScienceAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     DeleteModelRequest, DeleteModelResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteModelDeploymentResponse> deleteModelDeployment(
+            DeleteModelDeploymentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteModelDeploymentRequest, DeleteModelDeploymentResponse>
+                    handler) {
+        LOG.trace("Called async deleteModelDeployment");
+        final DeleteModelDeploymentRequest interceptedRequest =
+                DeleteModelDeploymentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteModelDeploymentResponse>
+                transformer = DeleteModelDeploymentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteModelDeploymentRequest, DeleteModelDeploymentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteModelDeploymentRequest, DeleteModelDeploymentResponse>,
+                        java.util.concurrent.Future<DeleteModelDeploymentResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteModelDeploymentRequest, DeleteModelDeploymentResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1094,6 +1307,45 @@ public class DataScienceAsyncClient implements DataScienceAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetModelArtifactContentRequest, GetModelArtifactContentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetModelDeploymentResponse> getModelDeployment(
+            GetModelDeploymentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetModelDeploymentRequest, GetModelDeploymentResponse>
+                    handler) {
+        LOG.trace("Called async getModelDeployment");
+        final GetModelDeploymentRequest interceptedRequest =
+                GetModelDeploymentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetModelDeploymentResponse>
+                transformer = GetModelDeploymentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetModelDeploymentRequest, GetModelDeploymentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetModelDeploymentRequest, GetModelDeploymentResponse>,
+                        java.util.concurrent.Future<GetModelDeploymentResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetModelDeploymentRequest, GetModelDeploymentResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1287,6 +1539,89 @@ public class DataScienceAsyncClient implements DataScienceAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     HeadModelArtifactRequest, HeadModelArtifactResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListModelDeploymentShapesResponse> listModelDeploymentShapes(
+            ListModelDeploymentShapesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListModelDeploymentShapesRequest, ListModelDeploymentShapesResponse>
+                    handler) {
+        LOG.trace("Called async listModelDeploymentShapes");
+        final ListModelDeploymentShapesRequest interceptedRequest =
+                ListModelDeploymentShapesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListModelDeploymentShapesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListModelDeploymentShapesResponse>
+                transformer = ListModelDeploymentShapesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListModelDeploymentShapesRequest, ListModelDeploymentShapesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListModelDeploymentShapesRequest,
+                                ListModelDeploymentShapesResponse>,
+                        java.util.concurrent.Future<ListModelDeploymentShapesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListModelDeploymentShapesRequest, ListModelDeploymentShapesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListModelDeploymentsResponse> listModelDeployments(
+            ListModelDeploymentsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListModelDeploymentsRequest, ListModelDeploymentsResponse>
+                    handler) {
+        LOG.trace("Called async listModelDeployments");
+        final ListModelDeploymentsRequest interceptedRequest =
+                ListModelDeploymentsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListModelDeploymentsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListModelDeploymentsResponse>
+                transformer = ListModelDeploymentsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListModelDeploymentsRequest, ListModelDeploymentsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListModelDeploymentsRequest, ListModelDeploymentsResponse>,
+                        java.util.concurrent.Future<ListModelDeploymentsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListModelDeploymentsRequest, ListModelDeploymentsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1604,6 +1939,47 @@ public class DataScienceAsyncClient implements DataScienceAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     UpdateModelRequest, UpdateModelResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateModelDeploymentResponse> updateModelDeployment(
+            UpdateModelDeploymentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateModelDeploymentRequest, UpdateModelDeploymentResponse>
+                    handler) {
+        LOG.trace("Called async updateModelDeployment");
+        final UpdateModelDeploymentRequest interceptedRequest =
+                UpdateModelDeploymentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateModelDeploymentResponse>
+                transformer = UpdateModelDeploymentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateModelDeploymentRequest, UpdateModelDeploymentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateModelDeploymentRequest, UpdateModelDeploymentResponse>,
+                        java.util.concurrent.Future<UpdateModelDeploymentResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateModelDeploymentRequest, UpdateModelDeploymentResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceClient.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceClient.java
@@ -470,6 +470,36 @@ public class DataScienceClient implements DataScience {
     }
 
     @Override
+    public ActivateModelDeploymentResponse activateModelDeployment(
+            ActivateModelDeploymentRequest request) {
+        LOG.trace("Called activateModelDeployment");
+        final ActivateModelDeploymentRequest interceptedRequest =
+                ActivateModelDeploymentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ActivateModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ActivateModelDeploymentResponse>
+                transformer = ActivateModelDeploymentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ActivateNotebookSessionResponse activateNotebookSession(
             ActivateNotebookSessionRequest request) {
         LOG.trace("Called activateNotebookSession");
@@ -556,6 +586,42 @@ public class DataScienceClient implements DataScience {
                                         client.post(
                                                 ib,
                                                 retriedRequest.getChangeModelCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ChangeModelDeploymentCompartmentResponse changeModelDeploymentCompartment(
+            ChangeModelDeploymentCompartmentRequest request) {
+        LOG.trace("Called changeModelDeploymentCompartment");
+        final ChangeModelDeploymentCompartmentRequest interceptedRequest =
+                ChangeModelDeploymentCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeModelDeploymentCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeModelDeploymentCompartmentResponse>
+                transformer = ChangeModelDeploymentCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeModelDeploymentCompartmentDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -731,6 +797,40 @@ public class DataScienceClient implements DataScience {
     }
 
     @Override
+    public CreateModelDeploymentResponse createModelDeployment(
+            CreateModelDeploymentRequest request) {
+        LOG.trace("Called createModelDeployment");
+        final CreateModelDeploymentRequest interceptedRequest =
+                CreateModelDeploymentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateModelDeploymentResponse>
+                transformer = CreateModelDeploymentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateModelDeploymentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateModelProvenanceResponse createModelProvenance(
             CreateModelProvenanceRequest request) {
         LOG.trace("Called createModelProvenance");
@@ -861,6 +961,37 @@ public class DataScienceClient implements DataScience {
     }
 
     @Override
+    public DeactivateModelDeploymentResponse deactivateModelDeployment(
+            DeactivateModelDeploymentRequest request) {
+        LOG.trace("Called deactivateModelDeployment");
+        final DeactivateModelDeploymentRequest interceptedRequest =
+                DeactivateModelDeploymentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeactivateModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeactivateModelDeploymentResponse>
+                transformer = DeactivateModelDeploymentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public DeactivateNotebookSessionResponse deactivateNotebookSession(
             DeactivateNotebookSessionRequest request) {
         LOG.trace("Called deactivateNotebookSession");
@@ -900,6 +1031,36 @@ public class DataScienceClient implements DataScience {
                 DeleteModelConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, DeleteModelResponse>
                 transformer = DeleteModelConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteModelDeploymentResponse deleteModelDeployment(
+            DeleteModelDeploymentRequest request) {
+        LOG.trace("Called deleteModelDeployment");
+        final DeleteModelDeploymentRequest interceptedRequest =
+                DeleteModelDeploymentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteModelDeploymentResponse>
+                transformer = DeleteModelDeploymentConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1016,6 +1177,34 @@ public class DataScienceClient implements DataScience {
                 GetModelArtifactContentConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetModelArtifactContentResponse>
                 transformer = GetModelArtifactContentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetModelDeploymentResponse getModelDeployment(GetModelDeploymentRequest request) {
+        LOG.trace("Called getModelDeployment");
+        final GetModelDeploymentRequest interceptedRequest =
+                GetModelDeploymentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetModelDeploymentResponse>
+                transformer = GetModelDeploymentConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1170,6 +1359,64 @@ public class DataScienceClient implements DataScience {
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response =
                                         client.head(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListModelDeploymentShapesResponse listModelDeploymentShapes(
+            ListModelDeploymentShapesRequest request) {
+        LOG.trace("Called listModelDeploymentShapes");
+        final ListModelDeploymentShapesRequest interceptedRequest =
+                ListModelDeploymentShapesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListModelDeploymentShapesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListModelDeploymentShapesResponse>
+                transformer = ListModelDeploymentShapesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListModelDeploymentsResponse listModelDeployments(ListModelDeploymentsRequest request) {
+        LOG.trace("Called listModelDeployments");
+        final ListModelDeploymentsRequest interceptedRequest =
+                ListModelDeploymentsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListModelDeploymentsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListModelDeploymentsResponse>
+                transformer = ListModelDeploymentsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });
@@ -1399,6 +1646,39 @@ public class DataScienceClient implements DataScience {
                                         client.put(
                                                 ib,
                                                 retriedRequest.getUpdateModelDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateModelDeploymentResponse updateModelDeployment(
+            UpdateModelDeploymentRequest request) {
+        LOG.trace("Called updateModelDeployment");
+        final UpdateModelDeploymentRequest interceptedRequest =
+                UpdateModelDeploymentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateModelDeploymentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateModelDeploymentResponse>
+                transformer = UpdateModelDeploymentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateModelDeploymentDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataSciencePaginators.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataSciencePaginators.java
@@ -31,6 +31,239 @@ public class DataSciencePaginators {
     private final DataScience client;
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listModelDeploymentShapes operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListModelDeploymentShapesResponse> listModelDeploymentShapesResponseIterator(
+            final ListModelDeploymentShapesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListModelDeploymentShapesRequest.Builder, ListModelDeploymentShapesRequest,
+                ListModelDeploymentShapesResponse>(
+                new com.google.common.base.Supplier<ListModelDeploymentShapesRequest.Builder>() {
+                    @Override
+                    public ListModelDeploymentShapesRequest.Builder get() {
+                        return ListModelDeploymentShapesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListModelDeploymentShapesResponse, String>() {
+                    @Override
+                    public String apply(ListModelDeploymentShapesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListModelDeploymentShapesRequest.Builder>,
+                        ListModelDeploymentShapesRequest>() {
+                    @Override
+                    public ListModelDeploymentShapesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListModelDeploymentShapesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListModelDeploymentShapesRequest, ListModelDeploymentShapesResponse>() {
+                    @Override
+                    public ListModelDeploymentShapesResponse apply(
+                            ListModelDeploymentShapesRequest request) {
+                        return client.listModelDeploymentShapes(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.datascience.model.ModelDeploymentShapeSummary} objects
+     * contained in responses from the listModelDeploymentShapes operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.datascience.model.ModelDeploymentShapeSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.datascience.model.ModelDeploymentShapeSummary>
+            listModelDeploymentShapesRecordIterator(
+                    final ListModelDeploymentShapesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListModelDeploymentShapesRequest.Builder, ListModelDeploymentShapesRequest,
+                ListModelDeploymentShapesResponse,
+                com.oracle.bmc.datascience.model.ModelDeploymentShapeSummary>(
+                new com.google.common.base.Supplier<ListModelDeploymentShapesRequest.Builder>() {
+                    @Override
+                    public ListModelDeploymentShapesRequest.Builder get() {
+                        return ListModelDeploymentShapesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListModelDeploymentShapesResponse, String>() {
+                    @Override
+                    public String apply(ListModelDeploymentShapesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListModelDeploymentShapesRequest.Builder>,
+                        ListModelDeploymentShapesRequest>() {
+                    @Override
+                    public ListModelDeploymentShapesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListModelDeploymentShapesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListModelDeploymentShapesRequest, ListModelDeploymentShapesResponse>() {
+                    @Override
+                    public ListModelDeploymentShapesResponse apply(
+                            ListModelDeploymentShapesRequest request) {
+                        return client.listModelDeploymentShapes(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListModelDeploymentShapesResponse,
+                        java.util.List<
+                                com.oracle.bmc.datascience.model.ModelDeploymentShapeSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.datascience.model.ModelDeploymentShapeSummary>
+                            apply(ListModelDeploymentShapesResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listModelDeployments operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListModelDeploymentsResponse> listModelDeploymentsResponseIterator(
+            final ListModelDeploymentsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListModelDeploymentsRequest.Builder, ListModelDeploymentsRequest,
+                ListModelDeploymentsResponse>(
+                new com.google.common.base.Supplier<ListModelDeploymentsRequest.Builder>() {
+                    @Override
+                    public ListModelDeploymentsRequest.Builder get() {
+                        return ListModelDeploymentsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListModelDeploymentsResponse, String>() {
+                    @Override
+                    public String apply(ListModelDeploymentsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListModelDeploymentsRequest.Builder>,
+                        ListModelDeploymentsRequest>() {
+                    @Override
+                    public ListModelDeploymentsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListModelDeploymentsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListModelDeploymentsRequest, ListModelDeploymentsResponse>() {
+                    @Override
+                    public ListModelDeploymentsResponse apply(ListModelDeploymentsRequest request) {
+                        return client.listModelDeployments(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.datascience.model.ModelDeploymentSummary} objects
+     * contained in responses from the listModelDeployments operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.datascience.model.ModelDeploymentSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.datascience.model.ModelDeploymentSummary>
+            listModelDeploymentsRecordIterator(final ListModelDeploymentsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListModelDeploymentsRequest.Builder, ListModelDeploymentsRequest,
+                ListModelDeploymentsResponse,
+                com.oracle.bmc.datascience.model.ModelDeploymentSummary>(
+                new com.google.common.base.Supplier<ListModelDeploymentsRequest.Builder>() {
+                    @Override
+                    public ListModelDeploymentsRequest.Builder get() {
+                        return ListModelDeploymentsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListModelDeploymentsResponse, String>() {
+                    @Override
+                    public String apply(ListModelDeploymentsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListModelDeploymentsRequest.Builder>,
+                        ListModelDeploymentsRequest>() {
+                    @Override
+                    public ListModelDeploymentsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListModelDeploymentsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListModelDeploymentsRequest, ListModelDeploymentsResponse>() {
+                    @Override
+                    public ListModelDeploymentsResponse apply(ListModelDeploymentsRequest request) {
+                        return client.listModelDeployments(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListModelDeploymentsResponse,
+                        java.util.List<com.oracle.bmc.datascience.model.ModelDeploymentSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.datascience.model.ModelDeploymentSummary>
+                            apply(ListModelDeploymentsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listModels operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceWaiters.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceWaiters.java
@@ -122,6 +122,112 @@ public class DataScienceWaiters {
      * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<GetModelDeploymentRequest, GetModelDeploymentResponse>
+            forModelDeployment(
+                    GetModelDeploymentRequest request,
+                    com.oracle.bmc.datascience.model.ModelDeploymentLifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forModelDeployment(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetModelDeploymentRequest, GetModelDeploymentResponse>
+            forModelDeployment(
+                    GetModelDeploymentRequest request,
+                    com.oracle.bmc.datascience.model.ModelDeploymentLifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forModelDeployment(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetModelDeploymentRequest, GetModelDeploymentResponse>
+            forModelDeployment(
+                    GetModelDeploymentRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.datascience.model.ModelDeploymentLifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forModelDeployment(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for ModelDeployment.
+    private com.oracle.bmc.waiter.Waiter<GetModelDeploymentRequest, GetModelDeploymentResponse>
+            forModelDeployment(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetModelDeploymentRequest request,
+                    final com.oracle.bmc.datascience.model.ModelDeploymentLifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.datascience.model.ModelDeploymentLifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetModelDeploymentRequest, GetModelDeploymentResponse>() {
+                            @Override
+                            public GetModelDeploymentResponse apply(
+                                    GetModelDeploymentRequest request) {
+                                return client.getModelDeployment(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetModelDeploymentResponse>() {
+                            @Override
+                            public boolean apply(GetModelDeploymentResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getModelDeployment().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.datascience.model.ModelDeploymentLifecycleState
+                                        .Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetNotebookSessionRequest, GetNotebookSessionResponse>
             forNotebookSession(
                     GetNotebookSessionRequest request,

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/ActivateModelDeploymentConverter.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/ActivateModelDeploymentConverter.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datascience.model.*;
+import com.oracle.bmc.datascience.requests.*;
+import com.oracle.bmc.datascience.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public class ActivateModelDeploymentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datascience.requests.ActivateModelDeploymentRequest
+            interceptRequest(
+                    com.oracle.bmc.datascience.requests.ActivateModelDeploymentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datascience.requests.ActivateModelDeploymentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getModelDeploymentId(), "modelDeploymentId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190101")
+                        .path("modelDeployments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getModelDeploymentId()))
+                        .path("actions")
+                        .path("activate");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datascience.responses.ActivateModelDeploymentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datascience.responses.ActivateModelDeploymentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datascience.responses
+                                        .ActivateModelDeploymentResponse>() {
+                            @Override
+                            public com.oracle.bmc.datascience.responses
+                                            .ActivateModelDeploymentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datascience.responses.ActivateModelDeploymentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datascience.responses.ActivateModelDeploymentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datascience.responses
+                                                        .ActivateModelDeploymentResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datascience.responses.ActivateModelDeploymentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/ChangeModelDeploymentCompartmentConverter.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/ChangeModelDeploymentCompartmentConverter.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datascience.model.*;
+import com.oracle.bmc.datascience.requests.*;
+import com.oracle.bmc.datascience.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public class ChangeModelDeploymentCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datascience.requests.ChangeModelDeploymentCompartmentRequest
+            interceptRequest(
+                    com.oracle.bmc.datascience.requests.ChangeModelDeploymentCompartmentRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datascience.requests.ChangeModelDeploymentCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getModelDeploymentId(), "modelDeploymentId must not be blank");
+        Validate.notNull(
+                request.getChangeModelDeploymentCompartmentDetails(),
+                "changeModelDeploymentCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190101")
+                        .path("modelDeployments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getModelDeploymentId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datascience.responses.ChangeModelDeploymentCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datascience.responses
+                                .ChangeModelDeploymentCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datascience.responses
+                                        .ChangeModelDeploymentCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.datascience.responses
+                                            .ChangeModelDeploymentCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datascience.responses.ChangeModelDeploymentCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datascience.responses
+                                                .ChangeModelDeploymentCompartmentResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datascience.responses
+                                                        .ChangeModelDeploymentCompartmentResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datascience.responses
+                                                .ChangeModelDeploymentCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/CreateModelDeploymentConverter.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/CreateModelDeploymentConverter.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datascience.model.*;
+import com.oracle.bmc.datascience.requests.*;
+import com.oracle.bmc.datascience.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public class CreateModelDeploymentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datascience.requests.CreateModelDeploymentRequest interceptRequest(
+            com.oracle.bmc.datascience.requests.CreateModelDeploymentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datascience.requests.CreateModelDeploymentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateModelDeploymentDetails(),
+                "createModelDeploymentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20190101").path("modelDeployments");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datascience.responses.CreateModelDeploymentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datascience.responses.CreateModelDeploymentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datascience.responses
+                                        .CreateModelDeploymentResponse>() {
+                            @Override
+                            public com.oracle.bmc.datascience.responses
+                                            .CreateModelDeploymentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datascience.responses.CreateModelDeploymentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ModelDeployment>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ModelDeployment.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ModelDeployment> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datascience.responses.CreateModelDeploymentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datascience.responses
+                                                        .CreateModelDeploymentResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.modelDeployment(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datascience.responses.CreateModelDeploymentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/DeactivateModelDeploymentConverter.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/DeactivateModelDeploymentConverter.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datascience.model.*;
+import com.oracle.bmc.datascience.requests.*;
+import com.oracle.bmc.datascience.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public class DeactivateModelDeploymentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datascience.requests.DeactivateModelDeploymentRequest
+            interceptRequest(
+                    com.oracle.bmc.datascience.requests.DeactivateModelDeploymentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datascience.requests.DeactivateModelDeploymentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getModelDeploymentId(), "modelDeploymentId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190101")
+                        .path("modelDeployments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getModelDeploymentId()))
+                        .path("actions")
+                        .path("deactivate");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datascience.responses.DeactivateModelDeploymentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datascience.responses.DeactivateModelDeploymentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datascience.responses
+                                        .DeactivateModelDeploymentResponse>() {
+                            @Override
+                            public com.oracle.bmc.datascience.responses
+                                            .DeactivateModelDeploymentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datascience.responses.DeactivateModelDeploymentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datascience.responses
+                                                .DeactivateModelDeploymentResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datascience.responses
+                                                        .DeactivateModelDeploymentResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datascience.responses
+                                                .DeactivateModelDeploymentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/DeleteModelDeploymentConverter.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/DeleteModelDeploymentConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datascience.model.*;
+import com.oracle.bmc.datascience.requests.*;
+import com.oracle.bmc.datascience.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public class DeleteModelDeploymentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datascience.requests.DeleteModelDeploymentRequest interceptRequest(
+            com.oracle.bmc.datascience.requests.DeleteModelDeploymentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datascience.requests.DeleteModelDeploymentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getModelDeploymentId(), "modelDeploymentId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190101")
+                        .path("modelDeployments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getModelDeploymentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datascience.responses.DeleteModelDeploymentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datascience.responses.DeleteModelDeploymentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datascience.responses
+                                        .DeleteModelDeploymentResponse>() {
+                            @Override
+                            public com.oracle.bmc.datascience.responses
+                                            .DeleteModelDeploymentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datascience.responses.DeleteModelDeploymentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datascience.responses.DeleteModelDeploymentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datascience.responses
+                                                        .DeleteModelDeploymentResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datascience.responses.DeleteModelDeploymentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/GetModelDeploymentConverter.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/GetModelDeploymentConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datascience.model.*;
+import com.oracle.bmc.datascience.requests.*;
+import com.oracle.bmc.datascience.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public class GetModelDeploymentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datascience.requests.GetModelDeploymentRequest interceptRequest(
+            com.oracle.bmc.datascience.requests.GetModelDeploymentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datascience.requests.GetModelDeploymentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getModelDeploymentId(), "modelDeploymentId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190101")
+                        .path("modelDeployments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getModelDeploymentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datascience.responses.GetModelDeploymentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datascience.responses.GetModelDeploymentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datascience.responses.GetModelDeploymentResponse>() {
+                            @Override
+                            public com.oracle.bmc.datascience.responses.GetModelDeploymentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datascience.responses.GetModelDeploymentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        ModelDeployment>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        ModelDeployment.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<ModelDeployment> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datascience.responses.GetModelDeploymentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datascience.responses
+                                                        .GetModelDeploymentResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.modelDeployment(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datascience.responses.GetModelDeploymentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/ListModelDeploymentShapesConverter.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/ListModelDeploymentShapesConverter.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datascience.model.*;
+import com.oracle.bmc.datascience.requests.*;
+import com.oracle.bmc.datascience.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public class ListModelDeploymentShapesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datascience.requests.ListModelDeploymentShapesRequest
+            interceptRequest(
+                    com.oracle.bmc.datascience.requests.ListModelDeploymentShapesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datascience.requests.ListModelDeploymentShapesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20190101").path("modelDeploymentShapes");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datascience.responses.ListModelDeploymentShapesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datascience.responses.ListModelDeploymentShapesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datascience.responses
+                                        .ListModelDeploymentShapesResponse>() {
+                            @Override
+                            public com.oracle.bmc.datascience.responses
+                                            .ListModelDeploymentShapesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datascience.responses.ListModelDeploymentShapesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                ModelDeploymentShapeSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        ModelDeploymentShapeSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<ModelDeploymentShapeSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datascience.responses
+                                                .ListModelDeploymentShapesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datascience.responses
+                                                        .ListModelDeploymentShapesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datascience.responses
+                                                .ListModelDeploymentShapesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/ListModelDeploymentsConverter.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/ListModelDeploymentsConverter.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datascience.model.*;
+import com.oracle.bmc.datascience.requests.*;
+import com.oracle.bmc.datascience.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public class ListModelDeploymentsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datascience.requests.ListModelDeploymentsRequest interceptRequest(
+            com.oracle.bmc.datascience.requests.ListModelDeploymentsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datascience.requests.ListModelDeploymentsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20190101").path("modelDeployments");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getId() != null) {
+            target =
+                    target.queryParam(
+                            "id",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getId()));
+        }
+
+        if (request.getProjectId() != null) {
+            target =
+                    target.queryParam(
+                            "projectId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getProjectId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getCreatedBy() != null) {
+            target =
+                    target.queryParam(
+                            "createdBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getCreatedBy()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datascience.responses.ListModelDeploymentsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datascience.responses.ListModelDeploymentsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datascience.responses
+                                        .ListModelDeploymentsResponse>() {
+                            @Override
+                            public com.oracle.bmc.datascience.responses.ListModelDeploymentsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datascience.responses.ListModelDeploymentsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<ModelDeploymentSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        ModelDeploymentSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<ModelDeploymentSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datascience.responses.ListModelDeploymentsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datascience.responses
+                                                        .ListModelDeploymentsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datascience.responses.ListModelDeploymentsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/UpdateModelDeploymentConverter.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/internal/http/UpdateModelDeploymentConverter.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datascience.model.*;
+import com.oracle.bmc.datascience.requests.*;
+import com.oracle.bmc.datascience.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public class UpdateModelDeploymentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datascience.requests.UpdateModelDeploymentRequest interceptRequest(
+            com.oracle.bmc.datascience.requests.UpdateModelDeploymentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datascience.requests.UpdateModelDeploymentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getModelDeploymentId(), "modelDeploymentId must not be blank");
+        Validate.notNull(
+                request.getUpdateModelDeploymentDetails(),
+                "updateModelDeploymentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190101")
+                        .path("modelDeployments")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getModelDeploymentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datascience.responses.UpdateModelDeploymentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datascience.responses.UpdateModelDeploymentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datascience.responses
+                                        .UpdateModelDeploymentResponse>() {
+                            @Override
+                            public com.oracle.bmc.datascience.responses
+                                            .UpdateModelDeploymentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datascience.responses.UpdateModelDeploymentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datascience.responses.UpdateModelDeploymentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.datascience.responses
+                                                        .UpdateModelDeploymentResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datascience.responses.UpdateModelDeploymentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CategoryLogDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CategoryLogDetails.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The log details for each category.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CategoryLogDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CategoryLogDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("access")
+        private LogDetails access;
+
+        public Builder access(LogDetails access) {
+            this.access = access;
+            this.__explicitlySet__.add("access");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("predict")
+        private LogDetails predict;
+
+        public Builder predict(LogDetails predict) {
+            this.predict = predict;
+            this.__explicitlySet__.add("predict");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CategoryLogDetails build() {
+            CategoryLogDetails __instance__ = new CategoryLogDetails(access, predict);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CategoryLogDetails o) {
+            Builder copiedBuilder = access(o.getAccess()).predict(o.getPredict());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("access")
+    LogDetails access;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("predict")
+    LogDetails predict;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ChangeModelDeploymentCompartmentDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ChangeModelDeploymentCompartmentDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * Details for changing the compartment of a model deployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeModelDeploymentCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeModelDeploymentCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeModelDeploymentCompartmentDetails build() {
+            ChangeModelDeploymentCompartmentDetails __instance__ =
+                    new ChangeModelDeploymentCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeModelDeploymentCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment where the resource should be moved.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateModelDeploymentDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateModelDeploymentDetails.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * Parameters needed to create a new model deployment. Model deployments are used by data scientists to perform predictions from the model hosted on an HTTP server.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateModelDeploymentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateModelDeploymentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentConfigurationDetails")
+        private ModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails;
+
+        public Builder modelDeploymentConfigurationDetails(
+                ModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails) {
+            this.modelDeploymentConfigurationDetails = modelDeploymentConfigurationDetails;
+            this.__explicitlySet__.add("modelDeploymentConfigurationDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("categoryLogDetails")
+        private CategoryLogDetails categoryLogDetails;
+
+        public Builder categoryLogDetails(CategoryLogDetails categoryLogDetails) {
+            this.categoryLogDetails = categoryLogDetails;
+            this.__explicitlySet__.add("categoryLogDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateModelDeploymentDetails build() {
+            CreateModelDeploymentDetails __instance__ =
+                    new CreateModelDeploymentDetails(
+                            displayName,
+                            description,
+                            projectId,
+                            compartmentId,
+                            modelDeploymentConfigurationDetails,
+                            categoryLogDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateModelDeploymentDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .projectId(o.getProjectId())
+                            .compartmentId(o.getCompartmentId())
+                            .modelDeploymentConfigurationDetails(
+                                    o.getModelDeploymentConfigurationDetails())
+                            .categoryLogDetails(o.getCategoryLogDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * Example: `My ModelDeployment`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * A short description of the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project to associate with the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+    String projectId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment where you want to create the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentConfigurationDetails")
+    ModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("categoryLogDetails")
+    CategoryLogDetails categoryLogDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateModelDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateModelDetails.java
@@ -120,19 +120,19 @@ public class CreateModelDetails {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the compartment to create the model in.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to create the model in.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project to associate with the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project to associate with the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("projectId")
     String projectId;
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      * Example: `My Model`
      *
      **/
@@ -140,7 +140,7 @@ public class CreateModelDetails {
     String displayName;
 
     /**
-     * A short blurb describing the model.
+     * A short description of the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateNotebookSessionDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateNotebookSessionDetails.java
@@ -123,7 +123,7 @@ public class CreateNotebookSessionDetails {
     }
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      * Example: `My NotebookSession`
      *
      **/
@@ -131,13 +131,13 @@ public class CreateNotebookSessionDetails {
     String displayName;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project to associate with the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project to associate with the notebook session.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("projectId")
     String projectId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the compartment where you want to create the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment where you want to create the notebook session.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateProjectDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateProjectDetails.java
@@ -106,19 +106,19 @@ public class CreateProjectDetails {
     }
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * A short blurb describing the project.
+     * A short description of the project.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the compartment to create the project in.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment to create the project in.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/FixedSizeScalingPolicy.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/FixedSizeScalingPolicy.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The fixed size scaling policy.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = FixedSizeScalingPolicy.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "policyType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class FixedSizeScalingPolicy extends ScalingPolicy {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceCount")
+        private Integer instanceCount;
+
+        public Builder instanceCount(Integer instanceCount) {
+            this.instanceCount = instanceCount;
+            this.__explicitlySet__.add("instanceCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public FixedSizeScalingPolicy build() {
+            FixedSizeScalingPolicy __instance__ = new FixedSizeScalingPolicy(instanceCount);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(FixedSizeScalingPolicy o) {
+            Builder copiedBuilder = instanceCount(o.getInstanceCount());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public FixedSizeScalingPolicy(Integer instanceCount) {
+        super();
+        this.instanceCount = instanceCount;
+    }
+
+    /**
+     * The number of instances for the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceCount")
+    Integer instanceCount;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/InstanceConfiguration.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/InstanceConfiguration.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The model deployment instance configuration
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = InstanceConfiguration.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class InstanceConfiguration {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceShapeName")
+        private String instanceShapeName;
+
+        public Builder instanceShapeName(String instanceShapeName) {
+            this.instanceShapeName = instanceShapeName;
+            this.__explicitlySet__.add("instanceShapeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public InstanceConfiguration build() {
+            InstanceConfiguration __instance__ = new InstanceConfiguration(instanceShapeName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(InstanceConfiguration o) {
+            Builder copiedBuilder = instanceShapeName(o.getInstanceShapeName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The shape used to launch the model deployment instances.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceShapeName")
+    String instanceShapeName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/LogDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/LogDetails.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The log details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = LogDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LogDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("logId")
+        private String logId;
+
+        public Builder logId(String logId) {
+            this.logId = logId;
+            this.__explicitlySet__.add("logId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("logGroupId")
+        private String logGroupId;
+
+        public Builder logGroupId(String logGroupId) {
+            this.logGroupId = logGroupId;
+            this.__explicitlySet__.add("logGroupId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LogDetails build() {
+            LogDetails __instance__ = new LogDetails(logId, logGroupId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LogDetails o) {
+            Builder copiedBuilder = logId(o.getLogId()).logGroupId(o.getLogGroupId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of a log to work with.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("logId")
+    String logId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of a log group to work with.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("logGroupId")
+    String logGroupId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/Model.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/Model.java
@@ -162,31 +162,31 @@ public class Model {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model's compartment.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model's compartment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project associated with the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project associated with the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("projectId")
     String projectId;
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * A short blurb describing the model.
+     * A short description of the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
@@ -198,7 +198,7 @@ public class Model {
     ModelLifecycleState lifecycleState;
 
     /**
-     * The date and time the resource was created, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The date and time the resource was created in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      * Example: 2019-08-25T21:10:29.41Z
      *
      **/
@@ -206,7 +206,7 @@ public class Model {
     java.util.Date timeCreated;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the user who created the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
     String createdBy;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelConfigurationDetails.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The model configuration details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ModelConfigurationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ModelConfigurationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("modelId")
+        private String modelId;
+
+        public Builder modelId(String modelId) {
+            this.modelId = modelId;
+            this.__explicitlySet__.add("modelId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceConfiguration")
+        private InstanceConfiguration instanceConfiguration;
+
+        public Builder instanceConfiguration(InstanceConfiguration instanceConfiguration) {
+            this.instanceConfiguration = instanceConfiguration;
+            this.__explicitlySet__.add("instanceConfiguration");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scalingPolicy")
+        private ScalingPolicy scalingPolicy;
+
+        public Builder scalingPolicy(ScalingPolicy scalingPolicy) {
+            this.scalingPolicy = scalingPolicy;
+            this.__explicitlySet__.add("scalingPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bandwidthMbps")
+        private Integer bandwidthMbps;
+
+        public Builder bandwidthMbps(Integer bandwidthMbps) {
+            this.bandwidthMbps = bandwidthMbps;
+            this.__explicitlySet__.add("bandwidthMbps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ModelConfigurationDetails build() {
+            ModelConfigurationDetails __instance__ =
+                    new ModelConfigurationDetails(
+                            modelId, instanceConfiguration, scalingPolicy, bandwidthMbps);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ModelConfigurationDetails o) {
+            Builder copiedBuilder =
+                    modelId(o.getModelId())
+                            .instanceConfiguration(o.getInstanceConfiguration())
+                            .scalingPolicy(o.getScalingPolicy())
+                            .bandwidthMbps(o.getBandwidthMbps());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the model you want to deploy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelId")
+    String modelId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceConfiguration")
+    InstanceConfiguration instanceConfiguration;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scalingPolicy")
+    ScalingPolicy scalingPolicy;
+
+    /**
+     * The network bandwidth for the model.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bandwidthMbps")
+    Integer bandwidthMbps;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeployment.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeployment.java
@@ -1,0 +1,299 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * Model deployments are interactive coding environments for data scientists.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ModelDeployment.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ModelDeployment {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+        private String createdBy;
+
+        public Builder createdBy(String createdBy) {
+            this.createdBy = createdBy;
+            this.__explicitlySet__.add("createdBy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentConfigurationDetails")
+        private ModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails;
+
+        public Builder modelDeploymentConfigurationDetails(
+                ModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails) {
+            this.modelDeploymentConfigurationDetails = modelDeploymentConfigurationDetails;
+            this.__explicitlySet__.add("modelDeploymentConfigurationDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("categoryLogDetails")
+        private CategoryLogDetails categoryLogDetails;
+
+        public Builder categoryLogDetails(CategoryLogDetails categoryLogDetails) {
+            this.categoryLogDetails = categoryLogDetails;
+            this.__explicitlySet__.add("categoryLogDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentUrl")
+        private String modelDeploymentUrl;
+
+        public Builder modelDeploymentUrl(String modelDeploymentUrl) {
+            this.modelDeploymentUrl = modelDeploymentUrl;
+            this.__explicitlySet__.add("modelDeploymentUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private ModelDeploymentLifecycleState lifecycleState;
+
+        public Builder lifecycleState(ModelDeploymentLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ModelDeployment build() {
+            ModelDeployment __instance__ =
+                    new ModelDeployment(
+                            id,
+                            timeCreated,
+                            displayName,
+                            description,
+                            projectId,
+                            createdBy,
+                            compartmentId,
+                            modelDeploymentConfigurationDetails,
+                            categoryLogDetails,
+                            modelDeploymentUrl,
+                            lifecycleState,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ModelDeployment o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .timeCreated(o.getTimeCreated())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .projectId(o.getProjectId())
+                            .createdBy(o.getCreatedBy())
+                            .compartmentId(o.getCompartmentId())
+                            .modelDeploymentConfigurationDetails(
+                                    o.getModelDeploymentConfigurationDetails())
+                            .categoryLogDetails(o.getCategoryLogDetails())
+                            .modelDeploymentUrl(o.getModelDeploymentUrl())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The date and time the resource was created, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: 2019-08-25T21:10:29.41Z
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * Example: `My ModelDeployment`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * A short description of the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project associated with the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+    String projectId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+    String createdBy;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment's compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentConfigurationDetails")
+    ModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("categoryLogDetails")
+    CategoryLogDetails categoryLogDetails;
+
+    /**
+     * The URL to interact with the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentUrl")
+    String modelDeploymentUrl;
+
+    /**
+     * The state of the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    ModelDeploymentLifecycleState lifecycleState;
+
+    /**
+     * Details about the state of the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentConfigurationDetails.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The model deployment configuration details.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deploymentType",
+    defaultImpl = ModelDeploymentConfigurationDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = SingleModelDeploymentConfigurationDetails.class,
+        name = "SINGLE_MODEL"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ModelDeploymentConfigurationDetails {}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentLifecycleState.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentLifecycleState.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The lifecycle state of a model deployment.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public enum ModelDeploymentLifecycleState {
+    Creating("CREATING"),
+    Active("ACTIVE"),
+    Deleting("DELETING"),
+    Failed("FAILED"),
+    Inactive("INACTIVE"),
+    Updating("UPDATING"),
+    Deleted("DELETED"),
+    NeedsAttention("NEEDS_ATTENTION"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, ModelDeploymentLifecycleState> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (ModelDeploymentLifecycleState v : ModelDeploymentLifecycleState.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    ModelDeploymentLifecycleState(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static ModelDeploymentLifecycleState create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'ModelDeploymentLifecycleState', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentShapeSummary.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentShapeSummary.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The compute shape used to launch a model deployment compute instance.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ModelDeploymentShapeSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ModelDeploymentShapeSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("coreCount")
+        private Integer coreCount;
+
+        public Builder coreCount(Integer coreCount) {
+            this.coreCount = coreCount;
+            this.__explicitlySet__.add("coreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memoryInGBs")
+        private Integer memoryInGBs;
+
+        public Builder memoryInGBs(Integer memoryInGBs) {
+            this.memoryInGBs = memoryInGBs;
+            this.__explicitlySet__.add("memoryInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ModelDeploymentShapeSummary build() {
+            ModelDeploymentShapeSummary __instance__ =
+                    new ModelDeploymentShapeSummary(name, coreCount, memoryInGBs);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ModelDeploymentShapeSummary o) {
+            Builder copiedBuilder =
+                    name(o.getName()).coreCount(o.getCoreCount()).memoryInGBs(o.getMemoryInGBs());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the model deployment shape.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The number of cores associated with this model deployment shape.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("coreCount")
+    Integer coreCount;
+
+    /**
+     * The amount of memory in GBs associated with this model deployment shape.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memoryInGBs")
+    Integer memoryInGBs;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentSummary.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentSummary.java
@@ -1,0 +1,283 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * Summary information for a model deployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ModelDeploymentSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ModelDeploymentSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+        private String createdBy;
+
+        public Builder createdBy(String createdBy) {
+            this.createdBy = createdBy;
+            this.__explicitlySet__.add("createdBy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentConfigurationDetails")
+        private ModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails;
+
+        public Builder modelDeploymentConfigurationDetails(
+                ModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails) {
+            this.modelDeploymentConfigurationDetails = modelDeploymentConfigurationDetails;
+            this.__explicitlySet__.add("modelDeploymentConfigurationDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("categoryLogDetails")
+        private CategoryLogDetails categoryLogDetails;
+
+        public Builder categoryLogDetails(CategoryLogDetails categoryLogDetails) {
+            this.categoryLogDetails = categoryLogDetails;
+            this.__explicitlySet__.add("categoryLogDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentUrl")
+        private String modelDeploymentUrl;
+
+        public Builder modelDeploymentUrl(String modelDeploymentUrl) {
+            this.modelDeploymentUrl = modelDeploymentUrl;
+            this.__explicitlySet__.add("modelDeploymentUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private ModelDeploymentLifecycleState lifecycleState;
+
+        public Builder lifecycleState(ModelDeploymentLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ModelDeploymentSummary build() {
+            ModelDeploymentSummary __instance__ =
+                    new ModelDeploymentSummary(
+                            id,
+                            timeCreated,
+                            displayName,
+                            description,
+                            projectId,
+                            createdBy,
+                            compartmentId,
+                            modelDeploymentConfigurationDetails,
+                            categoryLogDetails,
+                            modelDeploymentUrl,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ModelDeploymentSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .timeCreated(o.getTimeCreated())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .projectId(o.getProjectId())
+                            .createdBy(o.getCreatedBy())
+                            .compartmentId(o.getCompartmentId())
+                            .modelDeploymentConfigurationDetails(
+                                    o.getModelDeploymentConfigurationDetails())
+                            .categoryLogDetails(o.getCategoryLogDetails())
+                            .modelDeploymentUrl(o.getModelDeploymentUrl())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The date and time the resource was created, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: 2019-08-25T21:10:29.41Z
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * Example: `My ModelDeployment`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * A short description of the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project associated with the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+    String projectId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
+    String createdBy;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment's compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentConfigurationDetails")
+    ModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("categoryLogDetails")
+    CategoryLogDetails categoryLogDetails;
+
+    /**
+     * The URL to interact with the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentUrl")
+    String modelDeploymentUrl;
+
+    /**
+     * The state of the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    ModelDeploymentLifecycleState lifecycleState;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentType.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeploymentType.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The type of model deployment.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public enum ModelDeploymentType {
+    SingleModel("SINGLE_MODEL"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, ModelDeploymentType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (ModelDeploymentType v : ModelDeploymentType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    ModelDeploymentType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static ModelDeploymentType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'ModelDeploymentType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelSummary.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelSummary.java
@@ -151,37 +151,37 @@ public class ModelSummary {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model's compartment.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model's compartment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project associated with the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project associated with the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("projectId")
     String projectId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the user who created the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
     String createdBy;
 
     /**
-     * The date and time the resource was created, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The date and time the resource was created in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      * Example: 2019-08-25T21:10:29.41Z
      *
      **/

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSession.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSession.java
@@ -187,13 +187,13 @@ public class NotebookSession {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The date and time the resource was created, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The date and time the resource was created in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      * Example: 2019-08-25T21:10:29.41Z
      *
      **/
@@ -201,7 +201,7 @@ public class NotebookSession {
     java.util.Date timeCreated;
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      * Example: `My NotebookSession`
      *
      **/
@@ -209,19 +209,19 @@ public class NotebookSession {
     String displayName;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project associated with the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project associated with the notebook session.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("projectId")
     String projectId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the user who created the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the notebook session.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
     String createdBy;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session's compartment.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session's compartment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionConfigurationDetails.java
@@ -83,7 +83,7 @@ public class NotebookSessionConfigurationDetails {
     }
 
     /**
-     * The shape used to launch the notebook session compute instance.  The list of available shapes in a given compartment can be retrieved from the `ListNotebookSessionShapes` endpoint.
+     * The shape used to launch the notebook session compute instance.  The list of available shapes in a given compartment can be retrieved using the `ListNotebookSessionShapes` endpoint.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("shape")
@@ -97,7 +97,7 @@ public class NotebookSessionConfigurationDetails {
     Integer blockStorageSizeInGBs;
 
     /**
-     * A notebook session instance is provided with a VNIC for network access.  This specifies the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the subnet to create a VNIC in.  The subnet should be in a VCN with a NAT gateway for egress to the internet.
+     * A notebook session instance is provided with a VNIC for network access.  This specifies the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the subnet to create a VNIC in.  The subnet should be in a VCN with a NAT gateway for egress to the internet.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionSummary.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionSummary.java
@@ -177,13 +177,13 @@ public class NotebookSessionSummary {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The date and time the resource was created, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The date and time the resource was created in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      * Example: 2019-08-25T21:10:29.41Z
      *
      **/
@@ -191,7 +191,7 @@ public class NotebookSessionSummary {
     java.util.Date timeCreated;
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      * Example: `My NotebookSession`
      *
      **/
@@ -199,19 +199,19 @@ public class NotebookSessionSummary {
     String displayName;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project associated with the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project associated with the notebook session.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("projectId")
     String projectId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the user who created the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the notebook session.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
     String createdBy;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session's compartment.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session's compartment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/Project.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/Project.java
@@ -152,13 +152,13 @@ public class Project {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The date and time the resource was created, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The date and time the resource was created in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      * Example: 2019-08-25T21:10:29.41Z
      *
      **/
@@ -166,25 +166,25 @@ public class Project {
     java.util.Date timeCreated;
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * A short blurb describing the project.
+     * A short description of the project.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project's compartment.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project's compartment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the user who created this project.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created this project.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
     String createdBy;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ProjectSummary.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ProjectSummary.java
@@ -151,13 +151,13 @@ public class ProjectSummary {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * The date and time the resource was created, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The date and time the resource was created in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      * Example: 2019-08-25T21:10:29.41Z
      *
      **/
@@ -165,25 +165,25 @@ public class ProjectSummary {
     java.util.Date timeCreated;
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * A short blurb describing the project.
+     * A short description of the project.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project's compartment.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project's compartment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the user who created this project.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the project.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
     String createdBy;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ScalingPolicy.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ScalingPolicy.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The scaling policy to apply to each model of the deployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "policyType",
+    defaultImpl = ScalingPolicy.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = FixedSizeScalingPolicy.class,
+        name = "FIXED_SIZE"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ScalingPolicy {
+
+    /**
+     * The type of scaling policy.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PolicyType {
+        FixedSize("FIXED_SIZE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PolicyType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PolicyType v : PolicyType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PolicyType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PolicyType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PolicyType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/SingleModelDeploymentConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/SingleModelDeploymentConfigurationDetails.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The single model type deployment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = SingleModelDeploymentConfigurationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deploymentType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SingleModelDeploymentConfigurationDetails extends ModelDeploymentConfigurationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("modelConfigurationDetails")
+        private ModelConfigurationDetails modelConfigurationDetails;
+
+        public Builder modelConfigurationDetails(
+                ModelConfigurationDetails modelConfigurationDetails) {
+            this.modelConfigurationDetails = modelConfigurationDetails;
+            this.__explicitlySet__.add("modelConfigurationDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SingleModelDeploymentConfigurationDetails build() {
+            SingleModelDeploymentConfigurationDetails __instance__ =
+                    new SingleModelDeploymentConfigurationDetails(modelConfigurationDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SingleModelDeploymentConfigurationDetails o) {
+            Builder copiedBuilder = modelConfigurationDetails(o.getModelConfigurationDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public SingleModelDeploymentConfigurationDetails(
+            ModelConfigurationDetails modelConfigurationDetails) {
+        super();
+        this.modelConfigurationDetails = modelConfigurationDetails;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("modelConfigurationDetails")
+    ModelConfigurationDetails modelConfigurationDetails;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateCategoryLogDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateCategoryLogDetails.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The log details for each category for update.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateCategoryLogDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateCategoryLogDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("access")
+        private LogDetails access;
+
+        public Builder access(LogDetails access) {
+            this.access = access;
+            this.__explicitlySet__.add("access");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("predict")
+        private LogDetails predict;
+
+        public Builder predict(LogDetails predict) {
+            this.predict = predict;
+            this.__explicitlySet__.add("predict");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateCategoryLogDetails build() {
+            UpdateCategoryLogDetails __instance__ = new UpdateCategoryLogDetails(access, predict);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateCategoryLogDetails o) {
+            Builder copiedBuilder = access(o.getAccess()).predict(o.getPredict());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("access")
+    LogDetails access;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("predict")
+    LogDetails predict;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelConfigurationDetails.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The model configuration details for update.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateModelConfigurationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateModelConfigurationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("modelId")
+        private String modelId;
+
+        public Builder modelId(String modelId) {
+            this.modelId = modelId;
+            this.__explicitlySet__.add("modelId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceConfiguration")
+        private InstanceConfiguration instanceConfiguration;
+
+        public Builder instanceConfiguration(InstanceConfiguration instanceConfiguration) {
+            this.instanceConfiguration = instanceConfiguration;
+            this.__explicitlySet__.add("instanceConfiguration");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("scalingPolicy")
+        private ScalingPolicy scalingPolicy;
+
+        public Builder scalingPolicy(ScalingPolicy scalingPolicy) {
+            this.scalingPolicy = scalingPolicy;
+            this.__explicitlySet__.add("scalingPolicy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bandwidthMbps")
+        private Integer bandwidthMbps;
+
+        public Builder bandwidthMbps(Integer bandwidthMbps) {
+            this.bandwidthMbps = bandwidthMbps;
+            this.__explicitlySet__.add("bandwidthMbps");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateModelConfigurationDetails build() {
+            UpdateModelConfigurationDetails __instance__ =
+                    new UpdateModelConfigurationDetails(
+                            modelId, instanceConfiguration, scalingPolicy, bandwidthMbps);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateModelConfigurationDetails o) {
+            Builder copiedBuilder =
+                    modelId(o.getModelId())
+                            .instanceConfiguration(o.getInstanceConfiguration())
+                            .scalingPolicy(o.getScalingPolicy())
+                            .bandwidthMbps(o.getBandwidthMbps());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The OCID of the model you want to update.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("modelId")
+    String modelId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceConfiguration")
+    InstanceConfiguration instanceConfiguration;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scalingPolicy")
+    ScalingPolicy scalingPolicy;
+
+    /**
+     * The network bandwidth for the model.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bandwidthMbps")
+    Integer bandwidthMbps;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelDeploymentConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelDeploymentConfigurationDetails.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The model deployment configuration details for update.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deploymentType",
+    defaultImpl = UpdateModelDeploymentConfigurationDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateSingleModelDeploymentConfigurationDetails.class,
+        name = "SINGLE_MODEL"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateModelDeploymentConfigurationDetails {}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelDeploymentDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelDeploymentDetails.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * Details for updating a model deployment. You can update `modelDeploymentConfigurationDetails` and change `instanceShapeName` and `modelId` when the model deployment is in
+ * the ACTIVE lifecycle state. The `bandwidthMbps` or `instanceCount` can only be updated while the model deployment is in the `INACTIVE` state. Changes to the `bandwidthMbps`
+ * or `instanceCount` will take effect the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateModelDeploymentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateModelDeploymentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentConfigurationDetails")
+        private UpdateModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails;
+
+        public Builder modelDeploymentConfigurationDetails(
+                UpdateModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails) {
+            this.modelDeploymentConfigurationDetails = modelDeploymentConfigurationDetails;
+            this.__explicitlySet__.add("modelDeploymentConfigurationDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("categoryLogDetails")
+        private UpdateCategoryLogDetails categoryLogDetails;
+
+        public Builder categoryLogDetails(UpdateCategoryLogDetails categoryLogDetails) {
+            this.categoryLogDetails = categoryLogDetails;
+            this.__explicitlySet__.add("categoryLogDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateModelDeploymentDetails build() {
+            UpdateModelDeploymentDetails __instance__ =
+                    new UpdateModelDeploymentDetails(
+                            displayName,
+                            description,
+                            modelDeploymentConfigurationDetails,
+                            categoryLogDetails,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateModelDeploymentDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .modelDeploymentConfigurationDetails(
+                                    o.getModelDeploymentConfigurationDetails())
+                            .categoryLogDetails(o.getCategoryLogDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * Example: `My ModelDeployment`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * A short description of the model deployment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("modelDeploymentConfigurationDetails")
+    UpdateModelDeploymentConfigurationDetails modelDeploymentConfigurationDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("categoryLogDetails")
+    UpdateCategoryLogDetails categoryLogDetails;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelDetails.java
@@ -95,7 +95,7 @@ public class UpdateModelDetails {
     }
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      *  Example: `My Model`
      *
      **/
@@ -103,7 +103,7 @@ public class UpdateModelDetails {
     String displayName;
 
     /**
-     * A short blurb describing the model.
+     * A short description of the model.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateNotebookSessionDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateNotebookSessionDetails.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.datascience.model;
 
 /**
  * Details for updating a notebook session. `notebookSessionConfigurationDetails` can only be updated while the notebook session is in the `INACTIVE` state.
- * Changes to the `notebookSessionConfigurationDetails` will take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
+ * Changes to the `notebookSessionConfigurationDetails` take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -102,7 +102,7 @@ public class UpdateNotebookSessionDetails {
     }
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      * Example: `My NotebookSession`
      *
      **/

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateProjectDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateProjectDetails.java
@@ -94,13 +94,13 @@ public class UpdateProjectDetails {
     }
 
     /**
-     * A user-friendly display name for the resource. Does not have to be unique, and can be modified. Avoid entering confidential information.
+     * A user-friendly display name for the resource. It does not have to be unique and can be modified. Avoid entering confidential information.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
 
     /**
-     * A short blurb describing the project.
+     * A short description of the project.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateSingleModelDeploymentConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateSingleModelDeploymentConfigurationDetails.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The single model type deployment for update.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateSingleModelDeploymentConfigurationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "deploymentType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateSingleModelDeploymentConfigurationDetails
+        extends UpdateModelDeploymentConfigurationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("modelConfigurationDetails")
+        private UpdateModelConfigurationDetails modelConfigurationDetails;
+
+        public Builder modelConfigurationDetails(
+                UpdateModelConfigurationDetails modelConfigurationDetails) {
+            this.modelConfigurationDetails = modelConfigurationDetails;
+            this.__explicitlySet__.add("modelConfigurationDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateSingleModelDeploymentConfigurationDetails build() {
+            UpdateSingleModelDeploymentConfigurationDetails __instance__ =
+                    new UpdateSingleModelDeploymentConfigurationDetails(modelConfigurationDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateSingleModelDeploymentConfigurationDetails o) {
+            Builder copiedBuilder = modelConfigurationDetails(o.getModelConfigurationDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateSingleModelDeploymentConfigurationDetails(
+            UpdateModelConfigurationDetails modelConfigurationDetails) {
+        super();
+        this.modelConfigurationDetails = modelConfigurationDetails;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("modelConfigurationDetails")
+    UpdateModelConfigurationDetails modelConfigurationDetails;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequest.java
@@ -150,7 +150,7 @@ public class WorkRequest {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -168,7 +168,7 @@ public class WorkRequest {
     WorkRequestStatus status;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request's compartment.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request's compartment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -186,19 +186,19 @@ public class WorkRequest {
     java.util.List<WorkRequestResource> resources;
 
     /**
-     * The time the work request was accepted, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The time the work request was accepted in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
     java.util.Date timeAccepted;
 
     /**
-     * The time the work request was started, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The time the work request was started in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
     java.util.Date timeStarted;
 
     /**
-     * The time the work request was finished, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The time the work request was finished in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
     java.util.Date timeFinished;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequestError.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequestError.java
@@ -78,7 +78,7 @@ public class WorkRequestError {
     }
 
     /**
-     * A short error code that defines the error, meant for programmatic parsing. See [API Errors](https://docs.cloud.oracle.com/Content/API/References/apierrors.htm).
+     * A short error code that defines the error, which is meant for programmatic parsing. See [API Errors](https://docs.cloud.oracle.com/Content/General/References/apierrors.htm).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("code")
     String code;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequestOperationType.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequestOperationType.java
@@ -14,6 +14,11 @@ public enum WorkRequestOperationType {
     NotebookSessionDelete("NOTEBOOK_SESSION_DELETE"),
     NotebookSessionActivate("NOTEBOOK_SESSION_ACTIVATE"),
     NotebookSessionDeactivate("NOTEBOOK_SESSION_DEACTIVATE"),
+    ModelDeploymentCreate("MODEL_DEPLOYMENT_CREATE"),
+    ModelDeploymentDelete("MODEL_DEPLOYMENT_DELETE"),
+    ModelDeploymentActivate("MODEL_DEPLOYMENT_ACTIVATE"),
+    ModelDeploymentDeactivate("MODEL_DEPLOYMENT_DEACTIVATE"),
+    ModelDeploymentUpdate("MODEL_DEPLOYMENT_UPDATE"),
     ProjectDelete("PROJECT_DELETE"),
     WorkrequestCancel("WORKREQUEST_CANCEL"),
 

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequestResource.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequestResource.java
@@ -154,7 +154,7 @@ public class WorkRequestResource {
     String entityType;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the resource the work request affects.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the resource the work request affects.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("identifier")
     String identifier;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequestSummary.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/WorkRequestSummary.java
@@ -152,7 +152,7 @@ public class WorkRequestSummary {
     }
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -170,7 +170,7 @@ public class WorkRequestSummary {
     WorkRequestStatus status;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request's compartment.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request's compartment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -188,19 +188,19 @@ public class WorkRequestSummary {
     java.util.List<WorkRequestResource> resources;
 
     /**
-     * The date and time the work request was accepted, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The date and time the work request was accepted in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
     java.util.Date timeAccepted;
 
     /**
-     * The date and time the work request was started, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The date and time the work request was started in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
     java.util.Date timeStarted;
 
     /**
-     * The date and time the work request was finished, in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * The date and time the work request was finished in the timestamp format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
     java.util.Date timeFinished;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ActivateModelDeploymentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ActivateModelDeploymentRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.requests;
+
+import com.oracle.bmc.datascience.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/ActivateModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ActivateModelDeploymentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ActivateModelDeploymentRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.
+     */
+    private String modelDeploymentId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource is updated or deleted only if the `etag` you
+     * provide matches the resource's current `etag` value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ActivateModelDeploymentRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ActivateModelDeploymentRequest o) {
+            modelDeploymentId(o.getModelDeploymentId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ActivateModelDeploymentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ActivateModelDeploymentRequest
+         */
+        public ActivateModelDeploymentRequest build() {
+            ActivateModelDeploymentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ActivateModelRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ActivateModelRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.datascience.model.*;
 public class ActivateModelRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
@@ -22,14 +22,14 @@ public class ActivateModelRequest extends com.oracle.bmc.requests.BmcRequest<jav
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ActivateNotebookSessionRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ActivateNotebookSessionRequest.java
@@ -15,7 +15,7 @@ public class ActivateNotebookSessionRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session.
      */
     private String notebookSessionId;
 
@@ -23,14 +23,14 @@ public class ActivateNotebookSessionRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CancelWorkRequestRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CancelWorkRequestRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.datascience.model.*;
 public class CancelWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String workRequestId;
 
@@ -22,14 +22,14 @@ public class CancelWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ChangeModelCompartmentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ChangeModelCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeModelCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeModelCompartmentDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
@@ -28,14 +28,14 @@ public class ChangeModelCompartmentRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ChangeModelDeploymentCompartmentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ChangeModelDeploymentCompartmentRequest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.requests;
+
+import com.oracle.bmc.datascience.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/ChangeModelDeploymentCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeModelDeploymentCompartmentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ChangeModelDeploymentCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeModelDeploymentCompartmentDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.
+     */
+    private String modelDeploymentId;
+
+    /**
+     * Details for changing the compartment of a model deployment.
+     */
+    private ChangeModelDeploymentCompartmentDetails changeModelDeploymentCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource is updated or deleted only if the `etag` you
+     * provide matches the resource's current `etag` value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeModelDeploymentCompartmentDetails getBody$() {
+        return changeModelDeploymentCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeModelDeploymentCompartmentRequest,
+                    ChangeModelDeploymentCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeModelDeploymentCompartmentRequest o) {
+            modelDeploymentId(o.getModelDeploymentId());
+            changeModelDeploymentCompartmentDetails(o.getChangeModelDeploymentCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeModelDeploymentCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeModelDeploymentCompartmentRequest
+         */
+        public ChangeModelDeploymentCompartmentRequest build() {
+            ChangeModelDeploymentCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeModelDeploymentCompartmentDetails body) {
+            changeModelDeploymentCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ChangeNotebookSessionCompartmentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ChangeNotebookSessionCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeNotebookSessionCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeNotebookSessionCompartmentDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session.
      */
     private String notebookSessionId;
 
@@ -28,14 +28,14 @@ public class ChangeNotebookSessionCompartmentRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ChangeProjectCompartmentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ChangeProjectCompartmentRequest.java
@@ -15,7 +15,7 @@ public class ChangeProjectCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeProjectCompartmentDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project.
      */
     private String projectId;
 
@@ -28,14 +28,14 @@ public class ChangeProjectCompartmentRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelArtifactRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelArtifactRequest.java
@@ -15,7 +15,7 @@ public class CreateModelArtifactRequest
         extends com.oracle.bmc.requests.BmcRequest<java.io.InputStream> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
@@ -30,7 +30,7 @@ public class CreateModelArtifactRequest
     private java.io.InputStream modelArtifact;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelDeploymentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelDeploymentRequest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.requests;
+
+import com.oracle.bmc.datascience.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/CreateModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateModelDeploymentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateModelDeploymentRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateModelDeploymentDetails> {
+
+    /**
+     * Details for creating a new model deployment.
+     */
+    private CreateModelDeploymentDetails createModelDeploymentDetails;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or server error without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateModelDeploymentDetails getBody$() {
+        return createModelDeploymentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateModelDeploymentRequest, CreateModelDeploymentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateModelDeploymentRequest o) {
+            createModelDeploymentDetails(o.getCreateModelDeploymentDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateModelDeploymentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateModelDeploymentRequest
+         */
+        public CreateModelDeploymentRequest build() {
+            CreateModelDeploymentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateModelDeploymentDetails body) {
+            createModelDeploymentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelProvenanceRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelProvenanceRequest.java
@@ -15,7 +15,7 @@ public class CreateModelProvenanceRequest
         extends com.oracle.bmc.requests.BmcRequest<CreateModelProvenanceDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
@@ -25,7 +25,7 @@ public class CreateModelProvenanceRequest
     private CreateModelProvenanceDetails createModelProvenanceDetails;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelRequest.java
@@ -19,7 +19,7 @@ public class CreateModelRequest extends com.oracle.bmc.requests.BmcRequest<Creat
     private CreateModelDetails createModelDetails;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateNotebookSessionRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateNotebookSessionRequest.java
@@ -20,7 +20,7 @@ public class CreateNotebookSessionRequest
     private CreateNotebookSessionDetails createNotebookSessionDetails;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateProjectRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateProjectRequest.java
@@ -19,7 +19,7 @@ public class CreateProjectRequest extends com.oracle.bmc.requests.BmcRequest<Cre
     private CreateProjectDetails createProjectDetails;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeactivateModelDeploymentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeactivateModelDeploymentRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.requests;
+
+import com.oracle.bmc.datascience.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/DeactivateModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeactivateModelDeploymentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeactivateModelDeploymentRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.
+     */
+    private String modelDeploymentId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource is updated or deleted only if the `etag` you
+     * provide matches the resource's current `etag` value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeactivateModelDeploymentRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeactivateModelDeploymentRequest o) {
+            modelDeploymentId(o.getModelDeploymentId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeactivateModelDeploymentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeactivateModelDeploymentRequest
+         */
+        public DeactivateModelDeploymentRequest build() {
+            DeactivateModelDeploymentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeactivateModelRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeactivateModelRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.datascience.model.*;
 public class DeactivateModelRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
@@ -22,14 +22,14 @@ public class DeactivateModelRequest extends com.oracle.bmc.requests.BmcRequest<j
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeactivateNotebookSessionRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeactivateNotebookSessionRequest.java
@@ -15,7 +15,7 @@ public class DeactivateNotebookSessionRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session.
      */
     private String notebookSessionId;
 
@@ -23,14 +23,14 @@ public class DeactivateNotebookSessionRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeleteModelDeploymentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeleteModelDeploymentRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.requests;
+
+import com.oracle.bmc.datascience.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/DeleteModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteModelDeploymentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteModelDeploymentRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.
+     */
+    private String modelDeploymentId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource is updated or deleted only if the `etag` you
+     * provide matches the resource's current `etag` value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteModelDeploymentRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteModelDeploymentRequest o) {
+            modelDeploymentId(o.getModelDeploymentId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteModelDeploymentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteModelDeploymentRequest
+         */
+        public DeleteModelDeploymentRequest build() {
+            DeleteModelDeploymentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeleteModelRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeleteModelRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.datascience.model.*;
 public class DeleteModelRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
@@ -22,14 +22,14 @@ public class DeleteModelRequest extends com.oracle.bmc.requests.BmcRequest<java.
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeleteNotebookSessionRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeleteNotebookSessionRequest.java
@@ -15,7 +15,7 @@ public class DeleteNotebookSessionRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session.
      */
     private String notebookSessionId;
 
@@ -23,14 +23,14 @@ public class DeleteNotebookSessionRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeleteProjectRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/DeleteProjectRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.datascience.model.*;
 public class DeleteProjectRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project.
      */
     private String projectId;
 
@@ -22,14 +22,14 @@ public class DeleteProjectRequest extends com.oracle.bmc.requests.BmcRequest<jav
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetModelArtifactContentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetModelArtifactContentRequest.java
@@ -15,12 +15,12 @@ public class GetModelArtifactContentRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetModelDeploymentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetModelDeploymentRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.requests;
+
+import com.oracle.bmc.datascience.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/GetModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetModelDeploymentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetModelDeploymentRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.
+     */
+    private String modelDeploymentId;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetModelDeploymentRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetModelDeploymentRequest o) {
+            modelDeploymentId(o.getModelDeploymentId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetModelDeploymentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetModelDeploymentRequest
+         */
+        public GetModelDeploymentRequest build() {
+            GetModelDeploymentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetModelProvenanceRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetModelProvenanceRequest.java
@@ -14,12 +14,12 @@ import com.oracle.bmc.datascience.model.*;
 public class GetModelProvenanceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetModelRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetModelRequest.java
@@ -14,12 +14,12 @@ import com.oracle.bmc.datascience.model.*;
 public class GetModelRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetNotebookSessionRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetNotebookSessionRequest.java
@@ -14,12 +14,12 @@ import com.oracle.bmc.datascience.model.*;
 public class GetNotebookSessionRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session.
      */
     private String notebookSessionId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetProjectRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetProjectRequest.java
@@ -14,12 +14,12 @@ import com.oracle.bmc.datascience.model.*;
 public class GetProjectRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project.
      */
     private String projectId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetWorkRequestRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/GetWorkRequestRequest.java
@@ -14,12 +14,12 @@ import com.oracle.bmc.datascience.model.*;
 public class GetWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String workRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/HeadModelArtifactRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/HeadModelArtifactRequest.java
@@ -14,12 +14,12 @@ import com.oracle.bmc.datascience.model.*;
 public class HeadModelArtifactRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListModelDeploymentShapesRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListModelDeploymentShapesRequest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.requests;
+
+import com.oracle.bmc.datascience.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/ListModelDeploymentShapesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListModelDeploymentShapesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListModelDeploymentShapesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. The maximum number of results per page,
+     * or items to return in a paginated \"List\" call.
+     * 1 is the minimum, 1000 is the maximum.
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `500`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response
+     * header from the previous \"List\" call.
+     * <p>
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListModelDeploymentShapesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListModelDeploymentShapesRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListModelDeploymentShapesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListModelDeploymentShapesRequest
+         */
+        public ListModelDeploymentShapesRequest build() {
+            ListModelDeploymentShapesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListModelDeploymentsRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListModelDeploymentsRequest.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.requests;
+
+import com.oracle.bmc.datascience.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/ListModelDeploymentsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListModelDeploymentsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListModelDeploymentsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * <b>Filter</b> results by [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for the resource type.
+     *
+     */
+    private String id;
+
+    /**
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project.
+     */
+    private String projectId;
+
+    /**
+     * <b>Filter</b> results by its user-friendly name.
+     */
+    private String displayName;
+
+    /**
+     * <b>Filter</b> results by the specified lifecycle state. Must be a valid
+     * state for the resource type.
+     *
+     */
+    private com.oracle.bmc.datascience.model.ModelDeploymentLifecycleState lifecycleState;
+
+    /**
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the resource.
+     */
+    private String createdBy;
+
+    /**
+     * For list pagination. The maximum number of results per page,
+     * or items to return in a paginated \"List\" call.
+     * 1 is the minimum, 1000 is the maximum.
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `500`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response
+     * header from the previous \"List\" call.
+     * <p>
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * Specifies sort order to use, either `ASC` (ascending) or `DESC` (descending).
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * Specifies the field to sort by. Accepts only one field.
+     * By default, when you sort by `timeCreated`, results are shown
+     * in descending order. When you sort by `displayName`, results are
+     * shown in ascending order. Sort order for the `displayName` field is case sensitive.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * Specifies the field to sort by. Accepts only one field.
+     * By default, when you sort by `timeCreated`, results are shown
+     * in descending order. When you sort by `displayName`, results are
+     * shown in ascending order. Sort order for the `displayName` field is case sensitive.
+     *
+     **/
+    public enum SortBy {
+        TimeCreated("timeCreated"),
+        DisplayName("displayName"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListModelDeploymentsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListModelDeploymentsRequest o) {
+            compartmentId(o.getCompartmentId());
+            id(o.getId());
+            projectId(o.getProjectId());
+            displayName(o.getDisplayName());
+            lifecycleState(o.getLifecycleState());
+            createdBy(o.getCreatedBy());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListModelDeploymentsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListModelDeploymentsRequest
+         */
+        public ListModelDeploymentsRequest build() {
+            ListModelDeploymentsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListModelsRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListModelsRequest.java
@@ -14,18 +14,18 @@ import com.oracle.bmc.datascience.model.*;
 public class ListModelsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the compartment.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
     /**
-     * <b>Filter</b> results by [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm). Must be an OCID of the correct type for the resource type.
+     * <b>Filter</b> results by [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for the resource type.
      *
      */
     private String id;
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project.
      */
     private String projectId;
 
@@ -42,7 +42,7 @@ public class ListModelsRequest extends com.oracle.bmc.requests.BmcRequest<java.l
     private com.oracle.bmc.datascience.model.ModelLifecycleState lifecycleState;
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the user who created the resource.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the resource.
      */
     private String createdBy;
 
@@ -50,7 +50,7 @@ public class ListModelsRequest extends com.oracle.bmc.requests.BmcRequest<java.l
      * For list pagination. The maximum number of results per page,
      * or items to return in a paginated \"List\" call.
      * 1 is the minimum, 1000 is the maximum.
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      * <p>
      * Example: `500`
      *
@@ -61,7 +61,7 @@ public class ListModelsRequest extends com.oracle.bmc.requests.BmcRequest<java.l
      * For list pagination. The value of the `opc-next-page` response
      * header from the previous \"List\" call.
      * <p>
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      *
      */
     private String page;
@@ -110,16 +110,16 @@ public class ListModelsRequest extends com.oracle.bmc.requests.BmcRequest<java.l
     };
     /**
      * Specifies the field to sort by. Accepts only one field.
-     * By default, when you sort by `timeCreated`, results are shown
-     * in descending order. All other fields default to ascending order. Sort order for `displayName` field is case sensitive.
+     * By default, when you sort by `timeCreated`, the results are shown
+     * in descending order. All other fields default to ascending order. Sort order for the `displayName` field is case sensitive.
      *
      */
     private SortBy sortBy;
 
     /**
      * Specifies the field to sort by. Accepts only one field.
-     * By default, when you sort by `timeCreated`, results are shown
-     * in descending order. All other fields default to ascending order. Sort order for `displayName` field is case sensitive.
+     * By default, when you sort by `timeCreated`, the results are shown
+     * in descending order. All other fields default to ascending order. Sort order for the `displayName` field is case sensitive.
      *
      **/
     public enum SortBy {
@@ -156,7 +156,7 @@ public class ListModelsRequest extends com.oracle.bmc.requests.BmcRequest<java.l
         }
     };
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListNotebookSessionShapesRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListNotebookSessionShapesRequest.java
@@ -15,12 +15,12 @@ public class ListNotebookSessionShapesRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the compartment.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;
@@ -29,7 +29,7 @@ public class ListNotebookSessionShapesRequest
      * For list pagination. The maximum number of results per page,
      * or items to return in a paginated \"List\" call.
      * 1 is the minimum, 1000 is the maximum.
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      * <p>
      * Example: `500`
      *
@@ -40,7 +40,7 @@ public class ListNotebookSessionShapesRequest
      * For list pagination. The value of the `opc-next-page` response
      * header from the previous \"List\" call.
      * <p>
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      *
      */
     private String page;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListNotebookSessionsRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListNotebookSessionsRequest.java
@@ -15,18 +15,18 @@ public class ListNotebookSessionsRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the compartment.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
     /**
-     * <b>Filter</b> results by [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm). Must be an OCID of the correct type for the resource type.
+     * <b>Filter</b> results by [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for the resource type.
      *
      */
     private String id;
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project.
      */
     private String projectId;
 
@@ -43,7 +43,7 @@ public class ListNotebookSessionsRequest
     private com.oracle.bmc.datascience.model.NotebookSessionLifecycleState lifecycleState;
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the user who created the resource.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the resource.
      */
     private String createdBy;
 
@@ -51,7 +51,7 @@ public class ListNotebookSessionsRequest
      * For list pagination. The maximum number of results per page,
      * or items to return in a paginated \"List\" call.
      * 1 is the minimum, 1000 is the maximum.
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      * <p>
      * Example: `500`
      *
@@ -62,7 +62,7 @@ public class ListNotebookSessionsRequest
      * For list pagination. The value of the `opc-next-page` response
      * header from the previous \"List\" call.
      * <p>
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      *
      */
     private String page;
@@ -111,18 +111,18 @@ public class ListNotebookSessionsRequest
     };
     /**
      * Specifies the field to sort by. Accepts only one field.
-     * By default, when you sort by `timeCreated`, results are shown
+     * By default, when you sort by `timeCreated`, the results are shown
      * in descending order. When you sort by `displayName`, results are
-     * shown in ascending order. Sort order for `displayName` field is case sensitive.
+     * shown in ascending order. Sort order for the `displayName` field is case sensitive.
      *
      */
     private SortBy sortBy;
 
     /**
      * Specifies the field to sort by. Accepts only one field.
-     * By default, when you sort by `timeCreated`, results are shown
+     * By default, when you sort by `timeCreated`, the results are shown
      * in descending order. When you sort by `displayName`, results are
-     * shown in ascending order. Sort order for `displayName` field is case sensitive.
+     * shown in ascending order. Sort order for the `displayName` field is case sensitive.
      *
      **/
     public enum SortBy {
@@ -158,7 +158,7 @@ public class ListNotebookSessionsRequest
         }
     };
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListProjectsRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListProjectsRequest.java
@@ -14,12 +14,12 @@ import com.oracle.bmc.datascience.model.*;
 public class ListProjectsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the compartment.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
     /**
-     * <b>Filter</b> results by [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm). Must be an OCID of the correct type for the resource type.
+     * <b>Filter</b> results by [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for the resource type.
      *
      */
     private String id;
@@ -37,7 +37,7 @@ public class ListProjectsRequest extends com.oracle.bmc.requests.BmcRequest<java
     private com.oracle.bmc.datascience.model.ProjectLifecycleState lifecycleState;
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the user who created the resource.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the user who created the resource.
      */
     private String createdBy;
 
@@ -45,7 +45,7 @@ public class ListProjectsRequest extends com.oracle.bmc.requests.BmcRequest<java
      * For list pagination. The maximum number of results per page,
      * or items to return in a paginated \"List\" call.
      * 1 is the minimum, 1000 is the maximum.
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      * <p>
      * Example: `500`
      *
@@ -56,7 +56,7 @@ public class ListProjectsRequest extends com.oracle.bmc.requests.BmcRequest<java
      * For list pagination. The value of the `opc-next-page` response
      * header from the previous \"List\" call.
      * <p>
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      *
      */
     private String page;
@@ -105,18 +105,18 @@ public class ListProjectsRequest extends com.oracle.bmc.requests.BmcRequest<java
     };
     /**
      * Specifies the field to sort by. Accepts only one field.
-     * By default, when you sort by `timeCreated`, results are shown
-     * in descending order. When you sort by `displayName`, results are
-     * shown in ascending order. Sort order for `displayName` field is case sensitive.
+     * By default, when you sort by `timeCreated`, the results are shown
+     * in descending order. When you sort by `displayName`, the results are
+     * shown in ascending order. Sort order for the `displayName` field is case sensitive.
      *
      */
     private SortBy sortBy;
 
     /**
      * Specifies the field to sort by. Accepts only one field.
-     * By default, when you sort by `timeCreated`, results are shown
-     * in descending order. When you sort by `displayName`, results are
-     * shown in ascending order. Sort order for `displayName` field is case sensitive.
+     * By default, when you sort by `timeCreated`, the results are shown
+     * in descending order. When you sort by `displayName`, the results are
+     * shown in ascending order. Sort order for the `displayName` field is case sensitive.
      *
      **/
     public enum SortBy {
@@ -152,7 +152,7 @@ public class ListProjectsRequest extends com.oracle.bmc.requests.BmcRequest<java
         }
     };
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListWorkRequestErrorsRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListWorkRequestErrorsRequest.java
@@ -15,12 +15,12 @@ public class ListWorkRequestErrorsRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String workRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListWorkRequestLogsRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListWorkRequestLogsRequest.java
@@ -14,12 +14,12 @@ import com.oracle.bmc.datascience.model.*;
 public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the work request.
      */
     private String workRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListWorkRequestsRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/ListWorkRequestsRequest.java
@@ -14,12 +14,12 @@ import com.oracle.bmc.datascience.model.*;
 public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the compartment.
+     * <b>Filter</b> results by the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
      */
     private String compartmentId;
 
     /**
-     * <b>Filter</b> results by [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm). Must be an OCID of the correct type for the resource type.
+     * <b>Filter</b> results by [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm). Must be an OCID of the correct type for the resource type.
      *
      */
     private String id;
@@ -37,6 +37,11 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
         NotebookSessionDelete("NOTEBOOK_SESSION_DELETE"),
         NotebookSessionActivate("NOTEBOOK_SESSION_ACTIVATE"),
         NotebookSessionDeactivate("NOTEBOOK_SESSION_DEACTIVATE"),
+        ModelDeploymentCreate("MODEL_DEPLOYMENT_CREATE"),
+        ModelDeploymentDelete("MODEL_DEPLOYMENT_DELETE"),
+        ModelDeploymentActivate("MODEL_DEPLOYMENT_ACTIVATE"),
+        ModelDeploymentDeactivate("MODEL_DEPLOYMENT_DEACTIVATE"),
+        ModelDeploymentUpdate("MODEL_DEPLOYMENT_UPDATE"),
         ProjectDelete("PROJECT_DELETE"),
         WorkrequestCancel("WORKREQUEST_CANCEL"),
         ;
@@ -116,7 +121,7 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
      * For list pagination. The maximum number of results per page,
      * or items to return in a paginated \"List\" call.
      * 1 is the minimum, 1000 is the maximum.
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      * <p>
      * Example: `500`
      *
@@ -127,7 +132,7 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
      * For list pagination. The value of the `opc-next-page` response
      * header from the previous \"List\" call.
      * <p>
-     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/usingapi.htm#nine).
      *
      */
     private String page;
@@ -175,13 +180,13 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
         }
     };
     /**
-     * Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order.
+     * Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, the results are shown in descending order. All other fields default to ascending order.
      *
      */
     private SortBy sortBy;
 
     /**
-     * Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, results are shown in descending order. All other fields default to ascending order.
+     * Specifies the field to sort by. Accepts only one field. By default, when you sort by time fields, the results are shown in descending order. All other fields default to ascending order.
      *
      **/
     public enum SortBy {
@@ -218,7 +223,7 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
         }
     };
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateModelDeploymentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateModelDeploymentRequest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.requests;
+
+import com.oracle.bmc.datascience.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datascience/UpdateModelDeploymentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateModelDeploymentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateModelDeploymentRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateModelDeploymentDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model deployment.
+     */
+    private String modelDeploymentId;
+
+    /**
+     * Details for updating a model deployment. You can update `modelDeploymentConfigurationDetails` and change `instanceShapeName` and `modelId` when the model deployment is in
+     * the ACTIVE lifecycle state. The `bandwidthMbps` or `instanceCount` can only be updated while the model deployment is in the `INACTIVE` state. Changes to the `bandwidthMbps`
+     * or `instanceCount` will take effect the next time the `ActivateModelDeployment` action is invoked on the model deployment resource.
+     *
+     */
+    private UpdateModelDeploymentDetails updateModelDeploymentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource is updated or deleted only if the `etag` you
+     * provide matches the resource's current `etag` value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateModelDeploymentDetails getBody$() {
+        return updateModelDeploymentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateModelDeploymentRequest, UpdateModelDeploymentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateModelDeploymentRequest o) {
+            modelDeploymentId(o.getModelDeploymentId());
+            updateModelDeploymentDetails(o.getUpdateModelDeploymentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateModelDeploymentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateModelDeploymentRequest
+         */
+        public UpdateModelDeploymentRequest build() {
+            UpdateModelDeploymentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateModelDeploymentDetails body) {
+            updateModelDeploymentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateModelProvenanceRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateModelProvenanceRequest.java
@@ -15,7 +15,7 @@ public class UpdateModelProvenanceRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateModelProvenanceDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
@@ -25,7 +25,7 @@ public class UpdateModelProvenanceRequest
     private UpdateModelProvenanceDetails updateModelProvenanceDetails;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;
@@ -34,7 +34,7 @@ public class UpdateModelProvenanceRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateModelRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateModelRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.datascience.model.*;
 public class UpdateModelRequest extends com.oracle.bmc.requests.BmcRequest<UpdateModelDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the model.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the model.
      */
     private String modelId;
 
@@ -27,14 +27,14 @@ public class UpdateModelRequest extends com.oracle.bmc.requests.BmcRequest<Updat
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateNotebookSessionRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateNotebookSessionRequest.java
@@ -15,13 +15,13 @@ public class UpdateNotebookSessionRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateNotebookSessionDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the notebook session.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the notebook session.
      */
     private String notebookSessionId;
 
     /**
      * Details for updating a notebook session. `notebookSessionConfigurationDetails` can only be updated while the notebook session is in the `INACTIVE` state.
-     * Changes to the `notebookSessionConfigurationDetails` will take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
+     * Changes to the `notebookSessionConfigurationDetails` take effect the next time the `ActivateNotebookSession` action is invoked on the notebook session resource.
      *
      */
     private UpdateNotebookSessionDetails updateNotebookSessionDetails;
@@ -30,14 +30,14 @@ public class UpdateNotebookSessionRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateProjectRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateProjectRequest.java
@@ -14,7 +14,7 @@ import com.oracle.bmc.datascience.model.*;
 public class UpdateProjectRequest extends com.oracle.bmc.requests.BmcRequest<UpdateProjectDetails> {
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the project.
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the project.
      */
     private String projectId;
 
@@ -27,14 +27,14 @@ public class UpdateProjectRequest extends com.oracle.bmc.requests.BmcRequest<Upd
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the `if-match` parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the `etag` you
+     * The resource is updated or deleted only if the `etag` you
      * provide matches the resource's current `etag` value.
      *
      */
     private String ifMatch;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ActivateModelDeploymentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ActivateModelDeploymentResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.responses;
+
+import com.oracle.bmc.datascience.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ActivateModelDeploymentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ActivateModelDeploymentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ActivateModelResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ActivateModelResponse.java
@@ -22,8 +22,8 @@ public class ActivateModelResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ActivateNotebookSessionResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ActivateNotebookSessionResponse.java
@@ -23,8 +23,8 @@ public class ActivateNotebookSessionResponse {
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CancelWorkRequestResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CancelWorkRequestResponse.java
@@ -16,8 +16,8 @@ public class CancelWorkRequestResponse {
     private final int __httpStatusCode__;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ChangeModelCompartmentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ChangeModelCompartmentResponse.java
@@ -16,8 +16,8 @@ public class ChangeModelCompartmentResponse {
     private final int __httpStatusCode__;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ChangeModelDeploymentCompartmentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ChangeModelDeploymentCompartmentResponse.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.responses;
+
+import com.oracle.bmc.datascience.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ChangeModelDeploymentCompartmentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeModelDeploymentCompartmentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ChangeNotebookSessionCompartmentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ChangeNotebookSessionCompartmentResponse.java
@@ -16,8 +16,8 @@ public class ChangeNotebookSessionCompartmentResponse {
     private final int __httpStatusCode__;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ChangeProjectCompartmentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ChangeProjectCompartmentResponse.java
@@ -16,8 +16,8 @@ public class ChangeProjectCompartmentResponse {
     private final int __httpStatusCode__;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateModelArtifactResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateModelArtifactResponse.java
@@ -22,8 +22,8 @@ public class CreateModelArtifactResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateModelDeploymentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateModelDeploymentResponse.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.responses;
+
+import com.oracle.bmc.datascience.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateModelDeploymentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * The URI that identifies the entity described in the response body.
+     *
+     */
+    private String location;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned ModelDeployment instance.
+     */
+    private ModelDeployment modelDeployment;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateModelDeploymentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            location(o.getLocation());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            modelDeployment(o.getModelDeployment());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateModelProvenanceResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateModelProvenanceResponse.java
@@ -16,8 +16,8 @@ public class CreateModelProvenanceResponse {
     private final int __httpStatusCode__;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateModelResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateModelResponse.java
@@ -22,8 +22,8 @@ public class CreateModelResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateNotebookSessionResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateNotebookSessionResponse.java
@@ -28,8 +28,8 @@ public class CreateNotebookSessionResponse {
     private String location;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateProjectResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/CreateProjectResponse.java
@@ -22,8 +22,8 @@ public class CreateProjectResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeactivateModelDeploymentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeactivateModelDeploymentResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.responses;
+
+import com.oracle.bmc.datascience.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeactivateModelDeploymentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeactivateModelDeploymentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeactivateModelResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeactivateModelResponse.java
@@ -22,8 +22,8 @@ public class DeactivateModelResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeactivateNotebookSessionResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeactivateNotebookSessionResponse.java
@@ -23,8 +23,8 @@ public class DeactivateNotebookSessionResponse {
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeleteModelDeploymentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeleteModelDeploymentResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.responses;
+
+import com.oracle.bmc.datascience.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteModelDeploymentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteModelDeploymentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeleteModelResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeleteModelResponse.java
@@ -16,8 +16,8 @@ public class DeleteModelResponse {
     private final int __httpStatusCode__;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeleteNotebookSessionResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeleteNotebookSessionResponse.java
@@ -23,8 +23,8 @@ public class DeleteNotebookSessionResponse {
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeleteProjectResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/DeleteProjectResponse.java
@@ -23,8 +23,8 @@ public class DeleteProjectResponse {
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetModelArtifactContentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetModelArtifactContentResponse.java
@@ -22,8 +22,8 @@ public class GetModelArtifactContentResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetModelDeploymentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetModelDeploymentResponse.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.responses;
+
+import com.oracle.bmc.datascience.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetModelDeploymentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See [ETags for Optimistic Concurrency Control](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#eleven).
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ModelDeployment instance.
+     */
+    private ModelDeployment modelDeployment;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetModelDeploymentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            modelDeployment(o.getModelDeployment());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetModelProvenanceResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetModelProvenanceResponse.java
@@ -22,8 +22,8 @@ public class GetModelProvenanceResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetModelResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetModelResponse.java
@@ -22,8 +22,8 @@ public class GetModelResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetNotebookSessionResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetNotebookSessionResponse.java
@@ -22,8 +22,8 @@ public class GetNotebookSessionResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetProjectResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetProjectResponse.java
@@ -22,8 +22,8 @@ public class GetProjectResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetWorkRequestResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/GetWorkRequestResponse.java
@@ -22,8 +22,8 @@ public class GetWorkRequestResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/HeadModelArtifactResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/HeadModelArtifactResponse.java
@@ -22,8 +22,8 @@ public class HeadModelArtifactResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListModelDeploymentShapesResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListModelDeploymentShapesResponse.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.responses;
+
+import com.oracle.bmc.datascience.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListModelDeploymentShapesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of ModelDeploymentShapeSummary instances.
+     */
+    private java.util.List<ModelDeploymentShapeSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListModelDeploymentShapesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcPrevPage(o.getOpcPrevPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListModelDeploymentsResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListModelDeploymentsResponse.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.responses;
+
+import com.oracle.bmc.datascience.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListModelDeploymentsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Retrieves the next page of results. When this header appears in the response, additional pages of results remain. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Retrieves the previous page of results. When this header appears in the response, previous pages of results exist. See [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of ModelDeploymentSummary instances.
+     */
+    private java.util.List<ModelDeploymentSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListModelDeploymentsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcPrevPage(o.getOpcPrevPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListModelsResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListModelsResponse.java
@@ -28,8 +28,8 @@ public class ListModelsResponse {
     private String opcPrevPage;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListNotebookSessionShapesResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListNotebookSessionShapesResponse.java
@@ -28,8 +28,8 @@ public class ListNotebookSessionShapesResponse {
     private String opcPrevPage;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListNotebookSessionsResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListNotebookSessionsResponse.java
@@ -28,8 +28,8 @@ public class ListNotebookSessionsResponse {
     private String opcPrevPage;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListProjectsResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListProjectsResponse.java
@@ -28,8 +28,8 @@ public class ListProjectsResponse {
     private String opcPrevPage;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListWorkRequestErrorsResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListWorkRequestErrorsResponse.java
@@ -16,8 +16,8 @@ public class ListWorkRequestErrorsResponse {
     private final int __httpStatusCode__;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListWorkRequestLogsResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListWorkRequestLogsResponse.java
@@ -16,8 +16,8 @@ public class ListWorkRequestLogsResponse {
     private final int __httpStatusCode__;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListWorkRequestsResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/ListWorkRequestsResponse.java
@@ -28,8 +28,8 @@ public class ListWorkRequestsResponse {
     private String opcPrevPage;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateModelDeploymentResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateModelDeploymentResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.responses;
+
+import com.oracle.bmc.datascience.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateModelDeploymentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/identifiers.htm) of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateModelDeploymentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateModelProvenanceResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateModelProvenanceResponse.java
@@ -16,8 +16,8 @@ public class UpdateModelProvenanceResponse {
     private final int __httpStatusCode__;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateModelResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateModelResponse.java
@@ -22,8 +22,8 @@ public class UpdateModelResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateNotebookSessionResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateNotebookSessionResponse.java
@@ -22,8 +22,8 @@ public class UpdateNotebookSessionResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateProjectResponse.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/responses/UpdateProjectResponse.java
@@ -22,8 +22,8 @@ public class UpdateProjectResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
-     * Oracle about a particular request, please provide the request ID.
+     * Unique Oracle assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, then provide the request ID.
      *
      */
     private String opcRequestId;

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -25,17 +25,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/DownloadManagerExample.java
+++ b/bmc-examples/src/main/java/DownloadManagerExample.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.oracle.bmc.ConfigFileReader;
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.ObjectStorageClient;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import com.oracle.bmc.objectstorage.transfer.DownloadConfiguration;
+import com.oracle.bmc.objectstorage.transfer.DownloadManager;
+
+/**
+ * Example of using the DownloadManager to download objects.
+ * <p>
+ * DownloadManager can be configured to control how/when it does parallel uploads,
+ * and manages the underlying get requests and possible retries.
+ *
+ * Clients construct a GetObjectRequest similar to what they normally would.
+ */
+public class DownloadManagerExample {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 4) {
+            throw new IllegalArgumentException(
+                    "Syntax: java "
+                            + DownloadManagerExample.class.getName()
+                            + " <namespaceName> <bucketName> <objectName> <outputFileName>");
+        }
+
+        String namespaceName = args[0];
+        String bucketName = args[1];
+        String objectName = args[2];
+        String outputFileName = args[3];
+
+        String configurationFilePath = "~/.oci/config";
+        String profile = "DEFAULT";
+
+        // Configuring the AuthenticationDetailsProvider. It's assuming there is a default OCI config file
+        // "~/.oci/config", and a profile in that config with the name "DEFAULT". Make changes to the following
+        // line if needed and use ConfigFileReader.parse(CONFIG_LOCATION, CONFIG_PROFILE);
+
+        final ConfigFileReader.ConfigFile configFile = ConfigFileReader.parseDefault();
+
+        final ConfigFileAuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(configFile);
+
+        ObjectStorage client = new ObjectStorageClient(provider);
+        client.setRegion(Region.US_PHOENIX_1);
+
+        // configure download settings as desired
+        DownloadConfiguration downloadConfiguration =
+                DownloadConfiguration.builder()
+                        .parallelDownloads(3)
+                        .maxRetries(3)
+                        .multipartDownloadThresholdInBytes(6 * 1024 * 1024)
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .build();
+
+        DownloadManager downloadManager = new DownloadManager(client, downloadConfiguration);
+
+        GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+
+        // download request and print result
+        GetObjectResponse response = downloadManager.getObject(request);
+        System.out.println("Content length: " + response.getContentLength() + " bytes");
+
+        // use the stream contents; make sure to close the stream, e.g. by using try-with-resources
+        try (final InputStream stream = response.getInputStream();
+                final OutputStream outputStream = new FileOutputStream(outputFileName)) {
+            // use fileStream
+            byte[] buf = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = stream.read(buf)) > 0) {
+                outputStream.write(buf, 0, bytesRead);
+            }
+        } // try-with-resources automatically closes streams
+        System.out.println("File size: " + new File(outputFileName).length() + " bytes");
+
+        // or even simpler, if targetting a file:
+        response = downloadManager.downloadObjectToFile(request, new File(outputFileName));
+        System.out.println("Content length: " + response.getContentLength() + " bytes");
+        System.out.println("File size: " + new File(outputFileName).length() + " bytes");
+    }
+}

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.33.1</version>
+        <version>1.33.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancer.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancer.java
@@ -162,6 +162,18 @@ public interface LoadBalancer extends AutoCloseable {
     CreatePathRouteSetResponse createPathRouteSet(CreatePathRouteSetRequest request);
 
     /**
+     * Adds a routing policy to a load balancer. For more information, see
+     * [Managing Request Routing](https://docs.cloud.oracle.com/Content/Balance/Tasks/managingrequest.htm).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/CreateRoutingPolicyExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateRoutingPolicy API.
+     */
+    CreateRoutingPolicyResponse createRoutingPolicy(CreateRoutingPolicyRequest request);
+
+    /**
      * Creates a new rule set associated with the specified load balancer. For more information, see
      * [Managing Rule Sets](https://docs.cloud.oracle.com/Content/Balance/Tasks/managingrulesets.htm).
      *
@@ -260,6 +272,20 @@ public interface LoadBalancer extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/DeletePathRouteSetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeletePathRouteSet API.
      */
     DeletePathRouteSetResponse deletePathRouteSet(DeletePathRouteSetRequest request);
+
+    /**
+     * Deletes a routing policy from the specified load balancer.
+     * <p>
+     * To delete a routing rule from a routing policy, use the
+     * {@link #updateRoutingPolicy(UpdateRoutingPolicyRequest) updateRoutingPolicy} operation.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/DeleteRoutingPolicyExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteRoutingPolicy API.
+     */
+    DeleteRoutingPolicyResponse deleteRoutingPolicy(DeleteRoutingPolicyRequest request);
 
     /**
      * Deletes a rule set from the specified load balancer.
@@ -374,6 +400,16 @@ public interface LoadBalancer extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/GetPathRouteSetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPathRouteSet API.
      */
     GetPathRouteSetResponse getPathRouteSet(GetPathRouteSetRequest request);
+
+    /**
+     * Gets the specified routing policy.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/GetRoutingPolicyExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetRoutingPolicy API.
+     */
+    GetRoutingPolicyResponse getRoutingPolicy(GetRoutingPolicyRequest request);
 
     /**
      * Gets the specified set of rules.
@@ -511,6 +547,16 @@ public interface LoadBalancer extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/ListProtocolsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListProtocols API.
      */
     ListProtocolsResponse listProtocols(ListProtocolsRequest request);
+
+    /**
+     * Lists all routing policies associated with the specified load balancer.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/ListRoutingPoliciesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListRoutingPolicies API.
+     */
+    ListRoutingPoliciesResponse listRoutingPolicies(ListRoutingPoliciesRequest request);
 
     /**
      * Lists all rule sets associated with the specified load balancer.
@@ -656,6 +702,20 @@ public interface LoadBalancer extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/UpdatePathRouteSetExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdatePathRouteSet API.
      */
     UpdatePathRouteSetResponse updatePathRouteSet(UpdatePathRouteSetRequest request);
+
+    /**
+     * Overwrites an existing routing policy on the specified load balancer. Use this operation to add, delete, or alter
+     * routing policy rules in a routing policy.
+     * <p>
+     * To add a new routing rule to a routing policy, the body must include both the new routing rule to add and the existing rules to retain.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/UpdateRoutingPolicyExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateRoutingPolicy API.
+     */
+    UpdateRoutingPolicyResponse updateRoutingPolicy(UpdateRoutingPolicyRequest request);
 
     /**
      * Overwrites an existing set of rules on the specified load balancer. Use this operation to add or alter

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerAsync.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerAsync.java
@@ -207,6 +207,24 @@ public interface LoadBalancerAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Adds a routing policy to a load balancer. For more information, see
+     * [Managing Request Routing](https://docs.cloud.oracle.com/Content/Balance/Tasks/managingrequest.htm).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateRoutingPolicyResponse> createRoutingPolicy(
+            CreateRoutingPolicyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateRoutingPolicyRequest, CreateRoutingPolicyResponse>
+                    handler);
+
+    /**
      * Creates a new rule set associated with the specified load balancer. For more information, see
      * [Managing Rule Sets](https://docs.cloud.oracle.com/Content/Balance/Tasks/managingrulesets.htm).
      *
@@ -353,6 +371,26 @@ public interface LoadBalancerAsync extends AutoCloseable {
             DeletePathRouteSetRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             DeletePathRouteSetRequest, DeletePathRouteSetResponse>
+                    handler);
+
+    /**
+     * Deletes a routing policy from the specified load balancer.
+     * <p>
+     * To delete a routing rule from a routing policy, use the
+     * {@link #updateRoutingPolicy(UpdateRoutingPolicyRequest, Consumer, Consumer) updateRoutingPolicy} operation.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteRoutingPolicyResponse> deleteRoutingPolicy(
+            DeleteRoutingPolicyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteRoutingPolicyRequest, DeleteRoutingPolicyResponse>
                     handler);
 
     /**
@@ -523,6 +561,21 @@ public interface LoadBalancerAsync extends AutoCloseable {
     java.util.concurrent.Future<GetPathRouteSetResponse> getPathRouteSet(
             GetPathRouteSetRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetPathRouteSetRequest, GetPathRouteSetResponse>
+                    handler);
+
+    /**
+     * Gets the specified routing policy.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetRoutingPolicyResponse> getRoutingPolicy(
+            GetRoutingPolicyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetRoutingPolicyRequest, GetRoutingPolicyResponse>
                     handler);
 
     /**
@@ -729,6 +782,22 @@ public interface LoadBalancerAsync extends AutoCloseable {
     java.util.concurrent.Future<ListProtocolsResponse> listProtocols(
             ListProtocolsRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListProtocolsRequest, ListProtocolsResponse>
+                    handler);
+
+    /**
+     * Lists all routing policies associated with the specified load balancer.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListRoutingPoliciesResponse> listRoutingPolicies(
+            ListRoutingPoliciesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListRoutingPoliciesRequest, ListRoutingPoliciesResponse>
                     handler);
 
     /**
@@ -943,6 +1012,26 @@ public interface LoadBalancerAsync extends AutoCloseable {
             UpdatePathRouteSetRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             UpdatePathRouteSetRequest, UpdatePathRouteSetResponse>
+                    handler);
+
+    /**
+     * Overwrites an existing routing policy on the specified load balancer. Use this operation to add, delete, or alter
+     * routing policy rules in a routing policy.
+     * <p>
+     * To add a new routing rule to a routing policy, the body must include both the new routing rule to add and the existing rules to retain.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateRoutingPolicyResponse> updateRoutingPolicy(
+            UpdateRoutingPolicyRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateRoutingPolicyRequest, UpdateRoutingPolicyResponse>
                     handler);
 
     /**

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerAsyncClient.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerAsyncClient.java
@@ -687,6 +687,48 @@ public class LoadBalancerAsyncClient implements LoadBalancerAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreateRoutingPolicyResponse> createRoutingPolicy(
+            CreateRoutingPolicyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateRoutingPolicyRequest, CreateRoutingPolicyResponse>
+                    handler) {
+        LOG.trace("Called async createRoutingPolicy");
+        final CreateRoutingPolicyRequest interceptedRequest =
+                CreateRoutingPolicyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateRoutingPolicyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CreateRoutingPolicyResponse>
+                transformer = CreateRoutingPolicyConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CreateRoutingPolicyRequest, CreateRoutingPolicyResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateRoutingPolicyRequest, CreateRoutingPolicyResponse>,
+                        java.util.concurrent.Future<CreateRoutingPolicyResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateRoutingPolicyRequest, CreateRoutingPolicyResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateRuleSetResponse> createRuleSet(
             CreateRuleSetRequest request,
             final com.oracle.bmc.responses.AsyncHandler<CreateRuleSetRequest, CreateRuleSetResponse>
@@ -1026,6 +1068,47 @@ public class LoadBalancerAsyncClient implements LoadBalancerAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     DeletePathRouteSetRequest, DeletePathRouteSetResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteRoutingPolicyResponse> deleteRoutingPolicy(
+            DeleteRoutingPolicyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteRoutingPolicyRequest, DeleteRoutingPolicyResponse>
+                    handler) {
+        LOG.trace("Called async deleteRoutingPolicy");
+        final DeleteRoutingPolicyRequest interceptedRequest =
+                DeleteRoutingPolicyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteRoutingPolicyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteRoutingPolicyResponse>
+                transformer = DeleteRoutingPolicyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteRoutingPolicyRequest, DeleteRoutingPolicyResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteRoutingPolicyRequest, DeleteRoutingPolicyResponse>,
+                        java.util.concurrent.Future<DeleteRoutingPolicyResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteRoutingPolicyRequest, DeleteRoutingPolicyResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1456,6 +1539,45 @@ public class LoadBalancerAsyncClient implements LoadBalancerAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetPathRouteSetRequest, GetPathRouteSetResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetRoutingPolicyResponse> getRoutingPolicy(
+            GetRoutingPolicyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetRoutingPolicyRequest, GetRoutingPolicyResponse>
+                    handler) {
+        LOG.trace("Called async getRoutingPolicy");
+        final GetRoutingPolicyRequest interceptedRequest =
+                GetRoutingPolicyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetRoutingPolicyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetRoutingPolicyResponse>
+                transformer = GetRoutingPolicyConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetRoutingPolicyRequest, GetRoutingPolicyResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetRoutingPolicyRequest, GetRoutingPolicyResponse>,
+                        java.util.concurrent.Future<GetRoutingPolicyResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetRoutingPolicyRequest, GetRoutingPolicyResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1959,6 +2081,47 @@ public class LoadBalancerAsyncClient implements LoadBalancerAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListProtocolsRequest, ListProtocolsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListRoutingPoliciesResponse> listRoutingPolicies(
+            ListRoutingPoliciesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListRoutingPoliciesRequest, ListRoutingPoliciesResponse>
+                    handler) {
+        LOG.trace("Called async listRoutingPolicies");
+        final ListRoutingPoliciesRequest interceptedRequest =
+                ListRoutingPoliciesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListRoutingPoliciesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListRoutingPoliciesResponse>
+                transformer = ListRoutingPoliciesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListRoutingPoliciesRequest, ListRoutingPoliciesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListRoutingPoliciesRequest, ListRoutingPoliciesResponse>,
+                        java.util.concurrent.Future<ListRoutingPoliciesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListRoutingPoliciesRequest, ListRoutingPoliciesResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -2481,6 +2644,48 @@ public class LoadBalancerAsyncClient implements LoadBalancerAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     UpdatePathRouteSetRequest, UpdatePathRouteSetResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateRoutingPolicyResponse> updateRoutingPolicy(
+            UpdateRoutingPolicyRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateRoutingPolicyRequest, UpdateRoutingPolicyResponse>
+                    handler) {
+        LOG.trace("Called async updateRoutingPolicy");
+        final UpdateRoutingPolicyRequest interceptedRequest =
+                UpdateRoutingPolicyConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateRoutingPolicyConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateRoutingPolicyResponse>
+                transformer = UpdateRoutingPolicyConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateRoutingPolicyRequest, UpdateRoutingPolicyResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateRoutingPolicyRequest, UpdateRoutingPolicyResponse>,
+                        java.util.concurrent.Future<UpdateRoutingPolicyResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateRoutingPolicyRequest, UpdateRoutingPolicyResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerClient.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerClient.java
@@ -708,6 +708,39 @@ public class LoadBalancerClient implements LoadBalancer {
     }
 
     @Override
+    public CreateRoutingPolicyResponse createRoutingPolicy(CreateRoutingPolicyRequest request) {
+        LOG.trace("Called createRoutingPolicy");
+        final CreateRoutingPolicyRequest interceptedRequest =
+                CreateRoutingPolicyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateRoutingPolicyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateRoutingPolicyResponse>
+                transformer = CreateRoutingPolicyConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateRoutingPolicyDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateRuleSetResponse createRuleSet(CreateRuleSetRequest request) {
         LOG.trace("Called createRuleSet");
         final CreateRuleSetRequest interceptedRequest =
@@ -955,6 +988,35 @@ public class LoadBalancerClient implements LoadBalancer {
                 DeletePathRouteSetConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, DeletePathRouteSetResponse>
                 transformer = DeletePathRouteSetConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteRoutingPolicyResponse deleteRoutingPolicy(DeleteRoutingPolicyRequest request) {
+        LOG.trace("Called deleteRoutingPolicy");
+        final DeleteRoutingPolicyRequest interceptedRequest =
+                DeleteRoutingPolicyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteRoutingPolicyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteRoutingPolicyResponse>
+                transformer = DeleteRoutingPolicyConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1266,6 +1328,34 @@ public class LoadBalancerClient implements LoadBalancer {
                 GetPathRouteSetConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetPathRouteSetResponse>
                 transformer = GetPathRouteSetConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetRoutingPolicyResponse getRoutingPolicy(GetRoutingPolicyRequest request) {
+        LOG.trace("Called getRoutingPolicy");
+        final GetRoutingPolicyRequest interceptedRequest =
+                GetRoutingPolicyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetRoutingPolicyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetRoutingPolicyResponse>
+                transformer = GetRoutingPolicyConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1630,6 +1720,34 @@ public class LoadBalancerClient implements LoadBalancer {
                 ListProtocolsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListProtocolsResponse>
                 transformer = ListProtocolsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListRoutingPoliciesResponse listRoutingPolicies(ListRoutingPoliciesRequest request) {
+        LOG.trace("Called listRoutingPolicies");
+        final ListRoutingPoliciesRequest interceptedRequest =
+                ListRoutingPoliciesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListRoutingPoliciesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListRoutingPoliciesResponse>
+                transformer = ListRoutingPoliciesConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -2054,6 +2172,39 @@ public class LoadBalancerClient implements LoadBalancer {
                                         client.put(
                                                 ib,
                                                 retriedRequest.getUpdatePathRouteSetDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateRoutingPolicyResponse updateRoutingPolicy(UpdateRoutingPolicyRequest request) {
+        LOG.trace("Called updateRoutingPolicy");
+        final UpdateRoutingPolicyRequest interceptedRequest =
+                UpdateRoutingPolicyConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateRoutingPolicyConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateRoutingPolicyResponse>
+                transformer = UpdateRoutingPolicyConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateRoutingPolicyDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerPaginators.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/LoadBalancerPaginators.java
@@ -482,6 +482,119 @@ public class LoadBalancerPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listRoutingPolicies operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListRoutingPoliciesResponse> listRoutingPoliciesResponseIterator(
+            final ListRoutingPoliciesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListRoutingPoliciesRequest.Builder, ListRoutingPoliciesRequest,
+                ListRoutingPoliciesResponse>(
+                new com.google.common.base.Supplier<ListRoutingPoliciesRequest.Builder>() {
+                    @Override
+                    public ListRoutingPoliciesRequest.Builder get() {
+                        return ListRoutingPoliciesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListRoutingPoliciesResponse, String>() {
+                    @Override
+                    public String apply(ListRoutingPoliciesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListRoutingPoliciesRequest.Builder>,
+                        ListRoutingPoliciesRequest>() {
+                    @Override
+                    public ListRoutingPoliciesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListRoutingPoliciesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRoutingPoliciesRequest, ListRoutingPoliciesResponse>() {
+                    @Override
+                    public ListRoutingPoliciesResponse apply(ListRoutingPoliciesRequest request) {
+                        return client.listRoutingPolicies(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.loadbalancer.model.RoutingPolicy} objects
+     * contained in responses from the listRoutingPolicies operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.loadbalancer.model.RoutingPolicy} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.loadbalancer.model.RoutingPolicy>
+            listRoutingPoliciesRecordIterator(final ListRoutingPoliciesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListRoutingPoliciesRequest.Builder, ListRoutingPoliciesRequest,
+                ListRoutingPoliciesResponse, com.oracle.bmc.loadbalancer.model.RoutingPolicy>(
+                new com.google.common.base.Supplier<ListRoutingPoliciesRequest.Builder>() {
+                    @Override
+                    public ListRoutingPoliciesRequest.Builder get() {
+                        return ListRoutingPoliciesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListRoutingPoliciesResponse, String>() {
+                    @Override
+                    public String apply(ListRoutingPoliciesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListRoutingPoliciesRequest.Builder>,
+                        ListRoutingPoliciesRequest>() {
+                    @Override
+                    public ListRoutingPoliciesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListRoutingPoliciesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRoutingPoliciesRequest, ListRoutingPoliciesResponse>() {
+                    @Override
+                    public ListRoutingPoliciesResponse apply(ListRoutingPoliciesRequest request) {
+                        return client.listRoutingPolicies(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRoutingPoliciesResponse,
+                        java.util.List<com.oracle.bmc.loadbalancer.model.RoutingPolicy>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.loadbalancer.model.RoutingPolicy> apply(
+                            ListRoutingPoliciesResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listShapes operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/CreateRoutingPolicyConverter.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/CreateRoutingPolicyConverter.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loadbalancer.model.*;
+import com.oracle.bmc.loadbalancer.requests.*;
+import com.oracle.bmc.loadbalancer.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.extern.slf4j.Slf4j
+public class CreateRoutingPolicyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loadbalancer.requests.CreateRoutingPolicyRequest interceptRequest(
+            com.oracle.bmc.loadbalancer.requests.CreateRoutingPolicyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loadbalancer.requests.CreateRoutingPolicyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateRoutingPolicyDetails(), "createRoutingPolicyDetails is required");
+        Validate.notBlank(request.getLoadBalancerId(), "loadBalancerId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20170115")
+                        .path("loadBalancers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLoadBalancerId()))
+                        .path("routingPolicies");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loadbalancer.responses.CreateRoutingPolicyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loadbalancer.responses.CreateRoutingPolicyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loadbalancer.responses
+                                        .CreateRoutingPolicyResponse>() {
+                            @Override
+                            public com.oracle.bmc.loadbalancer.responses.CreateRoutingPolicyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loadbalancer.responses.CreateRoutingPolicyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loadbalancer.responses.CreateRoutingPolicyResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loadbalancer.responses
+                                                        .CreateRoutingPolicyResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loadbalancer.responses.CreateRoutingPolicyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/DeleteRoutingPolicyConverter.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/DeleteRoutingPolicyConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loadbalancer.model.*;
+import com.oracle.bmc.loadbalancer.requests.*;
+import com.oracle.bmc.loadbalancer.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.extern.slf4j.Slf4j
+public class DeleteRoutingPolicyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loadbalancer.requests.DeleteRoutingPolicyRequest interceptRequest(
+            com.oracle.bmc.loadbalancer.requests.DeleteRoutingPolicyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loadbalancer.requests.DeleteRoutingPolicyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getLoadBalancerId(), "loadBalancerId must not be blank");
+        Validate.notBlank(request.getRoutingPolicyName(), "routingPolicyName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20170115")
+                        .path("loadBalancers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLoadBalancerId()))
+                        .path("routingPolicies")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRoutingPolicyName()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loadbalancer.responses.DeleteRoutingPolicyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loadbalancer.responses.DeleteRoutingPolicyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loadbalancer.responses
+                                        .DeleteRoutingPolicyResponse>() {
+                            @Override
+                            public com.oracle.bmc.loadbalancer.responses.DeleteRoutingPolicyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loadbalancer.responses.DeleteRoutingPolicyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loadbalancer.responses.DeleteRoutingPolicyResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loadbalancer.responses
+                                                        .DeleteRoutingPolicyResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loadbalancer.responses.DeleteRoutingPolicyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/GetRoutingPolicyConverter.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/GetRoutingPolicyConverter.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loadbalancer.model.*;
+import com.oracle.bmc.loadbalancer.requests.*;
+import com.oracle.bmc.loadbalancer.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.extern.slf4j.Slf4j
+public class GetRoutingPolicyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loadbalancer.requests.GetRoutingPolicyRequest interceptRequest(
+            com.oracle.bmc.loadbalancer.requests.GetRoutingPolicyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loadbalancer.requests.GetRoutingPolicyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getLoadBalancerId(), "loadBalancerId must not be blank");
+        Validate.notBlank(request.getRoutingPolicyName(), "routingPolicyName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20170115")
+                        .path("loadBalancers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLoadBalancerId()))
+                        .path("routingPolicies")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRoutingPolicyName()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loadbalancer.responses.GetRoutingPolicyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loadbalancer.responses.GetRoutingPolicyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loadbalancer.responses.GetRoutingPolicyResponse>() {
+                            @Override
+                            public com.oracle.bmc.loadbalancer.responses.GetRoutingPolicyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loadbalancer.responses.GetRoutingPolicyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        RoutingPolicy>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        RoutingPolicy.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<RoutingPolicy> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loadbalancer.responses.GetRoutingPolicyResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loadbalancer.responses
+                                                        .GetRoutingPolicyResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.routingPolicy(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loadbalancer.responses.GetRoutingPolicyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/ListRoutingPoliciesConverter.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/ListRoutingPoliciesConverter.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loadbalancer.model.*;
+import com.oracle.bmc.loadbalancer.requests.*;
+import com.oracle.bmc.loadbalancer.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.extern.slf4j.Slf4j
+public class ListRoutingPoliciesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loadbalancer.requests.ListRoutingPoliciesRequest interceptRequest(
+            com.oracle.bmc.loadbalancer.requests.ListRoutingPoliciesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loadbalancer.requests.ListRoutingPoliciesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getLoadBalancerId(), "loadBalancerId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20170115")
+                        .path("loadBalancers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLoadBalancerId()))
+                        .path("routingPolicies");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loadbalancer.responses.ListRoutingPoliciesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loadbalancer.responses.ListRoutingPoliciesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loadbalancer.responses
+                                        .ListRoutingPoliciesResponse>() {
+                            @Override
+                            public com.oracle.bmc.loadbalancer.responses.ListRoutingPoliciesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loadbalancer.responses.ListRoutingPoliciesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<RoutingPolicy>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        RoutingPolicy>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<RoutingPolicy>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loadbalancer.responses.ListRoutingPoliciesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loadbalancer.responses
+                                                        .ListRoutingPoliciesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loadbalancer.responses.ListRoutingPoliciesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/UpdateRoutingPolicyConverter.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/internal/http/UpdateRoutingPolicyConverter.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loadbalancer.model.*;
+import com.oracle.bmc.loadbalancer.requests.*;
+import com.oracle.bmc.loadbalancer.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.extern.slf4j.Slf4j
+public class UpdateRoutingPolicyConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loadbalancer.requests.UpdateRoutingPolicyRequest interceptRequest(
+            com.oracle.bmc.loadbalancer.requests.UpdateRoutingPolicyRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loadbalancer.requests.UpdateRoutingPolicyRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getUpdateRoutingPolicyDetails(), "updateRoutingPolicyDetails is required");
+        Validate.notBlank(request.getLoadBalancerId(), "loadBalancerId must not be blank");
+        Validate.notBlank(request.getRoutingPolicyName(), "routingPolicyName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20170115")
+                        .path("loadBalancers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getLoadBalancerId()))
+                        .path("routingPolicies")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRoutingPolicyName()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loadbalancer.responses.UpdateRoutingPolicyResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loadbalancer.responses.UpdateRoutingPolicyResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loadbalancer.responses
+                                        .UpdateRoutingPolicyResponse>() {
+                            @Override
+                            public com.oracle.bmc.loadbalancer.responses.UpdateRoutingPolicyResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loadbalancer.responses.UpdateRoutingPolicyResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loadbalancer.responses.UpdateRoutingPolicyResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loadbalancer.responses
+                                                        .UpdateRoutingPolicyResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loadbalancer.responses.UpdateRoutingPolicyResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Action.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Action.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.model;
+
+/**
+ * An entity that represents an action to apply for a routing rule.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "name",
+    defaultImpl = Action.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ForwardToBackendSet.class,
+        name = "FORWARD_TO_BACKENDSET"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class Action {
+
+    /**
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Name {
+        ForwardToBackendset("FORWARD_TO_BACKENDSET"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Name> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Name v : Name.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Name(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Name create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Name', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/AddHttpRequestHeaderRule.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/AddHttpRequestHeaderRule.java
@@ -12,8 +12,6 @@ package com.oracle.bmc.loadbalancer.model;
  *  If a matching header already exists in the request, the system removes all of its occurrences, and then adds the
  *    new header.
  * <p>
- * If a customer adds empty value, it has the same effect as dropping that header.
- * <p>
  *  The system does not distinquish between underscore and dash characters in headers. That is, it treats
  *   `example_header_name` and `example-header-name` as identical. Oracle recommends that you do not rely on underscore
  *   or dash characters to uniquely distinguish header names.
@@ -104,7 +102,9 @@ public class AddHttpRequestHeaderRule extends Rule {
     String header;
 
     /**
-     * A header value that conforms to RFC 7230.
+     * A header value that conforms to RFC 7230. With the following exceptions:
+     * *  value cannot contain `$`
+     * *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
      * <p>
      * Example: `example_value`
      *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/AddHttpResponseHeaderRule.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/AddHttpResponseHeaderRule.java
@@ -104,6 +104,9 @@ public class AddHttpResponseHeaderRule extends Rule {
 
     /**
      * A header value that conforms to RFC 7230.
+     * With the following exceptions:
+     * *  value cannot contain `$`
+     * *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
      * <p>
      * Example: `example_value`
      *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateListenerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateListenerDetails.java
@@ -103,6 +103,15 @@ public class CreateListenerDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("routingPolicyName")
+        private String routingPolicyName;
+
+        public Builder routingPolicyName(String routingPolicyName) {
+            this.routingPolicyName = routingPolicyName;
+            this.__explicitlySet__.add("routingPolicyName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("ruleSetNames")
         private java.util.List<String> ruleSetNames;
 
@@ -126,6 +135,7 @@ public class CreateListenerDetails {
                             sslConfiguration,
                             connectionConfiguration,
                             name,
+                            routingPolicyName,
                             ruleSetNames);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -142,6 +152,7 @@ public class CreateListenerDetails {
                             .sslConfiguration(o.getSslConfiguration())
                             .connectionConfiguration(o.getConnectionConfiguration())
                             .name(o.getName())
+                            .routingPolicyName(o.getRoutingPolicyName())
                             .ruleSetNames(o.getRuleSetNames());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -192,6 +203,8 @@ public class CreateListenerDetails {
     java.util.List<String> hostnameNames;
 
     /**
+     * Deprecated. Please use `routingPolicies` instead.
+     * <p>
      * The name of the set of path-based routing rules, {@link PathRouteSet},
      * applied to this listener's traffic.
      * <p>
@@ -216,6 +229,15 @@ public class CreateListenerDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
+
+    /**
+     * The name of the routing policy applied to this listener's traffic.
+     * <p>
+     * Example: `example_routing_policy`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("routingPolicyName")
+    String routingPolicyName;
 
     /**
      * The names of the {@link RuleSet} to apply to the listener.

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateRoutingPolicyDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/CreateRoutingPolicyDetails.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.model;
+
+/**
+ * An ordered list of routing rules.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateRoutingPolicyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateRoutingPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("conditionLanguageVersion")
+        private ConditionLanguageVersion conditionLanguageVersion;
+
+        public Builder conditionLanguageVersion(ConditionLanguageVersion conditionLanguageVersion) {
+            this.conditionLanguageVersion = conditionLanguageVersion;
+            this.__explicitlySet__.add("conditionLanguageVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rules")
+        private java.util.List<RoutingRule> rules;
+
+        public Builder rules(java.util.List<RoutingRule> rules) {
+            this.rules = rules;
+            this.__explicitlySet__.add("rules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateRoutingPolicyDetails build() {
+            CreateRoutingPolicyDetails __instance__ =
+                    new CreateRoutingPolicyDetails(name, conditionLanguageVersion, rules);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateRoutingPolicyDetails o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .conditionLanguageVersion(o.getConditionLanguageVersion())
+                            .rules(o.getRules());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name for this list of routing rules. It must be unique and it cannot be changed. Avoid entering
+     * confidential information.
+     * <p>
+     * Example: `example_routing_rules`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+    /**
+     * The version of the language in which `condition` of `rules` are composed.
+     *
+     **/
+    public enum ConditionLanguageVersion {
+        V1("V1"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ConditionLanguageVersion> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ConditionLanguageVersion v : ConditionLanguageVersion.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ConditionLanguageVersion(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ConditionLanguageVersion create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ConditionLanguageVersion: " + key);
+        }
+    };
+    /**
+     * The version of the language in which `condition` of `rules` are composed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("conditionLanguageVersion")
+    ConditionLanguageVersion conditionLanguageVersion;
+
+    /**
+     * The list of routing rules.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rules")
+    java.util.List<RoutingRule> rules;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ExtendHttpRequestHeaderValueRule.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ExtendHttpRequestHeaderValueRule.java
@@ -119,6 +119,9 @@ public class ExtendHttpRequestHeaderValueRule extends Rule {
 
     /**
      * A string to prepend to the header value. The resulting header value must conform to RFC 7230.
+     * With the following exceptions:
+     * *  value cannot contain `$`
+     * *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
      * <p>
      * Example: `example_prefix_value`
      *
@@ -128,6 +131,9 @@ public class ExtendHttpRequestHeaderValueRule extends Rule {
 
     /**
      * A string to append to the header value. The resulting header value must conform to RFC 7230.
+     * With the following exceptions:
+     * *  value cannot contain `$`
+     * *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
      * <p>
      * Example: `example_suffix_value`
      *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ExtendHttpResponseHeaderValueRule.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ExtendHttpResponseHeaderValueRule.java
@@ -119,6 +119,9 @@ public class ExtendHttpResponseHeaderValueRule extends Rule {
 
     /**
      * A string to prepend to the header value. The resulting header value must still conform to RFC 7230.
+     * With the following exceptions:
+     * *  value cannot contain `$`
+     * *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
      * <p>
      * Example: `example_prefix_value`
      *
@@ -128,6 +131,9 @@ public class ExtendHttpResponseHeaderValueRule extends Rule {
 
     /**
      * A string to append to the header value. The resulting header value must still conform to RFC 7230.
+     * With the following exceptions:
+     * *  value cannot contain `$`
+     * *  value cannot contain patterns like `{variable_name}`. They are reserved for future extensions. Currently, such values are invalid.
      * <p>
      * Example: `example_suffix_value`
      *

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ForwardToBackendSet.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ForwardToBackendSet.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.model;
+
+/**
+ * Action to forward requests to a given backend set.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ForwardToBackendSet.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "name"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ForwardToBackendSet extends Action {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("backendSetName")
+        private String backendSetName;
+
+        public Builder backendSetName(String backendSetName) {
+            this.backendSetName = backendSetName;
+            this.__explicitlySet__.add("backendSetName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ForwardToBackendSet build() {
+            ForwardToBackendSet __instance__ = new ForwardToBackendSet(backendSetName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ForwardToBackendSet o) {
+            Builder copiedBuilder = backendSetName(o.getBackendSetName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ForwardToBackendSet(String backendSetName) {
+        super();
+        this.backendSetName = backendSetName;
+    }
+
+    /**
+     * Name of the backend set the listener will forward the traffic to.
+     * <p>
+     * Example: `backendSetForImages`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("backendSetName")
+    String backendSetName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Listener.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/Listener.java
@@ -108,6 +108,15 @@ public class Listener {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("routingPolicyName")
+        private String routingPolicyName;
+
+        public Builder routingPolicyName(String routingPolicyName) {
+            this.routingPolicyName = routingPolicyName;
+            this.__explicitlySet__.add("routingPolicyName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -122,7 +131,8 @@ public class Listener {
                             pathRouteSetName,
                             sslConfiguration,
                             connectionConfiguration,
-                            ruleSetNames);
+                            ruleSetNames,
+                            routingPolicyName);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -138,7 +148,8 @@ public class Listener {
                             .pathRouteSetName(o.getPathRouteSetName())
                             .sslConfiguration(o.getSslConfiguration())
                             .connectionConfiguration(o.getConnectionConfiguration())
-                            .ruleSetNames(o.getRuleSetNames());
+                            .ruleSetNames(o.getRuleSetNames())
+                            .routingPolicyName(o.getRoutingPolicyName());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -197,6 +208,8 @@ public class Listener {
     java.util.List<String> hostnameNames;
 
     /**
+     * Deprecated. Please use `routingPolicies` instead.
+     * <p>
      * The name of the set of path-based routing rules, {@link PathRouteSet},
      * applied to this listener's traffic.
      * <p>
@@ -220,6 +233,15 @@ public class Listener {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("ruleSetNames")
     java.util.List<String> ruleSetNames;
+
+    /**
+     * The name of the routing policy applied to this listener's traffic.
+     * <p>
+     * Example: `example_routing_policy_name`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("routingPolicyName")
+    String routingPolicyName;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ListenerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/ListenerDetails.java
@@ -87,6 +87,15 @@ public class ListenerDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("routingPolicyName")
+        private String routingPolicyName;
+
+        public Builder routingPolicyName(String routingPolicyName) {
+            this.routingPolicyName = routingPolicyName;
+            this.__explicitlySet__.add("routingPolicyName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("ruleSetNames")
         private java.util.List<String> ruleSetNames;
 
@@ -109,6 +118,7 @@ public class ListenerDetails {
                             pathRouteSetName,
                             sslConfiguration,
                             connectionConfiguration,
+                            routingPolicyName,
                             ruleSetNames);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -124,6 +134,7 @@ public class ListenerDetails {
                             .pathRouteSetName(o.getPathRouteSetName())
                             .sslConfiguration(o.getSslConfiguration())
                             .connectionConfiguration(o.getConnectionConfiguration())
+                            .routingPolicyName(o.getRoutingPolicyName())
                             .ruleSetNames(o.getRuleSetNames());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -174,6 +185,8 @@ public class ListenerDetails {
     java.util.List<String> hostnameNames;
 
     /**
+     * Deprecated. Please use `routingPolicies` instead.
+     * <p>
      * The name of the set of path-based routing rules, {@link PathRouteSet},
      * applied to this listener's traffic.
      * <p>
@@ -188,6 +201,15 @@ public class ListenerDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("connectionConfiguration")
     ConnectionConfiguration connectionConfiguration;
+
+    /**
+     * The name of the routing policy applied to this listener's traffic.
+     * <p>
+     * Example: `example_routing_policy`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("routingPolicyName")
+    String routingPolicyName;
 
     /**
      * The names of the {@link RuleSet} to apply to the listener.

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancer.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/LoadBalancer.java
@@ -224,6 +224,15 @@ public class LoadBalancer {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("routingPolicies")
+        private java.util.Map<String, RoutingPolicy> routingPolicies;
+
+        public Builder routingPolicies(java.util.Map<String, RoutingPolicy> routingPolicies) {
+            this.routingPolicies = routingPolicies;
+            this.__explicitlySet__.add("routingPolicies");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -250,7 +259,8 @@ public class LoadBalancer {
                             freeformTags,
                             definedTags,
                             systemTags,
-                            ruleSets);
+                            ruleSets,
+                            routingPolicies);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -278,7 +288,8 @@ public class LoadBalancer {
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .systemTags(o.getSystemTags())
-                            .ruleSets(o.getRuleSets());
+                            .ruleSets(o.getRuleSets())
+                            .routingPolicies(o.getRoutingPolicies());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -492,6 +503,9 @@ public class LoadBalancer {
 
     @com.fasterxml.jackson.annotation.JsonProperty("ruleSets")
     java.util.Map<String, RuleSet> ruleSets;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("routingPolicies")
+    java.util.Map<String, RoutingPolicy> routingPolicies;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/RoutingPolicy.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/RoutingPolicy.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.model;
+
+/**
+ * A named ordered list of routing rules that is applied to a listener.
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = RoutingPolicy.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RoutingPolicy {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("conditionLanguageVersion")
+        private ConditionLanguageVersion conditionLanguageVersion;
+
+        public Builder conditionLanguageVersion(ConditionLanguageVersion conditionLanguageVersion) {
+            this.conditionLanguageVersion = conditionLanguageVersion;
+            this.__explicitlySet__.add("conditionLanguageVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rules")
+        private java.util.List<RoutingRule> rules;
+
+        public Builder rules(java.util.List<RoutingRule> rules) {
+            this.rules = rules;
+            this.__explicitlySet__.add("rules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RoutingPolicy build() {
+            RoutingPolicy __instance__ = new RoutingPolicy(name, conditionLanguageVersion, rules);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RoutingPolicy o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .conditionLanguageVersion(o.getConditionLanguageVersion())
+                            .rules(o.getRules());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique name for this list of routing rules. Avoid entering confidential information.
+     * <p>
+     * Example: `example_routing_policy`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+    /**
+     * The version of the language in which `condition` of `rules` are composed.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ConditionLanguageVersion {
+        V1("V1"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ConditionLanguageVersion> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ConditionLanguageVersion v : ConditionLanguageVersion.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ConditionLanguageVersion(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ConditionLanguageVersion create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ConditionLanguageVersion', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The version of the language in which `condition` of `rules` are composed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("conditionLanguageVersion")
+    ConditionLanguageVersion conditionLanguageVersion;
+
+    /**
+     * The ordered list of routing rules.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rules")
+    java.util.List<RoutingRule> rules;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/RoutingPolicyDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/RoutingPolicyDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.model;
+
+/**
+ * An ordered list of routing rules.
+ * **Warning:** Oracle recommends that you avoid using any confidential information when you supply string values using the API.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RoutingPolicyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RoutingPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("rules")
+        private java.util.List<RoutingRule> rules;
+
+        public Builder rules(java.util.List<RoutingRule> rules) {
+            this.rules = rules;
+            this.__explicitlySet__.add("rules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RoutingPolicyDetails build() {
+            RoutingPolicyDetails __instance__ = new RoutingPolicyDetails(rules);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RoutingPolicyDetails o) {
+            Builder copiedBuilder = rules(o.getRules());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The list of routing rules.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rules")
+    java.util.List<RoutingRule> rules;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/RoutingRule.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/RoutingRule.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.model;
+
+/**
+ * A routing rule examines an incoming request, routing matching requests to the specified backend set.
+ * Routing rules apply only to HTTP and HTTPS requests. They have no effect on TCP requests.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = RoutingRule.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RoutingRule {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("condition")
+        private String condition;
+
+        public Builder condition(String condition) {
+            this.condition = condition;
+            this.__explicitlySet__.add("condition");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("actions")
+        private java.util.List<Action> actions;
+
+        public Builder actions(java.util.List<Action> actions) {
+            this.actions = actions;
+            this.__explicitlySet__.add("actions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RoutingRule build() {
+            RoutingRule __instance__ = new RoutingRule(name, condition, actions);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RoutingRule o) {
+            Builder copiedBuilder =
+                    name(o.getName()).condition(o.getCondition()).actions(o.getActions());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A unique name for the routing policy rule. Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * A routing rule to evaluate defined conditions against the incoming HTTP request and perform an action.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("condition")
+    String condition;
+
+    /**
+     * A list of actions to be applied when conditions of the routing rule are met.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("actions")
+    java.util.List<Action> actions;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/SourceIpAddressCondition.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/SourceIpAddressCondition.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.loadbalancer.model;
 
 /**
- * An access control rule condition that requires a match on the specified source IP address or address range.
+ * A rule condition that checks client source IP against specified IP address or address range.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateListenerDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateListenerDetails.java
@@ -71,6 +71,15 @@ public class UpdateListenerDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("routingPolicyName")
+        private String routingPolicyName;
+
+        public Builder routingPolicyName(String routingPolicyName) {
+            this.routingPolicyName = routingPolicyName;
+            this.__explicitlySet__.add("routingPolicyName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sslConfiguration")
         private SSLConfigurationDetails sslConfiguration;
 
@@ -109,6 +118,7 @@ public class UpdateListenerDetails {
                             protocol,
                             hostnameNames,
                             pathRouteSetName,
+                            routingPolicyName,
                             sslConfiguration,
                             connectionConfiguration,
                             ruleSetNames);
@@ -124,6 +134,7 @@ public class UpdateListenerDetails {
                             .protocol(o.getProtocol())
                             .hostnameNames(o.getHostnameNames())
                             .pathRouteSetName(o.getPathRouteSetName())
+                            .routingPolicyName(o.getRoutingPolicyName())
                             .sslConfiguration(o.getSslConfiguration())
                             .connectionConfiguration(o.getConnectionConfiguration())
                             .ruleSetNames(o.getRuleSetNames());
@@ -176,6 +187,8 @@ public class UpdateListenerDetails {
     java.util.List<String> hostnameNames;
 
     /**
+     * Deprecated. Please use `routingPolicies` instead.
+     * <p>
      * The name of the set of path-based routing rules, {@link PathRouteSet},
      * applied to this listener's traffic.
      * <p>
@@ -184,6 +197,15 @@ public class UpdateListenerDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pathRouteSetName")
     String pathRouteSetName;
+
+    /**
+     * The name of the routing policy applied to this listener's traffic.
+     * <p>
+     * Example: `example_routing_policy`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("routingPolicyName")
+    String routingPolicyName;
 
     @com.fasterxml.jackson.annotation.JsonProperty("sslConfiguration")
     SSLConfigurationDetails sslConfiguration;

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateRoutingPolicyDetails.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/model/UpdateRoutingPolicyDetails.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.model;
+
+/**
+ * An updated list of routing rules that overwrites the existing list of routing rules.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateRoutingPolicyDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateRoutingPolicyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("conditionLanguageVersion")
+        private ConditionLanguageVersion conditionLanguageVersion;
+
+        public Builder conditionLanguageVersion(ConditionLanguageVersion conditionLanguageVersion) {
+            this.conditionLanguageVersion = conditionLanguageVersion;
+            this.__explicitlySet__.add("conditionLanguageVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("rules")
+        private java.util.List<RoutingRule> rules;
+
+        public Builder rules(java.util.List<RoutingRule> rules) {
+            this.rules = rules;
+            this.__explicitlySet__.add("rules");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateRoutingPolicyDetails build() {
+            UpdateRoutingPolicyDetails __instance__ =
+                    new UpdateRoutingPolicyDetails(conditionLanguageVersion, rules);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateRoutingPolicyDetails o) {
+            Builder copiedBuilder =
+                    conditionLanguageVersion(o.getConditionLanguageVersion()).rules(o.getRules());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The version of the language in which `condition` of `rules` are composed.
+     *
+     **/
+    public enum ConditionLanguageVersion {
+        V1("V1"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ConditionLanguageVersion> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ConditionLanguageVersion v : ConditionLanguageVersion.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ConditionLanguageVersion(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ConditionLanguageVersion create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ConditionLanguageVersion: " + key);
+        }
+    };
+    /**
+     * The version of the language in which `condition` of `rules` are composed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("conditionLanguageVersion")
+    ConditionLanguageVersion conditionLanguageVersion;
+
+    /**
+     * The list of routing rules.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("rules")
+    java.util.List<RoutingRule> rules;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/CreateRoutingPolicyRequest.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/CreateRoutingPolicyRequest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.requests;
+
+import com.oracle.bmc.loadbalancer.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/CreateRoutingPolicyExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateRoutingPolicyRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class CreateRoutingPolicyRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateRoutingPolicyDetails> {
+
+    /**
+     * The details of the routing policy rules to add.
+     */
+    private CreateRoutingPolicyDetails createRoutingPolicyDetails;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the load balancer to add the routing policy rule list to.
+     */
+    private String loadBalancerId;
+
+    /**
+     * The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateRoutingPolicyDetails getBody$() {
+        return createRoutingPolicyDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateRoutingPolicyRequest, CreateRoutingPolicyDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateRoutingPolicyRequest o) {
+            createRoutingPolicyDetails(o.getCreateRoutingPolicyDetails());
+            loadBalancerId(o.getLoadBalancerId());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateRoutingPolicyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateRoutingPolicyRequest
+         */
+        public CreateRoutingPolicyRequest build() {
+            CreateRoutingPolicyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateRoutingPolicyDetails body) {
+            createRoutingPolicyDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/DeleteRoutingPolicyRequest.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/DeleteRoutingPolicyRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.requests;
+
+import com.oracle.bmc.loadbalancer.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/DeleteRoutingPolicyExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteRoutingPolicyRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class DeleteRoutingPolicyRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the load balancer associated with the routing policy to delete.
+     */
+    private String loadBalancerId;
+
+    /**
+     * The name of the routing policy to delete.
+     * <p>
+     * Example: `example_routing_policy`
+     *
+     */
+    private String routingPolicyName;
+
+    /**
+     * The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteRoutingPolicyRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteRoutingPolicyRequest o) {
+            loadBalancerId(o.getLoadBalancerId());
+            routingPolicyName(o.getRoutingPolicyName());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteRoutingPolicyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteRoutingPolicyRequest
+         */
+        public DeleteRoutingPolicyRequest build() {
+            DeleteRoutingPolicyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/GetRoutingPolicyRequest.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/GetRoutingPolicyRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.requests;
+
+import com.oracle.bmc.loadbalancer.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/GetRoutingPolicyExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetRoutingPolicyRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class GetRoutingPolicyRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the specified load balancer.
+     */
+    private String loadBalancerId;
+
+    /**
+     * The name of the routing policy to retrieve.
+     * <p>
+     * Example: `example_routing_policy`
+     *
+     */
+    private String routingPolicyName;
+
+    /**
+     * The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetRoutingPolicyRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetRoutingPolicyRequest o) {
+            loadBalancerId(o.getLoadBalancerId());
+            routingPolicyName(o.getRoutingPolicyName());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetRoutingPolicyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetRoutingPolicyRequest
+         */
+        public GetRoutingPolicyRequest build() {
+            GetRoutingPolicyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/ListRoutingPoliciesRequest.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/ListRoutingPoliciesRequest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.requests;
+
+import com.oracle.bmc.loadbalancer.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/ListRoutingPoliciesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListRoutingPoliciesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class ListRoutingPoliciesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the load balancer associated with the routing policies.
+     *
+     */
+    private String loadBalancerId;
+
+    /**
+     * The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated \"List\" call.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `50`
+     *
+     */
+    private Long limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\" call.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `3`
+     *
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListRoutingPoliciesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListRoutingPoliciesRequest o) {
+            loadBalancerId(o.getLoadBalancerId());
+            opcRequestId(o.getOpcRequestId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListRoutingPoliciesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListRoutingPoliciesRequest
+         */
+        public ListRoutingPoliciesRequest build() {
+            ListRoutingPoliciesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/UpdateRoutingPolicyRequest.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/requests/UpdateRoutingPolicyRequest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.requests;
+
+import com.oracle.bmc.loadbalancer.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loadbalancer/UpdateRoutingPolicyExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateRoutingPolicyRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder", buildMethodName = "buildWithoutInvocationCallback")
+@lombok.Getter
+public class UpdateRoutingPolicyRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateRoutingPolicyDetails> {
+
+    /**
+     * The configuration details needed to update a routing policy.
+     */
+    private UpdateRoutingPolicyDetails updateRoutingPolicyDetails;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the load balancer associated with the routing policy to update.
+     */
+    private String loadBalancerId;
+
+    /**
+     * The name of the routing policy to update.
+     * <p>
+     * Example: `example_routing_policy_name`
+     *
+     */
+    private String routingPolicyName;
+
+    /**
+     * The unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateRoutingPolicyDetails getBody$() {
+        return updateRoutingPolicyDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateRoutingPolicyRequest, UpdateRoutingPolicyDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateRoutingPolicyRequest o) {
+            updateRoutingPolicyDetails(o.getUpdateRoutingPolicyDetails());
+            loadBalancerId(o.getLoadBalancerId());
+            routingPolicyName(o.getRoutingPolicyName());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateRoutingPolicyRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateRoutingPolicyRequest
+         */
+        public UpdateRoutingPolicyRequest build() {
+            UpdateRoutingPolicyRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateRoutingPolicyDetails body) {
+            updateRoutingPolicyDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/CreateRoutingPolicyResponse.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/CreateRoutingPolicyResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.responses;
+
+import com.oracle.bmc.loadbalancer.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class CreateRoutingPolicyResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateRoutingPolicyResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/DeleteRoutingPolicyResponse.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/DeleteRoutingPolicyResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.responses;
+
+import com.oracle.bmc.loadbalancer.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class DeleteRoutingPolicyResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteRoutingPolicyResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/GetRoutingPolicyResponse.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/GetRoutingPolicyResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.responses;
+
+import com.oracle.bmc.loadbalancer.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class GetRoutingPolicyResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned RoutingPolicy instance.
+     */
+    private RoutingPolicy routingPolicy;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetRoutingPolicyResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            routingPolicy(o.getRoutingPolicy());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/ListRoutingPoliciesResponse.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/ListRoutingPoliciesResponse.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.responses;
+
+import com.oracle.bmc.loadbalancer.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class ListRoutingPoliciesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results remain.
+     * For important details about how pagination works, see [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of RoutingPolicy instances.
+     */
+    private java.util.List<RoutingPolicy> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListRoutingPoliciesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/UpdateRoutingPolicyResponse.java
+++ b/bmc-loadbalancer/src/main/java/com/oracle/bmc/loadbalancer/responses/UpdateRoutingPolicyResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loadbalancer.responses;
+
+import com.oracle.bmc.loadbalancer.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20170115")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.Getter
+public class UpdateRoutingPolicyResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request.
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateRoutingPolicyResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/DownloadConfiguration.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/DownloadConfiguration.java
@@ -1,0 +1,316 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer;
+
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import lombok.Getter;
+import org.apache.commons.lang3.Validate;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Configuration for the {@link DownloadManager}.
+ */
+@Getter
+public class DownloadConfiguration {
+
+    /**
+     * The smallest part size we will use.
+     */
+    final static int MIN_PART_SIZE_IN_BYTES = 4 * 1024 * 1024;
+
+    /**
+     * The largest part size we will allow.
+     */
+    private final static int MAX_PART_SIZE_IN_BYTES = 1024 * 1024 * 1024;
+
+    /**
+     * The largest value we will acceept for {@link #getParallelDownloads()}.
+     */
+    private final static int MAX_PARALLEL_DOWNLOADS = 256;
+
+    /**
+     * The largest value we will accept as {@link #getMultipartDownloadThresholdInBytes()}.
+     */
+    private final static long MAX_MULTIPART_DOWNLOAD_THRESHOLD = 5L * 1024L * 1024L * 1024L;
+
+    /**
+     * Maximum number of retries, not including the initial attempt.
+     */
+    private final int maxRetries;
+
+    /**
+     * Initial backoff, before a retry is performed.
+     */
+    private final Duration initialBackoff;
+
+    /**
+     * Maximum backoff between retries.
+     */
+    private final Duration maxBackoff;
+
+    /**
+     * The size in bytes of the individual parts as which the object is downloaded.
+     */
+    private final int partSizeInBytes;
+
+    /**
+     * The threshold size in bytes at which we will start splitting the object into parts.
+     */
+    private final long multipartDownloadThresholdInBytes;
+
+    /**
+     * The number of parallel operations to perform when downloading an
+     * object in multiple parts. Decreasing this value will make multipart
+     * downloads less resource intensive but they may take longer.
+     * Increasing this value may improve download times, but the download
+     * process will consume more system resources and network bandwidth.
+     *
+     * Note that this is per object. If you call {@link DownloadManager#getObject(GetObjectRequest)}
+     * multiple times concurrently from separate threads, you will get this many parallel operations
+     * per object. If you want to limit the overall number of parallel parts being downloaded, you can
+     * provide an {@link ExecutorService} using {@link Builder#executorService(ExecutorService)} that limits
+     * the number of threads.
+     */
+    private final int parallelDownloads;
+
+    /**
+     * Executor service for parallel downloads.
+     */
+    private final ExecutorService executorService;
+
+    /**
+     * Create a configuration for the {@link DownloadManager}.
+     * @param maxRetries maximum number of retries, not including the initial attempt.
+     * @param initialBackoff initial backoff, before a retry is performed.
+     * @param maxBackoff maximum backoff between retries
+     * @param partSizeInBytes the size in bytes of the individual parts as which the object is downloaded.
+     * @param multipartDownloadThresholdInBytes the threshold size in bytes at which we will start splitting the object into parts
+     * @param parallelDownloads maximum number of parallel downloads
+     * @param executorService executor service for parallel downloads
+     */
+    public DownloadConfiguration(
+            int maxRetries,
+            Duration initialBackoff,
+            Duration maxBackoff,
+            int partSizeInBytes,
+            long multipartDownloadThresholdInBytes,
+            int parallelDownloads,
+            ExecutorService executorService) {
+        Validate.isTrue(
+                maxRetries >= 0,
+                "maxRetries [%s] must be greater than or equal to %s",
+                maxRetries,
+                0);
+        Validate.isTrue(
+                initialBackoff.compareTo(Duration.ofMillis(1)) >= 0,
+                "initialBackoff [%s] must be greater than %s",
+                initialBackoff,
+                Duration.ZERO);
+        Validate.isTrue(
+                maxBackoff.compareTo(initialBackoff) >= 0,
+                "maxBackoff [%s] must be greater than or equal to initialBackoff [%s]",
+                maxBackoff,
+                initialBackoff);
+        Validate.inclusiveBetween(
+                MIN_PART_SIZE_IN_BYTES,
+                MAX_PART_SIZE_IN_BYTES,
+                partSizeInBytes,
+                "partSizeInBytes [%s] must be between %s and %s",
+                partSizeInBytes,
+                MIN_PART_SIZE_IN_BYTES,
+                MAX_PART_SIZE_IN_BYTES);
+        Validate.inclusiveBetween(
+                (long) MIN_PART_SIZE_IN_BYTES,
+                MAX_MULTIPART_DOWNLOAD_THRESHOLD,
+                multipartDownloadThresholdInBytes,
+                "multipartDownloadThresholdInBytes [%s] must be between %s and %s",
+                multipartDownloadThresholdInBytes,
+                MIN_PART_SIZE_IN_BYTES,
+                MAX_MULTIPART_DOWNLOAD_THRESHOLD);
+        Validate.inclusiveBetween(
+                0,
+                MAX_PARALLEL_DOWNLOADS,
+                parallelDownloads,
+                "parallelDownloads [%s] must be between %s and %s",
+                parallelDownloads,
+                0,
+                MAX_PARALLEL_DOWNLOADS);
+
+        this.maxRetries = maxRetries;
+        this.initialBackoff = initialBackoff;
+        this.maxBackoff = maxBackoff;
+        this.partSizeInBytes = partSizeInBytes;
+        this.multipartDownloadThresholdInBytes = multipartDownloadThresholdInBytes;
+        this.parallelDownloads = parallelDownloads;
+        this.executorService = executorService;
+    }
+
+    /**
+     * Create a new builder for the {@link DownloadManager} configuration
+     * @return builder for the configuration
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link DownloadConfiguration}.
+     */
+    public static class Builder {
+        private int maxRetries;
+        private Duration initialBackoff;
+        private Duration maxBackoff;
+        private int partSizeInBytes;
+        private long multipartDownloadThresholdInBytes;
+        private int parallelDownloads;
+        private ExecutorService executorService;
+
+        private Builder() {
+            this.maxRetries = 10;
+            this.initialBackoff = Duration.ofMillis(100);
+            this.maxBackoff = Duration.ofSeconds(30);
+            this.partSizeInBytes = 32 * 1024 * 1024;
+            this.multipartDownloadThresholdInBytes =
+                    DownloadConfiguration.MIN_PART_SIZE_IN_BYTES * 2;
+            this.parallelDownloads = 3;
+            this.executorService = null;
+        }
+
+        /**
+         * Build the {@link DownloadConfiguration}.
+         * @return the {@link DownloadConfiguration}
+         */
+        public DownloadConfiguration build() {
+            return new DownloadConfiguration(
+                    this.maxRetries,
+                    this.initialBackoff,
+                    this.maxBackoff,
+                    this.partSizeInBytes,
+                    this.multipartDownloadThresholdInBytes,
+                    this.parallelDownloads,
+                    this.executorService);
+        }
+
+        /**
+         * Copy the values from a {@link DownloadConfiguration} into this builder
+         * @param that other {@link DownloadConfiguration}
+         * @return this builder
+         */
+        public Builder copy(DownloadConfiguration that) {
+            this.maxRetries = that.maxRetries;
+            this.initialBackoff = that.initialBackoff;
+            this.maxBackoff = that.maxBackoff;
+            this.partSizeInBytes = that.partSizeInBytes;
+            this.multipartDownloadThresholdInBytes = that.multipartDownloadThresholdInBytes;
+            this.parallelDownloads = that.parallelDownloads;
+            this.executorService = that.executorService;
+            return this;
+        }
+
+        /**
+         * Maximum number of retries to attempt when downloading an object/part.
+         * The default value is 10 retries.
+         *
+         * The retries in the download manager are smarter than the retries built into the client: The download
+         * manager modifies the request to only retry the parts that haven't been read yet. The client would retry
+         * the entire request, and re-download parts that have already been downloaded.
+         *
+         * Since these retries have been implemented independent of the regular client retries, client retries
+         * set using {@link com.oracle.bmc.retrier.RetryConfiguration} are ignored.
+         *
+         * @param value
+         * @return this builder
+         */
+        public Builder maxRetries(int value) {
+            this.maxRetries = value;
+            return this;
+        }
+
+        /**
+         * Set the initial backoff before the first retry.
+         *
+         * @param value initial backoff before the first retry
+         * @return this builder
+         */
+        public Builder initialBackoff(Duration value) {
+            this.initialBackoff = value;
+            return this;
+        }
+
+        /**
+         * Set the maximum backoff between retries.
+         *
+         * @param value maximum backoff between retries
+         * @return this builder
+         */
+        public Builder maxBackoff(Duration value) {
+            this.maxBackoff = value;
+            return this;
+        }
+
+        /**
+         * Set the part size to use when downloading an object in multiple
+         * parts. The default value is 32 MiB, the minimum allowable size is
+         * 4 MiB, and the maximum allowable size is 1 GiB.
+         *
+         * @param value the size in bytes of the individual parts as which the object is downloaded.
+         * @return this builder
+         */
+        public Builder partSizeInBytes(int value) {
+            this.partSizeInBytes = value;
+            return this;
+        }
+
+        /**
+         * Objects larger than this size will be downloaded in multiple parts.
+         * The default value is 64 MiB, the minimum allowable threshold is
+         * 4 MiB, and the maximum allowable threshold is 5 GiB.
+         *
+         * @param value the threshold size in bytes at which we will start splitting the object into parts
+         * @return this builder
+         */
+        public Builder multipartDownloadThresholdInBytes(long value) {
+            this.multipartDownloadThresholdInBytes = value;
+            return this;
+        }
+
+        /**
+         * The number of parallel operations to perform when downloading an
+         * object in multiple parts. Decreasing this value will make multipart
+         * downloads less resource intensive but they may take longer.
+         * Increasing this value may improve download times, but the download
+         * process will consume more system resources and network bandwidth.
+         * The maximum allowed value is 256 and the default value is 3.
+         *
+         * Note that this is per object. If you call {@link DownloadManager#getObject(GetObjectRequest)}
+         * multiple times concurrently from separate threads, you will get this many parallel operations
+         * per object. If you want to limit the overall number of parallel parts being downloaded, you can
+         * provide an {@link ExecutorService} using {@link #executorService(ExecutorService)} that limits
+         * the number of threads.
+         *
+         * @param value maximum number of parallel operations when downloading a single object
+         * @return this builder
+         */
+        public Builder parallelDownloads(int value) {
+            this.parallelDownloads = value;
+            return this;
+        }
+
+        /**
+         * The executor service to use when performing parallel operations. If
+         * this is null (the default) each download will create its own executor
+         * service if necessary.
+         *
+         * @param value executor service for parallel downloads
+         * @return this builder
+         */
+        public Builder executorService(ExecutorService value) {
+            this.executorService = value;
+            return this;
+        }
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/DownloadManager.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/DownloadManager.java
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import com.oracle.bmc.objectstorage.transfer.internal.download.DownloadExecution;
+import com.oracle.bmc.objectstorage.transfer.internal.download.MultithreadStream;
+import com.oracle.bmc.objectstorage.transfer.internal.download.RetryingStream;
+import com.oracle.bmc.retrier.RetryConfiguration;
+import com.oracle.bmc.waiter.MaxAttemptsTerminationStrategy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+/**
+ * Download manager, which automatically breaks a larger download into parallel downloads, based on object size.
+ * It also handles possible retries.
+ *
+ * The retries in the download manager are smarter than the retries built into the client: The download
+ * manager modifies the request to only retry the parts that haven't been read yet. The client would retry
+ * the entire request, and re-download parts that have already been downloaded.
+ *
+ * Since these retries have been implemented independent of the regular client retries, client retries
+ * set using {@link com.oracle.bmc.retrier.RetryConfiguration} are ignored.
+ */
+public class DownloadManager {
+    private static final RetryConfiguration NO_RETRIES_IN_CLIENT =
+            RetryConfiguration.builder()
+                    .terminationStrategy(new MaxAttemptsTerminationStrategy(1))
+                    .build();
+
+    private final ObjectStorage objectStorage;
+    private final DownloadConfiguration config;
+
+    /**
+     * This calls acts just like {@link ObjectStorage#getObject(GetObjectRequest)}
+     * except that the {@link InputStream} returned {@link GetObjectResponse#getInputStream()}
+     * will automatically retry the get operation if there is failure.
+     *
+     * These retries introduce a new set of possible failures. If the object is
+     * modified during a get operation a retry can fail with a 412 or 404
+     * status code.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws com.oracle.bmc.model.BmcException when an error occurs.
+     */
+    public GetObjectResponse getObject(GetObjectRequest request) {
+        // The retries in the download manager are smarter than the retries built into the client: The download
+        // manager modifies the request to only retry the parts that haven't been read yet. The client would retry
+        // the entire request, and re-download parts that have already been downloaded.
+        // We need to make sure we don't get (download manager) retries on top of (client) retries, though.
+        request =
+                GetObjectRequest.builder()
+                        .copy(request)
+                        .retryConfiguration(NO_RETRIES_IN_CLIENT)
+                        .build();
+
+        final DownloadExecution execution = DownloadExecution.fromConfig(this.config);
+
+        // Perform the first request. Even if we are going to do a multi-threaded
+        // download we request the entire object so that we know the total size.
+        // (We can close the response early if needed.)
+        GetObjectResponse response;
+        while (true) {
+            try {
+                response = this.objectStorage.getObject(request);
+                break;
+            } catch (Throwable t) {
+                if (execution.shouldRetryOn(t)) {
+                    continue;
+                }
+                throw t;
+            }
+        }
+
+        // When an if-match request fails (i.e. the object matches the etag)
+        // the getObject call does not throw an exception, but also does not
+        // return any data. Match that behavior.
+        if (response.isNotModified()) {
+            return response;
+        }
+
+        // We have read the object. Remember the etag so that a retried request
+        // will fail if the object is changed underneath us.
+        final String etag = response.getETag();
+        final GetObjectRequest requestWithEtag =
+                GetObjectRequest.builder().copy(request).ifMatch(etag).build();
+
+        // This input stream will read the first part of the object.
+        final InputStream retryingStream =
+                new RetryingStream(this.objectStorage, requestWithEtag, response, execution);
+
+        // Do we want a single-threaded, or multi-threaded download?
+        final InputStream stream;
+        if (this.config.getParallelDownloads() > 0
+                && response.getContentLength() > this.config.getMultipartDownloadThresholdInBytes()
+                && response.getContentLength() > DownloadConfiguration.MIN_PART_SIZE_IN_BYTES) {
+            // This is a big object so we will use multiple threads to download
+            // it. How big should each part be?
+            //
+            // The first part will be downloaded by the foreground thread
+            // so we count it as a worker.
+            final int totalWorkers = this.config.getParallelDownloads() + 1;
+            assert totalWorkers >= 2;
+
+            // Is the object large enough to give each worker at least partSizeInBytes
+            // of data to download?
+            final int partSize;
+            if (response.getContentLength()
+                    >= (long) totalWorkers * (long) this.config.getPartSizeInBytes()) {
+                // This is a really big object -- each worker has at least partSizeInBytes
+                // of data to download.
+                partSize = this.config.getPartSizeInBytes();
+            } else {
+                // Divide the data evenly between the workers, respecting the minimum
+                // part size for all except the last part.
+                partSize =
+                        Math.max(
+                                Math.toIntExact(response.getContentLength() / totalWorkers),
+                                DownloadConfiguration.MIN_PART_SIZE_IN_BYTES);
+            }
+            assert partSize <= this.config.getPartSizeInBytes();
+            assert partSize >= DownloadConfiguration.MIN_PART_SIZE_IN_BYTES;
+            LOG.trace("partSizeInBytes = {}", partSize);
+
+            // Total number of parts we will be downloading
+            final int numParts =
+                    Math.toIntExact((response.getContentLength() + partSize - 1) / partSize);
+            assert numParts >= 2;
+
+            // The first part is downloaded by the foreground thread so we
+            // do not need more than numParts-1 threads
+            final int numThreads = Math.min(this.config.getParallelDownloads(), numParts - 1);
+            assert numThreads > 0;
+
+            stream =
+                    new MultithreadStream(
+                            this,
+                            requestWithEtag,
+                            response.getContentLength(),
+                            retryingStream,
+                            this.config.getParallelDownloads(),
+                            this.config.getExecutorService(),
+                            partSize);
+        } else {
+            // This is a small object. Use a single-threaded download.
+            stream = retryingStream;
+        }
+
+        final GetObjectResponse retryingResponse =
+                GetObjectResponse.builder().copy(response).inputStream(stream).build();
+        return retryingResponse;
+    }
+
+    /**
+     * Download the object and save it to a file.
+     *
+     * This calls acts just like {@link ObjectStorage#getObject(GetObjectRequest)}
+     * except that the {@link InputStream} returned {@link GetObjectResponse#getInputStream()}
+     * will automatically retry the get operation if there is failure.
+     *
+     * These retries introduce a new set of possible failures. If the object is
+     * modified during a get operation a retry can fail with a 412 or 404
+     * status code.
+     *
+     * The downloaded object will be saved in the specified file.
+     *
+     * The response will be returned, but note that the stream has already been consumed.
+     *
+     * @param request The request object containing the details to send
+     * @param target The file where the object should be saved
+     * @return A response object containing details about the completed operation, but with already consumed stream
+     * @throws com.oracle.bmc.model.BmcException when an error occurs.
+     */
+    public GetObjectResponse downloadObjectToFile(GetObjectRequest request, File target)
+            throws IOException {
+        GetObjectResponse response = getObject(request);
+
+        // use the stream contents; make sure to close the stream, e.g. by using try-with-resources
+        try (final InputStream stream = response.getInputStream();
+                final OutputStream outputStream = new FileOutputStream(target)) {
+            // use fileStream
+            byte[] buf = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = stream.read(buf)) > 0) {
+                outputStream.write(buf, 0, bytesRead);
+            }
+        } // try-with-resources automatically closes streams
+
+        return response;
+    }
+
+    /**
+     * Used by {@link MultithreadStream}. This does NOT multithread the download.
+     */
+    public GetObjectResponse getObject_singleThreaded(GetObjectRequest request) {
+        final DownloadExecution execution = DownloadExecution.fromConfig(this.config);
+
+        // Perform the first request. Even if we are going to do a multi-threaded
+        // download we request the entire object so that we know the total size.
+        // (We can close the response early if needed.)
+        GetObjectResponse response;
+        while (true) {
+            try {
+                response = this.objectStorage.getObject(request);
+                break;
+            } catch (Throwable t) {
+                if (execution.shouldRetryOn(t)) {
+                    continue;
+                }
+                throw t;
+            }
+        }
+
+        // We have read the object. Remember the etag so that a retried request
+        // will fail if the object is changed underneath us.
+        final String etag = response.getETag();
+        final GetObjectRequest requestWithEtag =
+                GetObjectRequest.builder().copy(request).ifMatch(etag).build();
+
+        // This input stream will read from the
+        final InputStream retryingStream =
+                new RetryingStream(this.objectStorage, requestWithEtag, response, execution);
+
+        final GetObjectResponse retryingResponse =
+                GetObjectResponse.builder().copy(response).inputStream(retryingStream).build();
+        return retryingResponse;
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/MultipartObjectAssembler.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/MultipartObjectAssembler.java
@@ -330,7 +330,7 @@ public class MultipartObjectAssembler {
     /**
      * Aborts the current multi-part assembly and all uploads
      * that are currently in progress.
-     * @return
+     * @return abort response
      */
     public AbortMultipartUploadResponse abort() {
         // allow aborted calls to call abort again (in case the first call

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/DownloadExecution.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/DownloadExecution.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.internal.download;
+
+import com.oracle.bmc.objectstorage.transfer.DownloadConfiguration;
+
+public interface DownloadExecution {
+    boolean shouldRetryOn(Throwable t);
+
+    static DownloadExecution fromConfig(DownloadConfiguration config) {
+        return SimpleRetry.simpleRetryFromConfig(config);
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/DownloadThread.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/DownloadThread.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.internal.download;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import com.oracle.bmc.objectstorage.transfer.DownloadManager;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A {@link DownloadThread} object has two important methods, {@link #run()}
+ * and {@link #read(byte[], int, int)}.
+ *
+ * {@link #run()} should be run asynchronously. It performs a request and reads
+ * data into the provided buffer.
+ *
+ * {@link #read(byte[], int, int)} is used by another thread that wants to
+ * consume the data that is being read.
+ */
+@Slf4j
+public class DownloadThread {
+
+    /**
+     * Used to perform the request.
+     */
+    private final DownloadManager downloadManager;
+
+    /**
+     * The object we are getting.
+     */
+    private final GetObjectRequest getObjectRequest;
+
+    /**
+     * The buffer we read into.
+     */
+    private final byte[] buffer;
+
+    /**
+     * Used to synchronize {@link #run()} and {@link #read(byte[], int, int).}
+     */
+    private final Object lock;
+
+    /**
+     * The amount of data we have to read.
+     */
+    private int objectSize;
+
+    /**
+     * The next point in {@link #buffer} that we will write to. This value is
+     * incremented by {@link #run()} and {@link #lock} is notified whenever
+     * the value is incremented.
+     */
+    private volatile int writeTo;
+
+    /**
+     * If {@link #run()} fails this will be set to a non-null value.
+     * {@link #lock} is notified if this value is set.
+     */
+    private volatile Throwable error;
+
+    /**
+     * The last point in {@link #buffer} we read from. This value is only read
+     * and written by {@link #read(byte[], int, int)} while holding
+     * {@link #lock}.
+     */
+    private volatile int readFrom;
+
+    /**
+     * Set this to stop the async thread from running. The read thread will
+     * exit when it sees this set.
+     */
+    private volatile boolean cancelRequested;
+
+    /**
+     * When the read thread stops because {@link #cancelRequested} is true
+     * it sets this to true and notifies {@link #lock}.
+     */
+    private volatile boolean threadCancelled;
+
+    public DownloadThread(
+            DownloadManager downloadManager, GetObjectRequest getObjectRequest, byte[] buffer) {
+        this.downloadManager = downloadManager;
+        this.getObjectRequest = getObjectRequest;
+        this.buffer = buffer;
+        this.lock = new Object();
+        this.writeTo = 0;
+        this.readFrom = 0;
+        this.error = null;
+        // We will not know the object size until we do our read
+        this.objectSize = Integer.MAX_VALUE;
+    }
+
+    /**
+     * Ask the background thread to stop running.
+     */
+    public void requestCancel() {
+        this.cancelRequested = true;
+    }
+
+    /**
+     * Start reading data into {@link #buffer} where it can be read by
+     * {@link #read(byte[], int, int)}.
+     */
+    public byte[] run() throws IOException {
+        LOG.debug(
+                "Reading bytes {}-{} from {}/{}/{}",
+                this.getObjectRequest.getRange().getStartByte(),
+                this.getObjectRequest.getRange().getEndByte(),
+                this.getObjectRequest.getNamespaceName(),
+                this.getObjectRequest.getBucketName(),
+                this.getObjectRequest.getObjectName());
+        try {
+            final GetObjectResponse getObjectResponse =
+                    this.downloadManager.getObject_singleThreaded(this.getObjectRequest);
+            try {
+                assert Math.toIntExact(getObjectResponse.getContentLength()) <= this.buffer.length;
+                this.objectSize = Math.toIntExact(getObjectResponse.getContentLength());
+                while (true) {
+                    assert this.writeTo >= this.readFrom;
+                    assert this.writeTo <= this.buffer.length;
+
+                    // If the operation is cancelled we stop the thread.
+                    if (this.cancelRequested) {
+                        break;
+                    }
+
+                    final int dataRemaining = this.objectSize - this.writeTo;
+                    if (dataRemaining <= 0) {
+                        break;
+                    }
+                    final int bytesRead =
+                            getObjectResponse
+                                    .getInputStream()
+                                    .read(this.buffer, this.writeTo, dataRemaining);
+                    if (bytesRead < 0) {
+                        LOG.error(
+                                "Truncated download. Got {} from read (expected {} bytes remaining)",
+                                bytesRead,
+                                dataRemaining);
+                        throw new IOException("Truncated read");
+                    }
+                    assert bytesRead > 0;
+                    LOG.trace("Read {} bytes from response", bytesRead);
+                    synchronized (this.lock) {
+                        this.writeTo += bytesRead;
+                        this.lock.notify();
+                    }
+                }
+            } finally {
+                getObjectResponse.getInputStream().close();
+                if (this.cancelRequested) {
+                    LOG.warn("Async read was cancelled");
+                    synchronized (this.lock) {
+                        this.threadCancelled = true;
+                        this.lock.notify();
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            LOG.error("Asynchronous object read failed", t);
+            synchronized (this.lock) {
+                this.error = t;
+                this.lock.notify();
+            }
+            throw t;
+        }
+
+        return this.buffer;
+    }
+
+    /**
+     * Returns true if all data has been read.
+     */
+    public boolean allDataRead() {
+        return this.readFrom >= this.objectSize;
+    }
+
+    /**
+     * Read data from {@link #buffer}. If there is no
+     * @param b
+     * @param off
+     * @param len
+     * @return
+     * @throws InterruptedException
+     */
+    public int read(byte b[], int off, int len) throws IOException {
+        if (len == 0) {
+            return 0;
+        }
+
+        // Where in the buffer we should copy data from
+        final int bufferIndex;
+
+        // Where we should copy the data to
+        final int dataLength;
+
+        synchronized (this.lock) {
+            // Wait until we are at the end of the buffer, we hit an error, or
+            // there is something to read.
+            while (!this.threadCancelled
+                    && this.error == null
+                    && this.readFrom < this.objectSize
+                    && this.readFrom >= this.writeTo) {
+                try {
+                    this.lock.wait();
+                } catch (InterruptedException e) {
+                    throw new IOException("wait() was interrupted", e);
+                }
+            }
+
+            if (this.threadCancelled) {
+                throw new InterruptedIOException("Async read was cancelled");
+            }
+
+            // Throw an exception if the background thread got an error.
+            if (this.error != null) {
+                throw new IOException("Asynchronous read failed", this.error);
+            }
+
+            // Nothing to read? Return -1.
+            if (this.readFrom >= this.objectSize) {
+                return -1;
+            }
+
+            // Copy out the data we have
+            final int available = this.writeTo - this.readFrom;
+            assert available > 0;
+            dataLength = Math.min(len, available);
+            bufferIndex = this.readFrom;
+            this.readFrom += dataLength;
+        }
+
+        // We have some data to copy out
+        System.arraycopy(this.buffer, bufferIndex, b, off, dataLength);
+        LOG.trace("Got {} bytes from buffer", dataLength);
+        return dataLength;
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/MultithreadStream.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/MultithreadStream.java
@@ -1,0 +1,414 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.internal.download;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
+
+import com.oracle.bmc.model.Range;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.transfer.DownloadManager;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * An InputStream that can resume a broken download by making a range read
+ * request to Object Storage.
+ */
+@Slf4j
+public class MultithreadStream extends InputStream {
+
+    /**
+     * Download manager we can use to create new requests.
+     */
+    private final DownloadManager downloadManager;
+
+    /**
+     * Request that can be cloned to read the object.
+     */
+    private final GetObjectRequest baseRequest;
+
+    /**
+     * Total size of the object.
+     */
+    private final long objectSize;
+
+    /**
+     * Input stream we can read the first part from.
+     */
+    private final InputStream firstPart;
+
+    /**
+     * Number of threads to use.
+     */
+    private final int numThreads;
+
+    /**
+     * Each thread will download up to this much data. An instance of this
+     * class uses about {@link #numThreads} * {@link #partSize} of buffer.
+     */
+    private final int partSize;
+
+    /**
+     * Used to manage the threads we have.
+     */
+    private final ExecutorService executorService;
+
+    /**
+     * True if we should shutdown {@link #executorService} when finished. This
+     * is set to true if the constructor creates the executor service.
+     */
+    private final boolean shutdownExecutorService;
+
+    /**
+     * Our async read operations.
+     */
+    private final AsyncRead[] asyncReads;
+
+    /**
+     * Which thread in {@link #asyncReads} is the current thread.
+     */
+    private int asyncReadIndex;
+
+    /**
+     * The offset that the next thread should start reading from.
+     */
+    private long nextReadOffset;
+
+    /**
+     * Number of bytes read so far.
+     */
+    private long bytesReadSoFar;
+
+    /**
+     * True if this stream has been closed.
+     */
+    private boolean isClosed;
+
+    public MultithreadStream(
+            DownloadManager downloadManager,
+            GetObjectRequest baseRequest,
+            long objectSize,
+            InputStream firstPart,
+            int numThreads,
+            ExecutorService executorService,
+            int partSize) {
+        assert partSize > 0;
+        assert numThreads > 0;
+        // If the object is not bigger than a single part we should not
+        // use a multi-threaded download.
+        assert objectSize >= partSize;
+
+        this.downloadManager = downloadManager;
+        this.baseRequest = baseRequest;
+        this.objectSize = objectSize;
+        this.numThreads = numThreads;
+        this.partSize = partSize;
+        this.firstPart = firstPart;
+
+        this.bytesReadSoFar = 0;
+
+        this.asyncReads = new AsyncRead[this.numThreads];
+        this.asyncReadIndex = 0;
+        this.nextReadOffset = this.partSize;
+
+        // Start the threads
+        if (executorService == null) {
+            this.executorService = Executors.newFixedThreadPool(this.numThreads);
+            this.shutdownExecutorService = true;
+        } else {
+            this.executorService = executorService;
+            this.shutdownExecutorService = false;
+        }
+        final int numParts = Math.toIntExact((objectSize + partSize - 1) / partSize);
+        // The foreground thread will read the first part
+        final int readsToStart = Math.min(numThreads, numParts - 1);
+        for (int i = 0; i < readsToStart; ++i) {
+            this.asyncReads[i] = this.startAsyncRead(null);
+        }
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        // If any threads are still running, cancel them.
+        for (int i = 0; i < this.asyncReads.length; ++i) {
+            if (this.asyncReads[i] != null) {
+                this.asyncReads[i].thread.requestCancel();
+            }
+        }
+
+        // We will give the threads this long to stop
+        final long deadline = 30_000;
+        final long stopMillis = System.currentTimeMillis() + deadline;
+
+        // Wait for the threads to stop
+        for (int i = 0; i < this.asyncReads.length; ++i) {
+            if (this.asyncReads[i] != null) {
+                final long millisToWait = Math.max(0L, stopMillis - System.currentTimeMillis());
+                try {
+                    this.asyncReads[i].future.get(millisToWait, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    LOG.warn("Ignoring exception from async read", e);
+                }
+            }
+        }
+
+        if (this.shutdownExecutorService) {
+            try {
+                this.executorService.shutdownNow();
+                this.executorService.awaitTermination(0, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                LOG.warn("Ignoring exception from executor service termination", e);
+            }
+        }
+
+        this.isClosed = true;
+    }
+
+    @Override
+    public int read() throws IOException {
+        final byte[] b = new byte[1];
+        final int r = this.read(b, 0, 1);
+        if (r < 0) {
+            return -1;
+        }
+        return Byte.toUnsignedInt(b[0]);
+    }
+
+    @Override
+    public synchronized int read(byte b[], int off, int len) throws IOException {
+        if (len == 0) {
+            return 0;
+        }
+
+        // Nothing left to read?
+        if (this.allDataRead()) {
+            return -1;
+        }
+
+        if (this.isClosed) {
+            throw new IOException("Stream has been closed");
+        }
+
+        if (this.bytesReadSoFar < (long) this.partSize) {
+            // The first part has some more data for us.
+            final int maxBytesToRead =
+                    Math.min(len, Math.toIntExact((long) this.partSize - this.bytesReadSoFar));
+            final int bytesRead = this.firstPart.read(b, off, maxBytesToRead);
+            if (bytesRead < 0) {
+                LOG.error(
+                        "Truncated download. Got {} from read (expected {} bytes remaining)",
+                        bytesRead,
+                        maxBytesToRead);
+                throw new IOException("Truncated read");
+            }
+            assert bytesRead > 0;
+            this.bytesReadSoFar += bytesRead;
+            assert this.bytesReadSoFar <= (long) this.partSize;
+            if (this.bytesReadSoFar >= this.partSize) {
+                // We are done with the first part
+                closeQuietly(this.firstPart);
+            }
+            LOG.trace(
+                    "Read {} bytes from first part ({} total, object is {} bytes)",
+                    bytesRead,
+                    this.asyncReadIndex,
+                    this.bytesReadSoFar,
+                    this.objectSize);
+            return bytesRead;
+        } else {
+            // We have not read all the data in the object, so the next background
+            // thread will have some data.
+            LOG.trace("Reading from thread {}", this.asyncReadIndex);
+            final AsyncRead asyncRead = this.asyncReads[this.asyncReadIndex];
+            final int bytesRead = asyncRead.thread.read(b, off, len);
+            if (bytesRead < 0) {
+                LOG.error("Truncated download. Got {} from read", bytesRead);
+                throw new IOException("Truncated read");
+            }
+
+            this.bytesReadSoFar += bytesRead;
+            LOG.trace(
+                    "Read {} bytes from thread {} ({} total, object is {} bytes)",
+                    bytesRead,
+                    this.asyncReadIndex,
+                    this.bytesReadSoFar,
+                    this.objectSize);
+
+            if (asyncRead.thread.allDataRead()) {
+                // This thread has no more data. Shut it down.
+                this.asyncReads[this.asyncReadIndex] = null;
+                try {
+                    final byte[] buffer = joinAsyncRead(asyncRead);
+                    assert buffer != null;
+                    // Have we read all the data?
+                    if (this.allDataRead()) {
+                        // Nothing left to read, so we don't need the executor
+                        // service any more.
+                        this.shutdownExecutorService();
+                    } else {
+                        // Time to start a new read?
+                        if (!this.allReadsStarted()) {
+                            // Start a new read
+                            this.asyncReads[this.asyncReadIndex] = this.startAsyncRead(buffer);
+                            assert this.asyncReads[this.asyncReadIndex] != null;
+                        }
+                        // There is more data to read so we move to the next async read
+                        this.advanceAsyncReadIndex();
+                        assert this.asyncReads[this.asyncReadIndex] != null;
+                    }
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new IOException("Unable to start AsyncRead", e);
+                }
+            }
+
+            return bytesRead;
+        }
+    }
+
+    /**
+     * Wait for an async read to finish and return its buffer.
+     */
+    private byte[] joinAsyncRead(AsyncRead asyncRead)
+            throws ExecutionException, InterruptedException {
+        assert asyncRead.thread.allDataRead();
+        return asyncRead.future.get();
+    }
+
+    /**
+     * Returns true if all reads have been started.
+     */
+    private boolean allReadsStarted() {
+        return (this.nextReadOffset >= this.objectSize);
+    }
+
+    /**
+     * Returns true if all reads have finished.
+     */
+    private boolean allDataRead() {
+        return (this.bytesReadSoFar >= this.objectSize);
+    }
+
+    /**
+     * Update {@link #asyncReadIndex}.
+     */
+    private void advanceAsyncReadIndex() {
+        assert this.asyncReadIndex >= 0;
+        assert this.asyncReadIndex < this.asyncReads.length;
+        ++this.asyncReadIndex;
+        if (this.asyncReadIndex >= this.asyncReads.length) {
+            this.asyncReadIndex = 0;
+        }
+        assert this.asyncReadIndex >= 0;
+        assert this.asyncReadIndex < this.asyncReads.length;
+    }
+
+    private void shutdownExecutorService() throws InterruptedException {
+        // All AsyncReads should be done
+        for (AsyncRead asyncRead : this.asyncReads) {
+            assert asyncRead == null;
+        }
+        if (this.shutdownExecutorService) {
+            this.executorService.shutdownNow();
+            this.executorService.awaitTermination(1, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Start a new async read that will read {@link #partSize} bytes from
+     * the object starting as {@link #nextReadOffset}, offset by the range
+     * in {@link #baseRequest} if necessary.
+     * @param buffer An existing buffer to use. If this is null a new
+     *               buffer is allocated.
+     * @return The new async read.
+     */
+    private AsyncRead startAsyncRead(@Nullable byte[] buffer) {
+        // Calculate the new range
+        final long baseRequestRangeStart;
+        if (this.baseRequest.getRange() != null
+                && this.baseRequest.getRange().getStartByte() != null) {
+            baseRequestRangeStart = this.baseRequest.getRange().getStartByte();
+        } else {
+            baseRequestRangeStart = 0L;
+        }
+        final long baseRequestRangeEnd;
+        if (this.baseRequest.getRange() != null
+                && this.baseRequest.getRange().getEndByte() != null) {
+            baseRequestRangeEnd = this.baseRequest.getRange().getEndByte();
+        } else {
+            // If there is no end range we will treat it as max
+            baseRequestRangeEnd = Long.MAX_VALUE;
+        }
+        assert baseRequestRangeStart < baseRequestRangeEnd;
+        final long rangeStart = baseRequestRangeStart + this.nextReadOffset;
+        long rangeEnd = rangeStart + this.partSize - 1;
+        // Do not go past the end of the range in the request
+        rangeEnd = Math.min(rangeEnd, baseRequestRangeEnd);
+        // Or past the end of the object
+        rangeEnd = Math.min(rangeEnd, baseRequestRangeStart + this.objectSize - 1);
+        assert rangeEnd >= rangeStart;
+        final long rangeSize = rangeEnd - rangeStart + 1;
+        assert rangeSize > 0;
+
+        // Create the new request
+        final Range range = new Range(rangeStart, rangeEnd);
+        final GetObjectRequest getObjectRequest =
+                GetObjectRequest.builder().copy(this.baseRequest).range(range).build();
+
+        // Get the buffer
+        if (buffer == null) {
+            buffer = new byte[Math.toIntExact(rangeSize)];
+        } else {
+            assert buffer.length >= Math.toIntExact(rangeSize);
+        }
+
+        // Start the async read
+        LOG.debug(
+                "Starting async read of {}/{}/{} from {}-{} ({})",
+                getObjectRequest.getNamespaceName(),
+                getObjectRequest.getBucketName(),
+                getObjectRequest.getObjectName(),
+                getObjectRequest.getRange().getStartByte(),
+                getObjectRequest.getRange().getEndByte(),
+                this.asyncReadIndex);
+        final DownloadThread thread =
+                new DownloadThread(this.downloadManager, getObjectRequest, buffer);
+        final Future<byte[]> future = this.executorService.submit(() -> thread.run());
+        final AsyncRead asyncRead = new AsyncRead(future, thread);
+        this.nextReadOffset += rangeSize;
+        return asyncRead;
+    }
+
+    private static void closeQuietly(InputStream s) {
+        try {
+            s.close();
+        } catch (Throwable t) {
+            LOG.trace("Ignoring error from InputStream.close", t);
+        }
+    }
+
+    private static final class AsyncRead {
+        /**
+         * Completes when the async thread finishes.
+         */
+        private final Future<byte[]> future;
+
+        /**
+         * The download thread we can read from.
+         */
+        private final DownloadThread thread;
+
+        public AsyncRead(Future<byte[]> future, DownloadThread thread) {
+            this.future = future;
+            this.thread = thread;
+        }
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/RetryingStream.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/RetryingStream.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.internal.download;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.oracle.bmc.model.Range;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import com.oracle.bmc.util.StreamUtils;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * An InputStream that can resume a broken download by making a range read
+ * request to Object Storage.
+ */
+@Slf4j
+public class RetryingStream extends InputStream {
+
+    /**
+     * ObjectStorage client.
+     */
+    private final ObjectStorage objectStorage;
+
+    /**
+     * Used to control retries of the download.
+     */
+    private final DownloadExecution execution;
+
+    /**
+     * Current request.
+     */
+    private GetObjectRequest request;
+
+    /**
+     * Current response.
+     */
+    private GetObjectResponse response;
+
+    /**
+     * Number of bytes in the response
+     */
+    private long bytesInResponse;
+
+    /**
+     * Total bytes read from the object.
+     */
+    private long bytesReadFromResponse;
+
+    /**
+     * True if this stream has been closed.
+     */
+    private boolean isClosed;
+
+    public RetryingStream(
+            ObjectStorage objectStorage,
+            GetObjectRequest request,
+            GetObjectResponse response,
+            DownloadExecution execution) {
+        this.objectStorage = objectStorage;
+        this.request = request;
+        this.response = response;
+        this.bytesReadFromResponse = 0;
+        this.bytesInResponse = response.getContentLength();
+        this.execution = execution;
+        this.isClosed = false;
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        StreamUtils.closeQuietly(this.response.getInputStream());
+        this.response = null;
+        this.request = null;
+        this.isClosed = true;
+    }
+
+    @Override
+    public synchronized int read() throws IOException {
+        if (this.bytesInResponse == this.bytesReadFromResponse) {
+            return -1;
+        }
+
+        this.throwIfClosed();
+
+        while (true) {
+            try {
+                final int value = this.response.getInputStream().read();
+                if (value >= 0) {
+                    ++this.bytesReadFromResponse;
+                }
+                return value;
+            } catch (Throwable t) {
+                if (this.execution.shouldRetryOn(t)) {
+                    LOG.info("Refreshing request on retry", t);
+                    this.refresh();
+                    continue;
+                }
+                throw t;
+            }
+        }
+    }
+
+    @Override
+    public synchronized int read(byte b[], int off, int len) throws IOException {
+        if (len == 0) {
+            return 0;
+        }
+
+        if (this.bytesInResponse == this.bytesReadFromResponse) {
+            return -1;
+        }
+
+        this.throwIfClosed();
+
+        while (true) {
+            try {
+                final int bytesRead = this.response.getInputStream().read(b, off, len);
+                LOG.trace("Read {} bytes", bytesRead);
+                if (bytesRead > 0) {
+                    this.bytesReadFromResponse += bytesRead;
+                }
+                return bytesRead;
+            } catch (Throwable t) {
+                if (this.execution.shouldRetryOn(t)) {
+                    LOG.info("Refreshing request on retry", t);
+                    this.refresh();
+                    continue;
+                }
+                throw t;
+            }
+        }
+    }
+
+    private void throwIfClosed() throws IOException {
+        if (this.isClosed) {
+            throw new IOException("Stream has been closed");
+        }
+    }
+
+    /**
+     * Called when we hit an exception reading from the InputStream. This
+     * performs a range read to pick up reading where the previous request
+     * left off.
+     */
+    private void refresh() {
+        // We no longer need data from the current response
+        StreamUtils.closeQuietly(this.response.getInputStream());
+
+        // Create a new request to read the remaining bytes
+        this.refreshRequest();
+
+        // Get the object, with retries
+        while (true) {
+            try {
+                this.response = this.objectStorage.getObject(this.request);
+                break;
+            } catch (Throwable t) {
+                if (this.execution.shouldRetryOn(t)) {
+                    continue;
+                }
+                throw t;
+            }
+        }
+
+        this.bytesInResponse = this.response.getContentLength();
+        this.bytesReadFromResponse = 0;
+    }
+
+    /**
+     * Called when we get an exception reading from the response. We calculate
+     * a new request that does a range read starting with the last byte that
+     * was successfully read.
+     */
+    private void refreshRequest() {
+        // Prepare the new request
+        final GetObjectRequest.Builder requestBuilder = GetObjectRequest.builder();
+        requestBuilder.copy(this.request);
+
+        // Compute the new range
+        final Range currentRange = this.request.getRange();
+        final Range newRange;
+        if (null == currentRange) {
+            // No current range
+            newRange = new Range(this.bytesReadFromResponse, null);
+        } else if (currentRange.getStartByte() == null) {
+            // Current range implicitly started at 0
+            newRange = new Range(this.bytesReadFromResponse, currentRange.getEndByte());
+        } else {
+            newRange =
+                    new Range(
+                            currentRange.getStartByte() + this.bytesReadFromResponse,
+                            currentRange.getEndByte());
+        }
+        LOG.info("Current range was {}. New range is = {}", currentRange, newRange);
+        requestBuilder.range(newRange);
+
+        this.request = requestBuilder.build();
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/SimpleRetry.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/download/SimpleRetry.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.internal.download;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.objectstorage.transfer.DownloadConfiguration;
+import com.oracle.bmc.retrier.DefaultRetryCondition;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class SimpleRetry implements DownloadExecution {
+
+    /**
+     * Maximum amount of time we are willing to wait for. We will perform
+     * exponential backoff from {@link #currentBackoffMillis} until we hit this
+     * value.
+     */
+    final Duration maximumBackoff;
+
+    /**
+     * Maximum number of retries we are willing to do.
+     */
+    final long maxRetries;
+
+    /**
+     * How long to sleep on the next retry.
+     */
+    final AtomicLong currentBackoffMillis;
+
+    /**
+     * Number of retries we have performed so far.
+     */
+    final AtomicLong currentRetries;
+
+    /**
+     * Default retry condition, to re-use the retry conditions from the rest of the SDK.
+     */
+    static final DefaultRetryCondition defaultRetryCondition = new DefaultRetryCondition();
+
+    private SimpleRetry(Duration initialBackoff, Duration maximumBackoff, int maxRetries) {
+        this.maximumBackoff = maximumBackoff;
+        this.maxRetries = maxRetries;
+        this.currentBackoffMillis = new AtomicLong(initialBackoff.toMillis());
+        this.currentRetries = new AtomicLong(0L);
+    }
+
+    static SimpleRetry simpleRetryFromConfig(DownloadConfiguration config) {
+        return new SimpleRetry(
+                config.getInitialBackoff(), config.getMaxBackoff(), config.getMaxRetries());
+    }
+
+    @Override
+    public boolean shouldRetryOn(Throwable t) {
+        if (!isRetryableError(t)) {
+            LOG.debug("Non-retryable exception", t);
+            return false;
+        }
+        if (this.currentRetries.get() >= this.maxRetries
+                || this.currentRetries.getAndIncrement() >= this.maxRetries) {
+            LOG.error("Too many retries ({}/{})", this.currentRetries.get(), this.maxRetries, t);
+            return false;
+        }
+
+        final long oldBackoff = this.currentBackoffMillis.get();
+        try {
+            // Introduce jitter: we will sleep for a random time up to the
+            // backoff value.
+            final long sleepTime = ThreadLocalRandom.current().nextLong(0, oldBackoff);
+            LOG.info("Retrying request. Sleeping for {}ms before retry", sleepTime, t);
+            Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Increase the backoff
+        final long newBackoff = Math.min(oldBackoff * 2, this.maximumBackoff.toMillis());
+        // If another thread has already increased the backoff we will not bother.
+        this.currentBackoffMillis.compareAndSet(oldBackoff, newBackoff);
+        return true;
+    }
+
+    private static boolean isRetryableError(Throwable t) {
+        return shouldBeRetriedPerDefault(t) || isIOException(t);
+    }
+
+    private static boolean shouldBeRetriedPerDefault(Throwable t) {
+        if (t instanceof BmcException) {
+            final BmcException e = (BmcException) t;
+            return defaultRetryCondition.shouldBeRetried(e);
+        }
+        return false;
+    }
+
+    private static boolean isIOException(Throwable t) {
+        return t instanceof IOException;
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/DownloadConfigurationTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/DownloadConfigurationTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class DownloadConfigurationTest {
+
+    @Test
+    public void defaultsAreSane() {
+        final DownloadConfiguration config = DownloadConfiguration.builder().build();
+        Assert.assertEquals(config.getExecutorService(), null);
+        Assert.assertTrue(config.getInitialBackoff().compareTo(Duration.ZERO) > 0);
+        Assert.assertTrue(config.getMaxBackoff().compareTo(Duration.ZERO) > 0);
+        Assert.assertTrue(config.getMaxBackoff().compareTo(config.getInitialBackoff()) > 0);
+        Assert.assertTrue(config.getMaxRetries() > 0);
+        Assert.assertTrue(config.getMultipartDownloadThresholdInBytes() > 0L);
+        Assert.assertTrue(config.getParallelDownloads() > 0L);
+        Assert.assertTrue(config.getPartSizeInBytes() > 0L);
+    }
+
+    @Test
+    public void setProperties() {
+        final ExecutorService executorService = Executors.newCachedThreadPool();
+        try {
+            final DownloadConfiguration config =
+                    DownloadConfiguration.builder()
+                            .executorService(executorService)
+                            .initialBackoff(Duration.ofMinutes(1))
+                            .maxBackoff(Duration.ofMinutes(2))
+                            .maxRetries(3)
+                            .multipartDownloadThresholdInBytes(5L * 1024L * 1024L * 1024L)
+                            .parallelDownloads(6)
+                            .partSizeInBytes(7 * 1024 * 1024)
+                            .build();
+            Assert.assertEquals(config.getExecutorService(), executorService);
+            Assert.assertEquals(config.getInitialBackoff(), Duration.ofMinutes(1));
+            Assert.assertEquals(config.getMaxBackoff(), Duration.ofMinutes(2));
+            Assert.assertEquals(config.getMaxRetries(), 3);
+            Assert.assertEquals(
+                    config.getMultipartDownloadThresholdInBytes(), 5L * 1024L * 1024L * 1024L);
+            Assert.assertEquals(config.getParallelDownloads(), 6);
+            Assert.assertEquals(config.getPartSizeInBytes(), 7 * 1024 * 1024);
+
+            final DownloadConfiguration copy = DownloadConfiguration.builder().copy(config).build();
+            Assert.assertEquals(copy.getExecutorService(), config.getExecutorService());
+            Assert.assertEquals(copy.getInitialBackoff(), config.getInitialBackoff());
+            Assert.assertEquals(copy.getMaxBackoff(), config.getMaxBackoff());
+            Assert.assertEquals(copy.getMaxRetries(), config.getMaxRetries());
+            Assert.assertEquals(
+                    copy.getMultipartDownloadThresholdInBytes(),
+                    config.getMultipartDownloadThresholdInBytes());
+            Assert.assertEquals(copy.getParallelDownloads(), config.getParallelDownloads());
+            Assert.assertEquals(copy.getPartSizeInBytes(), config.getPartSizeInBytes());
+        } finally {
+            executorService.shutdown();
+        }
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/DownloadManagerErrorHandlingTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/DownloadManagerErrorHandlingTest.java
@@ -1,0 +1,301 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer;
+
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.model.Range;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import com.oracle.bmc.objectstorage.transfer.helper.MockObject;
+import com.oracle.bmc.objectstorage.transfer.helper.MockObjectStorage;
+import com.oracle.bmc.objectstorage.transfer.helper.RandomFailureInjector;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+public class DownloadManagerErrorHandlingTest {
+
+    /**
+     * Test the case where the very first getObject fails.
+     */
+    @Test
+    public void completeFailure() throws Exception {
+        // No operation will ever work
+        final RandomFailureInjector alwaysFail = new RandomFailureInjector(1.0, Integer.MAX_VALUE);
+
+        final MockObject mockObject = new MockObject(new HashMap<>(), 0, new byte[0], alwaysFail);
+        final ObjectStorage objectStorage = MockObjectStorage.create(mockObject);
+
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        // Keep the test fast by keeping retries short
+                        .initialBackoff(Duration.ofMillis(1))
+                        .maxBackoff(Duration.ofMillis(2))
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(mockObject.getNamespaceName())
+                        .bucketName(mockObject.getBucketName())
+                        .objectName(mockObject.getObjectName())
+                        .build();
+        try {
+            downloadManager.getObject(request);
+            Assert.fail("Expected an exception");
+        } catch (BmcException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Test the case where there are too many failures for success
+     */
+    @Test
+    public void tooManyFailures() throws Exception {
+        // 50% chance of failure
+        final RandomFailureInjector randomFailures =
+                new RandomFailureInjector(0.5, Integer.MAX_VALUE);
+
+        final byte[] data = new byte[128 * 1024 * 1024];
+        ThreadLocalRandom.current().nextBytes(data);
+        final MockObject mockObject =
+                new MockObject(new HashMap<>(), data.length, data, randomFailures);
+        final ObjectStorage objectStorage = MockObjectStorage.create(mockObject);
+
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        // Keep the test fast by keeping retries short
+                        .initialBackoff(Duration.ofMillis(1))
+                        .maxBackoff(Duration.ofMillis(2))
+                        .maxRetries(3)
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .multipartDownloadThresholdInBytes(4 * 1024 * 1024)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(mockObject.getNamespaceName())
+                        .bucketName(mockObject.getBucketName())
+                        .objectName(mockObject.getObjectName())
+                        .build();
+        final byte[] readBuffer = new byte[64 * 1024];
+        for (int attempt = 0; attempt < 10; ++attempt) {
+            try {
+                final GetObjectResponse response = downloadManager.getObject(request);
+                try {
+                    int offset = 0;
+                    while (true) {
+                        int bytesRead = response.getInputStream().read(readBuffer);
+                        Assert.assertTrue(bytesRead > 0);
+                        for (int i = 0; i < bytesRead; ++i) {
+                            // Do a cheap check first
+                            if (readBuffer[i] != data[i + offset]) {
+                                Assert.assertEquals(readBuffer[i], data[i + offset]);
+                            }
+                        }
+                        // We should never read the entire object -- we should hit the retry limit
+                        // first
+                        offset += bytesRead;
+                        Assert.assertTrue(offset < data.length);
+                    }
+                } finally {
+                    response.getInputStream().close();
+                }
+            } catch (BmcException | IOException e) {
+                // Expected
+            }
+        }
+    }
+
+    /**
+     * Have a small chance of failure, but read byte-by-byte
+     */
+    @Test
+    public void tooManyFailuresRead() throws Exception {
+        // 1% chance of failure
+        final RandomFailureInjector randomFailures =
+                new RandomFailureInjector(0.01, Integer.MAX_VALUE);
+
+        final byte[] data = new byte[100_000_000];
+        ThreadLocalRandom.current().nextBytes(data);
+        final MockObject mockObject =
+                new MockObject(new HashMap<>(), data.length, data, randomFailures);
+        final ObjectStorage objectStorage = MockObjectStorage.create(mockObject);
+
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        // Keep the test fast by keeping retries short
+                        .initialBackoff(Duration.ofMillis(1))
+                        .maxBackoff(Duration.ofMillis(2))
+                        .multipartDownloadThresholdInBytes(1024 * 1024 * 1024)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(mockObject.getNamespaceName())
+                        .bucketName(mockObject.getBucketName())
+                        .objectName(mockObject.getObjectName())
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        try {
+            int offset = 0;
+            while (true) {
+                int b = response.getInputStream().read();
+                Assert.assertTrue(b >= 0);
+                Assert.assertEquals(b, Byte.toUnsignedInt(data[offset]));
+                ++offset;
+                Assert.assertTrue(offset < data.length);
+            }
+        } catch (IOException e) {
+            // Expected
+        } finally {
+            response.getInputStream().close();
+        }
+    }
+
+    @Test
+    public void readWithFailures() throws Exception {
+        // Allocate this once and use it in all the tests
+        final byte[] data = new byte[128 * 1024 * 1024];
+        ThreadLocalRandom.current().nextBytes(data);
+
+        // Perform a read that creates its own executor service
+        readWithFailures(null, data.length, data);
+
+        // Create a reusable executor service for all subsequent tests
+        final ExecutorService executorService = Executors.newFixedThreadPool(4);
+        try {
+            // Small objects
+            for (int contentLength = 1; contentLength <= 16; ++contentLength) {
+                readWithFailures(executorService, contentLength, data);
+            }
+
+            readWithFailures(executorService, 4 * 1024 * 1024 - 1, data);
+            readWithFailures(executorService, 4 * 1024 * 1024, data);
+            readWithFailures(executorService, 4 * 1024 * 1024 + 1, data);
+
+            // Larger objects with random sizes
+            for (int i = 0; i < 10; ++i) {
+                final int contentLength =
+                        ThreadLocalRandom.current().nextInt(5 * 1024 * 1024, data.length);
+                readWithFailures(executorService, contentLength, data);
+            }
+        } finally {
+            executorService.shutdownNow();
+            executorService.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    private void readWithFailures(ExecutorService executorService, int contentLength, byte[] data)
+            throws IOException {
+        Assert.assertTrue(contentLength <= data.length);
+        final RandomFailureInjector randomFailures = new RandomFailureInjector(0.1, 100);
+
+        final MockObject mockObject =
+                new MockObject(new HashMap<>(), contentLength, data, randomFailures);
+        final ObjectStorage objectStorage = MockObjectStorage.create(mockObject);
+
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .maxRetries(101)
+                        // Keep the test fast by keeping retries short
+                        .initialBackoff(Duration.ofMillis(1))
+                        .maxBackoff(Duration.ofMillis(2))
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .multipartDownloadThresholdInBytes(4 * 1024 * 1024)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(mockObject.getNamespaceName())
+                        .bucketName(mockObject.getBucketName())
+                        .objectName(mockObject.getObjectName())
+                        .range(fullObjectRange(contentLength))
+                        .build();
+
+        // 1) Download some of the object with single-byte read and close the stream
+        final GetObjectResponse r1 = downloadManager.getObject(request);
+        for (int i = 0; i < Math.min(1024, contentLength - 1); ++i) {
+            Assert.assertEquals(r1.getInputStream().read(), Byte.toUnsignedInt(data[i]));
+        }
+        r1.getInputStream().close();
+        Assert.assertEquals(r1.getInputStream().read(new byte[0]), 0);
+
+        try {
+            r1.getInputStream().read();
+            Assert.fail("Expected an IOException");
+        } catch (IOException e) {
+            // expected
+        }
+
+        try {
+            r1.getInputStream().read(new byte[1]);
+            Assert.fail("Expected an IOException");
+        } catch (IOException e) {
+            // expected
+        }
+
+        try {
+            r1.getInputStream().read(new byte[1], 0, 1);
+            Assert.fail("Expected an IOException");
+        } catch (IOException e) {
+            // expected
+        }
+
+        // 2) Download the entire object
+        final GetObjectResponse r2 = downloadManager.getObject(request);
+        Assert.assertEquals(r2.getContentLength(), Long.valueOf(contentLength));
+        Assert.assertEquals(r2.getETag(), mockObject.getEtag());
+
+        final byte[] readBuffer = new byte[Math.min(contentLength, 64 * 1024)];
+        int offset = 0;
+        while (offset < contentLength) {
+            int bytesRead = r2.getInputStream().read(readBuffer);
+            Assert.assertTrue(bytesRead > 0);
+            for (int i = 0; i < bytesRead; ++i) {
+                // Do a cheap check before asserting
+                if (readBuffer[i] != data[i + offset]) {
+                    Assert.assertEquals(readBuffer[i], data[i + offset]);
+                }
+            }
+            offset += bytesRead;
+        }
+    }
+
+    /**
+     * Choose a random range that will retrieve the entire object.
+     */
+    private Range fullObjectRange(int contentLength) {
+        switch (ThreadLocalRandom.current().nextInt(0, 6)) {
+            case 0:
+                return null;
+            case 1:
+                return new Range(null, (long) contentLength);
+            case 2:
+                return new Range(null, Long.MAX_VALUE);
+            case 3:
+                return new Range(0L, null);
+            case 4:
+                return new Range(0L, (long) contentLength - 1);
+            case 5:
+                return new Range(0L, (long) contentLength);
+            default:
+                return new Range(0L, Long.MAX_VALUE);
+        }
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/DownloadManagerTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/DownloadManagerTest.java
@@ -1,0 +1,375 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer;
+
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.model.Range;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import com.oracle.bmc.objectstorage.transfer.helper.MockObject;
+import com.oracle.bmc.objectstorage.transfer.helper.MockObjectStorage;
+import com.oracle.bmc.objectstorage.transfer.helper.NoFailureInjector;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+public class DownloadManagerTest {
+
+    /**
+     * Use this for all tests to save setup/teardown time. Tests should not
+     * modify this data!
+     */
+    private static byte[] data;
+
+    /**
+     * Use the same executor service for all tests to save setup/teardown time.
+     * Test should not terminate this service!
+     */
+    private static ExecutorService executorService;
+
+    private ObjectStorage objectStorage;
+    private String namespaceName;
+    private String bucketName;
+    private String objectName;
+    private String etag;
+
+    @BeforeClass
+    public static void setupClass() {
+        data = new byte[64 * 1024 * 1024];
+        ThreadLocalRandom.current().nextBytes(data);
+        executorService = Executors.newFixedThreadPool(8);
+    }
+
+    @AfterClass
+    public static void teardownClass() throws InterruptedException {
+        executorService.shutdownNow();
+        executorService.awaitTermination(1, TimeUnit.SECONDS);
+    }
+
+    @Before
+    public void setup() {
+        final MockObject mockObject =
+                new MockObject(new HashMap<>(), data.length, data, NoFailureInjector.INSTANCE);
+        this.namespaceName = mockObject.getNamespaceName();
+        this.bucketName = mockObject.getBucketName();
+        this.objectName = mockObject.getObjectName();
+        this.etag = mockObject.getEtag();
+        this.objectStorage = MockObjectStorage.create(mockObject);
+    }
+
+    @Test
+    public void notFound() {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder().executorService(executorService).build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName("wrongnamespace")
+                        .bucketName("wrongbucket")
+                        .objectName("wrongobject")
+                        .build();
+        try {
+            downloadManager.getObject(request);
+            Assert.fail("Expected a BmcException");
+        } catch (BmcException ex) {
+            Assert.assertEquals(ex.getStatusCode(), 404);
+        }
+    }
+
+    @Test
+    public void notModified() {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder().executorService(executorService).build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .ifNoneMatch(etag)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        Assert.assertTrue(response.isNotModified());
+    }
+
+    @Test
+    public void defaultOptions() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder().executorService(executorService).build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        verify(request, response);
+    }
+
+    @Test
+    public void minDownloadThreshold() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .multipartDownloadThresholdInBytes(4 * 1024 * 1024)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        verify(request, response);
+    }
+
+    @Test
+    public void maxDownloadThreshold() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .multipartDownloadThresholdInBytes(1024 * 1024 * 1024)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        verify(request, response);
+    }
+
+    @Test
+    public void minPartSize() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        verify(request, response);
+    }
+
+    @Test
+    public void maxPartSize() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .partSizeInBytes(1024 * 1024 * 1024)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        verify(request, response);
+    }
+
+    @Test
+    public void noParallelDownloads() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .multipartDownloadThresholdInBytes(4 * 1024 * 1024)
+                        .parallelDownloads(0)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        verify(request, response);
+    }
+
+    @Test
+    public void oneParallelDownload() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .multipartDownloadThresholdInBytes(4 * 1024 * 1024)
+                        .parallelDownloads(1)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        verify(request, response);
+    }
+
+    @Test
+    public void twoParallelDownloads() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .multipartDownloadThresholdInBytes(4 * 1024 * 1024)
+                        .parallelDownloads(2)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        verify(request, response);
+    }
+
+    @Test
+    public void maxParallelDownloads() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .multipartDownloadThresholdInBytes(4 * 1024 * 1024)
+                        .parallelDownloads(256)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+        final GetObjectResponse response = downloadManager.getObject(request);
+        verify(request, response);
+    }
+
+    @Test
+    public void closeStream() throws Exception {
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .multipartDownloadThresholdInBytes(4 * 1024 * 1024)
+                        .parallelDownloads(8)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(namespaceName)
+                        .bucketName(bucketName)
+                        .objectName(objectName)
+                        .build();
+
+        final byte[] buffer = new byte[9_000_000];
+        assert buffer.length < data.length;
+        for (int iteration = 0; iteration < 10; ++iteration) {
+            final GetObjectResponse response = downloadManager.getObject(request);
+
+            // Read some data
+            final int dataToRead = ThreadLocalRandom.current().nextInt(1, buffer.length);
+            final int bytesRead = response.getInputStream().read(buffer, 0, dataToRead);
+            Assert.assertTrue(bytesRead > 0);
+
+            // Check the data
+            for (int i = 0; i < bytesRead; ++i) {
+                Assert.assertEquals(buffer[i], data[i]);
+            }
+
+            // Close the stream
+            response.getInputStream().close();
+        }
+    }
+
+    @Test
+    public void rangeGets() throws Exception {
+        // Range get of the entire object
+        final Collection<Range> ranges = new ArrayList<>();
+        ranges.add(null);
+        ranges.add(new Range(0L, null));
+        ranges.add(new Range(0L, data.length - 1L));
+        ranges.add(new Range(0L, (long) data.length));
+        ranges.add(new Range(0L, data.length + 1L));
+        ranges.add(new Range(0L, Long.MAX_VALUE));
+        ranges.add(new Range(null, (long) data.length));
+        ranges.add(new Range(null, data.length + 1L));
+        ranges.add(new Range(null, Long.MAX_VALUE));
+
+        final DownloadConfiguration config =
+                DownloadConfiguration.builder()
+                        .partSizeInBytes(4 * 1024 * 1024)
+                        .multipartDownloadThresholdInBytes(4 * 1024 * 1024)
+                        .executorService(executorService)
+                        .build();
+        final DownloadManager downloadManager = new DownloadManager(objectStorage, config);
+
+        for (Range range : ranges) {
+            final GetObjectRequest request =
+                    GetObjectRequest.builder()
+                            .namespaceName(namespaceName)
+                            .bucketName(bucketName)
+                            .objectName(objectName)
+                            .range(range)
+                            .build();
+            final GetObjectResponse response = downloadManager.getObject(request);
+            verify(request, response);
+        }
+    }
+
+    private void verify(GetObjectRequest request, GetObjectResponse response) throws IOException {
+        Assert.assertEquals(response.getETag(), etag);
+        Assert.assertEquals(response.getContentLength(), Long.valueOf(data.length));
+        final byte[] zeroLengthBuffer = new byte[0];
+        final byte[] buffer = new byte[65 * 1024 - 1];
+        int offset = 0;
+        while (offset < response.getContentLength()) {
+            Assert.assertEquals(response.getInputStream().read(buffer, 0, 0), 0);
+            int bytesRead = response.getInputStream().read(buffer);
+            Assert.assertTrue(bytesRead > 0);
+            for (int i = 0; i < bytesRead; ++i) {
+                // Do a cheap check before asserting
+                if (buffer[i] != data[i + offset]) {
+                    Assert.assertEquals(buffer[i], data[i + offset]);
+                }
+            }
+            offset += bytesRead;
+
+            Assert.assertEquals(response.getInputStream().read(zeroLengthBuffer), 0);
+            Assert.assertEquals(response.getInputStream().read(buffer, 0, 0), 0);
+        }
+
+        Assert.assertEquals(response.getInputStream().read(), -1);
+        Assert.assertEquals(response.getInputStream().read(buffer), -1);
+        Assert.assertEquals(response.getInputStream().read(buffer, 0, 0), 0);
+        Assert.assertEquals(response.getInputStream().read(buffer, 0, 1), -1);
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/FailingInputStream.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/FailingInputStream.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class FailingInputStream extends FilterInputStream {
+
+    private final FailureInjector failureInjector;
+
+    public FailingInputStream(FailureInjector failureInjector, InputStream in) {
+        super(in);
+        this.failureInjector = failureInjector;
+    }
+
+    @Override
+    public int read() throws IOException {
+        this.failureInjector.onDataRead();
+        return super.read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        this.failureInjector.onDataRead();
+        return super.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        this.failureInjector.onDataRead();
+        return super.read(b, off, len);
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/FailingInputStreamTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/FailingInputStreamTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class FailingInputStreamTest {
+
+    /**
+     * Used by all tests in the class. Individual tests should not modify this.
+     */
+    private static byte[] data;
+
+    /**
+     * New one created for each test.
+     */
+    private InputStream wrappedStream;
+
+    @BeforeClass
+    public static void setupClass() {
+        data = new byte[100];
+        ThreadLocalRandom.current().nextBytes(data);
+    }
+
+    @Before
+    public void setup() {
+        wrappedStream = new ByteArrayInputStream(data);
+    }
+
+    @Test
+    public void read() throws Exception {
+        final InputStream s = new FailingInputStream(NoFailureInjector.INSTANCE, wrappedStream);
+        Assert.assertEquals(s.read(), Byte.toUnsignedInt(data[0]));
+    }
+
+    @Test
+    public void readBytes() throws Exception {
+        final InputStream s = new FailingInputStream(NoFailureInjector.INSTANCE, wrappedStream);
+
+        final byte[] buffer = new byte[data.length];
+        s.read(buffer);
+        Assert.assertArrayEquals(buffer, data);
+    }
+
+    @Test
+    public void readBytes2() throws Exception {
+        final InputStream s = new FailingInputStream(NoFailureInjector.INSTANCE, wrappedStream);
+
+        final byte[] buffer = new byte[data.length];
+        s.read(buffer, 0, buffer.length);
+        Assert.assertArrayEquals(buffer, data);
+    }
+
+    @Test
+    public void readFails() throws Exception {
+        final FailureInjector failureInjector = new RandomFailureInjector(1.0, 1);
+        final InputStream s = new FailingInputStream(failureInjector, wrappedStream);
+        try {
+            s.read();
+            Assert.fail("Expected an exception");
+        } catch (Exception e) {
+            // expected
+        }
+
+        // read should work now
+        Assert.assertEquals(s.read(), Byte.toUnsignedInt(data[0]));
+    }
+
+    @Test
+    public void readBytesFails() throws Exception {
+        final FailureInjector failureInjector = new RandomFailureInjector(1.0, 1);
+        final InputStream s = new FailingInputStream(failureInjector, wrappedStream);
+        final byte[] buffer = new byte[data.length];
+        try {
+            s.read(buffer);
+            Assert.fail("Expected an exception");
+        } catch (Exception e) {
+            // expected
+        }
+
+        // read should work now
+        s.read(buffer);
+        Assert.assertArrayEquals(buffer, data);
+    }
+
+    @Test
+    public void readBytes2Fails() throws Exception {
+        final FailureInjector failureInjector = new RandomFailureInjector(1.0, 1);
+        final InputStream s = new FailingInputStream(failureInjector, wrappedStream);
+        final byte[] buffer = new byte[data.length];
+        try {
+            s.read(buffer, 0, buffer.length);
+            Assert.fail("Expected an exception");
+        } catch (Exception e) {
+            // expected
+        }
+
+        // read should work now
+        s.read(buffer, 0, buffer.length);
+        Assert.assertArrayEquals(buffer, data);
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/FailureInjector.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/FailureInjector.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import java.io.IOException;
+
+/**
+ * Called by {@link MockObject} to inject failures.
+ */
+public interface FailureInjector {
+
+    /**
+     * Called every time a getObject request is made.
+     */
+    void onGetObjectRequest();
+
+    /**
+     * Called every time data is read.
+     */
+    void onDataRead() throws IOException;
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/MockObject.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/MockObject.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import org.junit.Assert;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class MockObject implements Answer<GetObjectResponse> {
+    private final String namespaceName;
+    private final String bucketName;
+    private final String objectName;
+    private final Map<String, String> metadata;
+    private final int dataLength;
+    private final byte[] data;
+    private final String etag;
+    private final FailureInjector failureInjector;
+
+    public MockObject(
+            Map<String, String> metadata,
+            int dataLength,
+            byte[] data,
+            FailureInjector failureInjector) {
+        this.namespaceName = "namespace" + randomSuffix();
+        this.bucketName = "bucket" + randomSuffix();
+        this.objectName = "object" + randomSuffix();
+        this.dataLength = dataLength;
+        this.data = data;
+        this.metadata = metadata;
+        this.etag = UUID.randomUUID().toString();
+        this.failureInjector = failureInjector;
+    }
+
+    public String getNamespaceName() {
+        return namespaceName;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public String getObjectName() {
+        return objectName;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public int getDataLength() {
+        return dataLength;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    @Override
+    public GetObjectResponse answer(InvocationOnMock invocationOnMock) throws Throwable {
+        return this.getObject((GetObjectRequest) invocationOnMock.getArguments()[0]);
+    }
+
+    GetObjectResponse getObject(GetObjectRequest request) {
+        failureInjector.onGetObjectRequest();
+        if (!request.getNamespaceName().equals(getNamespaceName())
+                || !request.getBucketName().equals(getBucketName())
+                || !request.getObjectName().equals(getObjectName())) {
+            throw new BmcException(404, "NotFound", "object not found", "fakerequestid");
+        }
+        if (request.getIfMatch() != null && !getEtag().equals(request.getIfMatch())) {
+            throw new BmcException(412, "IfMatch", "if-match mismatch", "fakerequestid");
+        }
+        if (request.getIfNoneMatch() != null && getEtag().equals(request.getIfNoneMatch())) {
+            return GetObjectResponse.builder().isNotModified(true).build();
+        }
+        final InputStream inputStream;
+        final long contentLength;
+        if (request.getRange() != null) {
+            final long rangeStart =
+                    request.getRange().getStartByte() == null
+                            ? 0L
+                            : request.getRange().getStartByte();
+            final long rangeEnd =
+                    request.getRange().getEndByte() == null
+                            ? Long.MAX_VALUE
+                            : request.getRange().getEndByte();
+            final long availableData = getDataLength() - rangeStart;
+            Assert.assertTrue(availableData >= 0);
+            if (rangeEnd - rangeStart > availableData - 1) {
+                contentLength = Math.toIntExact(availableData);
+            } else {
+                contentLength = Math.toIntExact(rangeEnd - rangeStart + 1);
+            }
+            inputStream =
+                    new ByteArrayInputStream(
+                            getData(), Math.toIntExact(rangeStart), Math.toIntExact(contentLength));
+        } else {
+            contentLength = getDataLength();
+            inputStream = new ByteArrayInputStream(getData());
+        }
+
+        return GetObjectResponse.builder()
+                .eTag(getEtag())
+                .opcMeta(getMetadata())
+                .inputStream(new FailingInputStream(failureInjector, inputStream))
+                .contentLength(contentLength)
+                .build();
+    }
+
+    private static String randomSuffix() {
+        return Long.toHexString(ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE));
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/MockObjectStorage.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/MockObjectStorage.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import org.mockito.Mockito;
+
+public final class MockObjectStorage {
+
+    private MockObjectStorage() {}
+
+    /**
+     * Create a mock ObjectStorage client that can return the specified object.
+     */
+    public static ObjectStorage create(MockObject mockObject) {
+        final ObjectStorage objectStorage = Mockito.mock(ObjectStorage.class);
+        Mockito.when(objectStorage.getObject(Mockito.anyObject())).thenAnswer(mockObject);
+        return objectStorage;
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/MockObjectTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/MockObjectTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.model.Range;
+import com.oracle.bmc.objectstorage.requests.GetObjectRequest;
+import com.oracle.bmc.objectstorage.responses.GetObjectResponse;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class MockObjectTest {
+
+    /**
+     * Use this for all tests to save setup/teardown time. Tests should not
+     * modify this data!
+     */
+    private static byte[] data;
+
+    @BeforeClass
+    public static void setupClass() {
+        data = new byte[1024];
+        ThreadLocalRandom.current().nextBytes(data);
+    }
+
+    @Test
+    public void objectNotFound() {
+        final MockObject object =
+                new MockObject(new HashMap<>(), data.length, data, NoFailureInjector.INSTANCE);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName("n")
+                        .bucketName("b")
+                        .objectName("o")
+                        .build();
+        try {
+            object.getObject(request);
+            Assert.fail("Expected an exception");
+        } catch (BmcException e) {
+            Assert.assertEquals(e.getStatusCode(), 404);
+        }
+    }
+
+    @Test
+    public void notModified() {
+        final MockObject object =
+                new MockObject(new HashMap<>(), data.length, data, NoFailureInjector.INSTANCE);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(object.getNamespaceName())
+                        .bucketName(object.getBucketName())
+                        .objectName(object.getObjectName())
+                        .ifNoneMatch(object.getEtag())
+                        .build();
+        final GetObjectResponse response = object.getObject(request);
+        Assert.assertTrue(response.isNotModified());
+    }
+
+    @Test
+    public void etagMismatch() {
+        final MockObject object =
+                new MockObject(new HashMap<>(), data.length, data, NoFailureInjector.INSTANCE);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(object.getNamespaceName())
+                        .bucketName(object.getBucketName())
+                        .objectName(object.getObjectName())
+                        .ifMatch("wrongetag")
+                        .build();
+        try {
+            object.getObject(request);
+            Assert.fail("Expected an exception");
+        } catch (BmcException e) {
+            Assert.assertEquals(e.getStatusCode(), 412);
+        }
+    }
+
+    @Test
+    public void read() throws Exception {
+        final MockObject object =
+                new MockObject(new HashMap<>(), data.length, data, NoFailureInjector.INSTANCE);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(object.getNamespaceName())
+                        .bucketName(object.getBucketName())
+                        .objectName(object.getObjectName())
+                        .build();
+        final GetObjectResponse response = object.getObject(request);
+        Assert.assertEquals(response.getInputStream().read(), Byte.toUnsignedInt(data[0]));
+    }
+
+    @Test
+    public void rangeRead() throws Exception {
+        final MockObject object =
+                new MockObject(new HashMap<>(), data.length, data, NoFailureInjector.INSTANCE);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(object.getNamespaceName())
+                        .bucketName(object.getBucketName())
+                        .objectName(object.getObjectName())
+                        .range(new Range(100L, null))
+                        .build();
+        final GetObjectResponse response = object.getObject(request);
+        Assert.assertEquals(response.getInputStream().read(), Byte.toUnsignedInt(data[100]));
+    }
+
+    @Test
+    public void getObjectFails() throws Exception {
+        final FailureInjector failureInjector = new RandomFailureInjector(1.0, 1);
+        final MockObject object =
+                new MockObject(new HashMap<>(), data.length, data, failureInjector);
+        final GetObjectRequest request =
+                GetObjectRequest.builder()
+                        .namespaceName(object.getNamespaceName())
+                        .bucketName(object.getBucketName())
+                        .objectName(object.getObjectName())
+                        .range(new Range(100L, null))
+                        .build();
+        try {
+            object.getObject(request);
+            Assert.fail("Expected an exception");
+        } catch (Exception e) {
+            // expected
+        }
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/NoFailureInjector.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/NoFailureInjector.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import java.io.IOException;
+
+public class NoFailureInjector implements FailureInjector {
+
+    public static final NoFailureInjector INSTANCE = new NoFailureInjector();
+
+    private NoFailureInjector() {}
+
+    @Override
+    public void onGetObjectRequest() {}
+
+    @Override
+    public void onDataRead() throws IOException {}
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/NoFailureInjectorTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/NoFailureInjectorTest.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import org.junit.Test;
+
+public class NoFailureInjectorTest {
+
+    @Test
+    public void neverFails() throws Exception {
+        final FailureInjector failureInjector = NoFailureInjector.INSTANCE;
+        for (int i = 0; i < 10; ++i) {
+            failureInjector.onDataRead();
+            failureInjector.onGetObjectRequest();
+        }
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/RandomFailureInjector.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/RandomFailureInjector.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import com.oracle.bmc.model.BmcException;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RandomFailureInjector implements FailureInjector {
+
+    /**
+     * Chance that an operation will fail.
+     */
+    private final double pctFailureChance;
+
+    /**
+     * Maximum numbers of failures we will generate on a thread.
+     */
+    private final int maxFailures;
+
+    /**
+     * Failures we have seen so far
+     */
+    private AtomicLong failures;
+
+    public RandomFailureInjector(double pctFailureChance, int maxFailures) {
+        this.pctFailureChance = pctFailureChance;
+        this.maxFailures = maxFailures;
+        this.failures = new AtomicLong(0L);
+    }
+
+    @Override
+    public void onGetObjectRequest() {
+        if (this.shouldFail()) {
+            switch (ThreadLocalRandom.current().nextInt(0, 5)) {
+                case 0:
+                    throw new BmcException(
+                            429, "TooManyRequests", "Too many requests (throttling)", requestId());
+                case 1:
+                    throw new BmcException(
+                            500, "InternalServerError", "Internal service error", requestId());
+                case 2:
+                    throw new BmcException(
+                            503,
+                            "ServiceUnavailable",
+                            "Service unavailable (throttling)",
+                            requestId());
+                case 3:
+                    throw new BmcException(
+                            true, "Timeout", new SocketTimeoutException(), requestId());
+                default:
+                    throw new BmcException(false, "IOError", new SocketException(), requestId());
+            }
+        }
+    }
+
+    @Override
+    public void onDataRead() throws IOException {
+        if (this.shouldFail()) {
+            throw new IOException("IO exception on data read");
+        }
+    }
+
+    private static String requestId() {
+        return Long.toHexString(ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE));
+    }
+
+    private boolean shouldFail() {
+        if (this.failures.get() >= this.maxFailures) {
+            // no failures possible
+            return false;
+        }
+        if (ThreadLocalRandom.current().nextDouble() > this.pctFailureChance) {
+            // no random failure
+            return false;
+        }
+        while (true) {
+            final long currentFailures = this.failures.get();
+            if (currentFailures < this.maxFailures) {
+                final long newFailures = currentFailures + 1;
+                if (this.failures.compareAndSet(currentFailures, newFailures)) {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/RandomFailureInjectorTest.java
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/src/test/java/com/oracle/bmc/objectstorage/transfer/helper/RandomFailureInjectorTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.objectstorage.transfer.helper;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RandomFailureInjectorTest {
+
+    @Test
+    public void alwaysFails() {
+        final FailureInjector failureInjector = new RandomFailureInjector(1.0, Integer.MAX_VALUE);
+        for (int i = 0; i < 10; ++i) {
+            try {
+                failureInjector.onGetObjectRequest();
+                Assert.fail("Expected an exception");
+            } catch (Exception e) {
+                // expected
+            }
+            try {
+                failureInjector.onDataRead();
+                Assert.fail("Expected an exception");
+            } catch (Exception e) {
+                // expected
+            }
+        }
+    }
+
+    @Test
+    public void limitedFailures() throws Exception {
+        final FailureInjector failureInjector = new RandomFailureInjector(1.0, 2);
+        try {
+            failureInjector.onGetObjectRequest();
+            Assert.fail("Expected an exception");
+        } catch (Exception e) {
+            // expected
+        }
+        try {
+            failureInjector.onDataRead();
+            Assert.fail("Expected an exception");
+        } catch (Exception e) {
+            // expected
+        }
+        failureInjector.onGetObjectRequest();
+        failureInjector.onDataRead();
+    }
+
+    @Test
+    public void onGetObjectSometimesFails() throws Exception {
+        final FailureInjector failureInjector = new RandomFailureInjector(0.5, Integer.MAX_VALUE);
+
+        // With a 50% chance of failure we should see at least one failure here
+        for (int i = 0; i < 100; ++i) {
+            try {
+                failureInjector.onGetObjectRequest();
+                return;
+            } catch (Exception e) {
+                // Ignore
+            }
+        }
+        Assert.fail("Expected at least one call to succeed");
+    }
+
+    @Test
+    public void onDataReadSometimesFails() throws Exception {
+        final FailureInjector failureInjector = new RandomFailureInjector(0.5, Integer.MAX_VALUE);
+
+        // With a 50% chance of failure we should see at least one success
+        for (int i = 0; i < 100; ++i) {
+            try {
+                failureInjector.onDataRead();
+                return;
+            } catch (Exception e) {
+                // Ignore
+            }
+        }
+        Assert.fail("Expected at least one call to succeed");
+    }
+
+    @Test
+    public void onGetObjectRequestSometimesSucceeds() throws Exception {
+        final FailureInjector failureInjector = new RandomFailureInjector(0.5, Integer.MAX_VALUE);
+
+        // With a 50% chance of failure we should see at least one failure here
+        for (int i = 0; i < 100; ++i) {
+            try {
+                failureInjector.onGetObjectRequest();
+            } catch (Exception e) {
+                return;
+            }
+        }
+        Assert.fail("Expected at least one call to fail");
+    }
+
+    @Test
+    public void onDataReadRequestSometimesSucceeds() throws Exception {
+        final FailureInjector failureInjector = new RandomFailureInjector(0.5, Integer.MAX_VALUE);
+
+        // With a 50% chance of failure we should see at least one failure here
+        for (int i = 0; i < 100; ++i) {
+            try {
+                failureInjector.onDataRead();
+            } catch (Exception e) {
+                return;
+            }
+        }
+        Assert.fail("Expected at least one call to fail");
+    }
+}

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/internal/http/ObjectMetadataInterceptor.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/internal/http/ObjectMetadataInterceptor.java
@@ -37,6 +37,9 @@ public class ObjectMetadataInterceptor {
     }
 
     public static CopyObjectRequest intercept(CopyObjectRequest request) {
+        if (request.getCopyObjectDetails().getDestinationObjectMetadata() == null) {
+            return request;
+        }
         Map<String, String> newMetadata =
                 toServiceMeta(request.getCopyObjectDetails().getDestinationObjectMetadata());
         CopyObjectDetails newDetails =

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/model/UpdateOceInstanceDetails.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/model/UpdateOceInstanceDetails.java
@@ -53,6 +53,15 @@ public class UpdateOceInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceUsageType")
+        private InstanceUsageType instanceUsageType;
+
+        public Builder instanceUsageType(InstanceUsageType instanceUsageType) {
+            this.instanceUsageType = instanceUsageType;
+            this.__explicitlySet__.add("instanceUsageType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -81,6 +90,7 @@ public class UpdateOceInstanceDetails {
                             description,
                             wafPrimaryDomain,
                             instanceLicenseType,
+                            instanceUsageType,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -93,6 +103,7 @@ public class UpdateOceInstanceDetails {
                     description(o.getDescription())
                             .wafPrimaryDomain(o.getWafPrimaryDomain())
                             .instanceLicenseType(o.getInstanceLicenseType())
+                            .instanceUsageType(o.getInstanceUsageType())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -125,6 +136,46 @@ public class UpdateOceInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("instanceLicenseType")
     LicenseType instanceLicenseType;
+    /**
+     * Instance type based on its usage
+     **/
+    public enum InstanceUsageType {
+        Primary("PRIMARY"),
+        Nonprimary("NONPRIMARY"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, InstanceUsageType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (InstanceUsageType v : InstanceUsageType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        InstanceUsageType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static InstanceUsageType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid InstanceUsageType: " + key);
+        }
+    };
+    /**
+     * Instance type based on its usage
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceUsageType")
+    InstanceUsageType instanceUsageType;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/ResourceSearchAsyncClient.java
+++ b/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/ResourceSearchAsyncClient.java
@@ -31,7 +31,7 @@ public class ResourceSearchAsyncClient implements ResourceSearchAsync {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("RESOURCESEARCH")
                     .serviceEndpointPrefix("query")
-                    .serviceEndpointTemplate("https://query.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate("https://query.{region}.oci.{secondLevelDomain}")
                     .build();
 
     @lombok.Getter(value = lombok.AccessLevel.PACKAGE)

--- a/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/ResourceSearchClient.java
+++ b/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/ResourceSearchClient.java
@@ -18,7 +18,7 @@ public class ResourceSearchClient implements ResourceSearch {
             com.oracle.bmc.Services.serviceBuilder()
                     .serviceName("RESOURCESEARCH")
                     .serviceEndpointPrefix("query")
-                    .serviceEndpointTemplate("https://query.{region}.{secondLevelDomain}")
+                    .serviceEndpointTemplate("https://query.{region}.oci.{secondLevelDomain}")
                     .build();
     // attempt twice if it's instance principals, immediately failures will try to refresh the token
     private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;

--- a/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/requests/SearchResourcesRequest.java
+++ b/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/requests/SearchResourcesRequest.java
@@ -14,7 +14,8 @@ import com.oracle.bmc.resourcesearch.model.*;
 public class SearchResourcesRequest extends com.oracle.bmc.requests.BmcRequest<SearchDetails> {
 
     /**
-     * Request parameters that describe query criteria.
+     * Request parameters that describe query criteria. For more information, see {@link #searchDetails(SearchDetailsRequest) searchDetails}.
+     *
      */
     private SearchDetails searchDetails;
 

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.33.1</version>
+    <version>1.33.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.33.1</version>
+      <version>1.33.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.33.1</version>
+  <version>1.33.2</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for routing policies and HTTP2 listener protocols in the Load Balancing service

- Support for model deployments in the Data Science service

- Support for private clusters in the Container Engine for Kubernetes service

- Support for updating an instance's usage type in the Content and Experience service