### PR TITLE
Releasing version 1.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.36.1 - 2021-04-20
+### Added
+- Support for opting in/out of live migration on instances in the Compute service
+- Support for enabling/disabling Operations Insights on external non-container and external pluggable databases in the Database service
+- Support for a GraphStudio URL as a connection URL on databases in the Database service
+- Support for adding customer contacts on autonomous databases in the Database service
+- Support for name annotations on harvested objects in the Data Catalog service
+
 ## 1.36.0 - 2021-04-13
 ### Added
 - Support for the Database Migration service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -15,11 +15,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,11 +17,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,456 +19,456 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/io/internal/WrappedByteArrayInputStream.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/io/internal/WrappedByteArrayInputStream.java
@@ -16,6 +16,9 @@ import com.oracle.bmc.io.DuplicatableInputStream;
 public class WrappedByteArrayInputStream extends ByteArrayInputStream
         implements DuplicatableInputStream {
 
+    private int length;
+    private int offset;
+
     /**
      * Create a new stream from the given buffer.
      * @param buf The byte buffer.
@@ -32,6 +35,8 @@ public class WrappedByteArrayInputStream extends ByteArrayInputStream
      */
     public WrappedByteArrayInputStream(byte[] buf, int offset, int length) {
         super(buf, offset, length);
+        this.offset = offset;
+        this.length = length;
     }
 
     /**
@@ -40,11 +45,12 @@ public class WrappedByteArrayInputStream extends ByteArrayInputStream
      * @return The length of the underlying buffer.
      */
     public long length() {
-        return buf.length;
+        return length == 0 ? buf.length : Math.min(offset + length, buf.length);
     }
 
     @Override
     public InputStream duplicate() {
-        return new WrappedByteArrayInputStream(this.buf);
+        if (length == 0 && offset == 0) return new WrappedByteArrayInputStream(this.buf);
+        else return new WrappedByteArrayInputStream(this.buf, offset, length);
     }
 }

--- a/bmc-common/src/test/java/com/oracle/bmc/io/internal/WrappedByteArrayInputStreamTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/io/internal/WrappedByteArrayInputStreamTest.java
@@ -19,6 +19,9 @@ public class WrappedByteArrayInputStreamTest {
 
         WrappedByteArrayInputStream stream = new WrappedByteArrayInputStream(buffer);
         assertEquals(35, stream.length());
+
+        WrappedByteArrayInputStream stream1 = new WrappedByteArrayInputStream(buffer, 4, 20);
+        assertEquals(24, stream1.length());
     }
 
     @Test
@@ -44,7 +47,8 @@ public class WrappedByteArrayInputStreamTest {
     }
 
     @Test
-    public void testStreamWithOffsetLength() throws IOException {
+    public void testDuplicateStreamWithOffsetLength() throws IOException {
+
         byte[] buffer = new byte[20];
         buffer[2] = 'a';
         buffer[6] = 'b';
@@ -53,5 +57,14 @@ public class WrappedByteArrayInputStreamTest {
         byte[] stream1buffer = new byte[7];
         int read1 = stream1.read(stream1buffer);
         assertEquals(7, read1);
+
+        WrappedByteArrayInputStream stream2 = (WrappedByteArrayInputStream) stream1.duplicate();
+        byte[] stream2buffer = new byte[7];
+        int read2 = stream2.read(stream2buffer);
+        assertEquals(7, read2);
+
+        for (int i = 0; i < 7; i++) {
+            assertEquals(stream1buffer[i], stream2buffer[i]);
+        }
     }
 }

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,11 +17,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,16 +17,17 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceAvailabilityConfig.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceAvailabilityConfig.java
@@ -27,6 +27,15 @@ public class InstanceAvailabilityConfig {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isLiveMigrationPreferred")
+        private Boolean isLiveMigrationPreferred;
+
+        public Builder isLiveMigrationPreferred(Boolean isLiveMigrationPreferred) {
+            this.isLiveMigrationPreferred = isLiveMigrationPreferred;
+            this.__explicitlySet__.add("isLiveMigrationPreferred");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
         private RecoveryAction recoveryAction;
 
@@ -41,14 +50,16 @@ public class InstanceAvailabilityConfig {
 
         public InstanceAvailabilityConfig build() {
             InstanceAvailabilityConfig __instance__ =
-                    new InstanceAvailabilityConfig(recoveryAction);
+                    new InstanceAvailabilityConfig(isLiveMigrationPreferred, recoveryAction);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(InstanceAvailabilityConfig o) {
-            Builder copiedBuilder = recoveryAction(o.getRecoveryAction());
+            Builder copiedBuilder =
+                    isLiveMigrationPreferred(o.getIsLiveMigrationPreferred())
+                            .recoveryAction(o.getRecoveryAction());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -62,6 +73,14 @@ public class InstanceAvailabilityConfig {
         return new Builder();
     }
 
+    /**
+     * Whether to live migrate supported VM instances to a healthy physical VM host without
+     * disrupting running instances during infrastructure maintenance events. If null, Oracle
+     * chooses the best option for migrating the VM during infrastructure maintenance events.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLiveMigrationPreferred")
+    Boolean isLiveMigrationPreferred;
     /**
      * The lifecycle state for an instance when it is recovered after infrastructure maintenance.
      * * `RESTORE_INSTANCE` - The instance is restored to the lifecycle state it was in before the maintenance event.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceAvailabilityConfigDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/LaunchInstanceAvailabilityConfigDetails.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Options for defining the availability of a VM instance after a maintenance event that impacts the underlying hardware.
+ * Options for defining the availability of a VM instance after a maintenance event that impacts the underlying
+ * hardware, including whether to live migrate supported VM instances when possible.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -27,6 +28,15 @@ public class LaunchInstanceAvailabilityConfigDetails {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isLiveMigrationPreferred")
+        private Boolean isLiveMigrationPreferred;
+
+        public Builder isLiveMigrationPreferred(Boolean isLiveMigrationPreferred) {
+            this.isLiveMigrationPreferred = isLiveMigrationPreferred;
+            this.__explicitlySet__.add("isLiveMigrationPreferred");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
         private RecoveryAction recoveryAction;
 
@@ -41,14 +51,17 @@ public class LaunchInstanceAvailabilityConfigDetails {
 
         public LaunchInstanceAvailabilityConfigDetails build() {
             LaunchInstanceAvailabilityConfigDetails __instance__ =
-                    new LaunchInstanceAvailabilityConfigDetails(recoveryAction);
+                    new LaunchInstanceAvailabilityConfigDetails(
+                            isLiveMigrationPreferred, recoveryAction);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(LaunchInstanceAvailabilityConfigDetails o) {
-            Builder copiedBuilder = recoveryAction(o.getRecoveryAction());
+            Builder copiedBuilder =
+                    isLiveMigrationPreferred(o.getIsLiveMigrationPreferred())
+                            .recoveryAction(o.getRecoveryAction());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -62,6 +75,14 @@ public class LaunchInstanceAvailabilityConfigDetails {
         return new Builder();
     }
 
+    /**
+     * Whether to live migrate supported VM instances to a healthy physical VM host without
+     * disrupting running instances during infrastructure maintenance events. If null, Oracle
+     * chooses the best option for migrating the VM during infrastructure maintenance events.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLiveMigrationPreferred")
+    Boolean isLiveMigrationPreferred;
     /**
      * The lifecycle state for an instance when it is recovered after infrastructure maintenance.
      * * `RESTORE_INSTANCE` - The instance is restored to the lifecycle state it was in before the maintenance event.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Shape.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Shape.java
@@ -146,6 +146,15 @@ public class Shape {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLiveMigrationSupported")
+        private Boolean isLiveMigrationSupported;
+
+        public Builder isLiveMigrationSupported(Boolean isLiveMigrationSupported) {
+            this.isLiveMigrationSupported = isLiveMigrationSupported;
+            this.__explicitlySet__.add("isLiveMigrationSupported");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("ocpuOptions")
         private ShapeOcpuOptions ocpuOptions;
 
@@ -203,6 +212,7 @@ public class Shape {
                             localDisks,
                             localDisksTotalSizeInGBs,
                             localDiskDescription,
+                            isLiveMigrationSupported,
                             ocpuOptions,
                             memoryOptions,
                             networkingBandwidthOptions,
@@ -227,6 +237,7 @@ public class Shape {
                             .localDisks(o.getLocalDisks())
                             .localDisksTotalSizeInGBs(o.getLocalDisksTotalSizeInGBs())
                             .localDiskDescription(o.getLocalDiskDescription())
+                            .isLiveMigrationSupported(o.getIsLiveMigrationSupported())
                             .ocpuOptions(o.getOcpuOptions())
                             .memoryOptions(o.getMemoryOptions())
                             .networkingBandwidthOptions(o.getNetworkingBandwidthOptions())
@@ -388,6 +399,13 @@ public class Shape {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("localDiskDescription")
     String localDiskDescription;
+
+    /**
+     * Whether live migration is supported for this shape.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLiveMigrationSupported")
+    Boolean isLiveMigrationSupported;
 
     @com.fasterxml.jackson.annotation.JsonProperty("ocpuOptions")
     ShapeOcpuOptions ocpuOptions;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceAvailabilityConfigDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateInstanceAvailabilityConfigDetails.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.core.model;
 
 /**
- * Options for defining the availability of a VM instance after a maintenance event that impacts the underlying hardware.
+ * Options for defining the availability of a VM instance after a maintenance event that impacts the underlying
+ * hardware, including whether to live migrate supported VM instances when possible.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -27,6 +28,15 @@ public class UpdateInstanceAvailabilityConfigDetails {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isLiveMigrationPreferred")
+        private Boolean isLiveMigrationPreferred;
+
+        public Builder isLiveMigrationPreferred(Boolean isLiveMigrationPreferred) {
+            this.isLiveMigrationPreferred = isLiveMigrationPreferred;
+            this.__explicitlySet__.add("isLiveMigrationPreferred");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("recoveryAction")
         private RecoveryAction recoveryAction;
 
@@ -41,14 +51,17 @@ public class UpdateInstanceAvailabilityConfigDetails {
 
         public UpdateInstanceAvailabilityConfigDetails build() {
             UpdateInstanceAvailabilityConfigDetails __instance__ =
-                    new UpdateInstanceAvailabilityConfigDetails(recoveryAction);
+                    new UpdateInstanceAvailabilityConfigDetails(
+                            isLiveMigrationPreferred, recoveryAction);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateInstanceAvailabilityConfigDetails o) {
-            Builder copiedBuilder = recoveryAction(o.getRecoveryAction());
+            Builder copiedBuilder =
+                    isLiveMigrationPreferred(o.getIsLiveMigrationPreferred())
+                            .recoveryAction(o.getRecoveryAction());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -62,6 +75,14 @@ public class UpdateInstanceAvailabilityConfigDetails {
         return new Builder();
     }
 
+    /**
+     * Whether to live migrate supported VM instances to a healthy physical VM host without
+     * disrupting running instances during infrastructure maintenance events. If null, Oracle
+     * chooses the best option for migrating the VM during infrastructure maintenance events.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLiveMigrationPreferred")
+    Boolean isLiveMigrationPreferred;
     /**
      * The lifecycle state for an instance when it is recovered after infrastructure maintenance.
      * * `RESTORE_INSTANCE` - The instance is restored to the lifecycle state it was in before the maintenance event.

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,16 +17,17 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
@@ -862,6 +862,19 @@ public interface Database extends AutoCloseable {
                     DisableExternalNonContainerDatabaseDatabaseManagementRequest request);
 
     /**
+     * Disable Operations Insights for the external non-container database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/DisableExternalNonContainerDatabaseOperationsInsightsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DisableExternalNonContainerDatabaseOperationsInsights API.
+     */
+    DisableExternalNonContainerDatabaseOperationsInsightsResponse
+            disableExternalNonContainerDatabaseOperationsInsights(
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest request);
+
+    /**
      * Disable Database Management Service for the external pluggable database.
      * For more information about the Database Management Service, see
      * [Database Management Service](https://docs.cloud.oracle.com/Content/ExternalDatabase/Concepts/databasemanagementservice.htm).
@@ -875,6 +888,19 @@ public interface Database extends AutoCloseable {
     DisableExternalPluggableDatabaseDatabaseManagementResponse
             disableExternalPluggableDatabaseDatabaseManagement(
                     DisableExternalPluggableDatabaseDatabaseManagementRequest request);
+
+    /**
+     * Disable Operations Insights for the external pluggable database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/DisableExternalPluggableDatabaseOperationsInsightsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DisableExternalPluggableDatabaseOperationsInsights API.
+     */
+    DisableExternalPluggableDatabaseOperationsInsightsResponse
+            disableExternalPluggableDatabaseOperationsInsights(
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest request);
 
     /**
      * Downloads the configuration file for the specified Exadata Cloud@Customer infrastructure.
@@ -943,6 +969,19 @@ public interface Database extends AutoCloseable {
                     EnableExternalNonContainerDatabaseDatabaseManagementRequest request);
 
     /**
+     * Enable Operations Insights for the external non-container database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/EnableExternalNonContainerDatabaseOperationsInsightsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use EnableExternalNonContainerDatabaseOperationsInsights API.
+     */
+    EnableExternalNonContainerDatabaseOperationsInsightsResponse
+            enableExternalNonContainerDatabaseOperationsInsights(
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest request);
+
+    /**
      * Enable Database Management Service for the external pluggable database.
      * For more information about the Database Management Service, see
      * [Database Management Service](https://docs.cloud.oracle.com/Content/ExternalDatabase/Concepts/databasemanagementservice.htm).
@@ -956,6 +995,19 @@ public interface Database extends AutoCloseable {
     EnableExternalPluggableDatabaseDatabaseManagementResponse
             enableExternalPluggableDatabaseDatabaseManagement(
                     EnableExternalPluggableDatabaseDatabaseManagementRequest request);
+
+    /**
+     * Enable Operations Insights for the external pluggable database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/EnableExternalPluggableDatabaseOperationsInsightsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use EnableExternalPluggableDatabaseOperationsInsights API.
+     */
+    EnableExternalPluggableDatabaseOperationsInsightsResponse
+            enableExternalPluggableDatabaseOperationsInsights(
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest request);
 
     /**
      * Initiates a failover the specified Autonomous Database to a standby.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
@@ -1247,6 +1247,25 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Disable Operations Insights for the external non-container database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+            disableExternalNonContainerDatabaseOperationsInsights(
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    DisableExternalNonContainerDatabaseOperationsInsightsRequest,
+                                    DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+                            handler);
+
+    /**
      * Disable Database Management Service for the external pluggable database.
      * For more information about the Database Management Service, see
      * [Database Management Service](https://docs.cloud.oracle.com/Content/ExternalDatabase/Concepts/databasemanagementservice.htm).
@@ -1265,6 +1284,25 @@ public interface DatabaseAsync extends AutoCloseable {
                     com.oracle.bmc.responses.AsyncHandler<
                                     DisableExternalPluggableDatabaseDatabaseManagementRequest,
                                     DisableExternalPluggableDatabaseDatabaseManagementResponse>
+                            handler);
+
+    /**
+     * Disable Operations Insights for the external pluggable database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DisableExternalPluggableDatabaseOperationsInsightsResponse>
+            disableExternalPluggableDatabaseOperationsInsights(
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    DisableExternalPluggableDatabaseOperationsInsightsRequest,
+                                    DisableExternalPluggableDatabaseOperationsInsightsResponse>
                             handler);
 
     /**
@@ -1367,6 +1405,25 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Enable Operations Insights for the external non-container database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+            enableExternalNonContainerDatabaseOperationsInsights(
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    EnableExternalNonContainerDatabaseOperationsInsightsRequest,
+                                    EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+                            handler);
+
+    /**
      * Enable Database Management Service for the external pluggable database.
      * For more information about the Database Management Service, see
      * [Database Management Service](https://docs.cloud.oracle.com/Content/ExternalDatabase/Concepts/databasemanagementservice.htm).
@@ -1385,6 +1442,25 @@ public interface DatabaseAsync extends AutoCloseable {
                     com.oracle.bmc.responses.AsyncHandler<
                                     EnableExternalPluggableDatabaseDatabaseManagementRequest,
                                     EnableExternalPluggableDatabaseDatabaseManagementResponse>
+                            handler);
+
+    /**
+     * Enable Operations Insights for the external pluggable database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<EnableExternalPluggableDatabaseOperationsInsightsResponse>
+            enableExternalPluggableDatabaseOperationsInsights(
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    EnableExternalPluggableDatabaseOperationsInsightsRequest,
+                                    EnableExternalPluggableDatabaseOperationsInsightsResponse>
                             handler);
 
     /**

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -3222,6 +3222,60 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<
+                    DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+            disableExternalNonContainerDatabaseOperationsInsights(
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DisableExternalNonContainerDatabaseOperationsInsightsRequest,
+                                    DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+                            handler) {
+        LOG.trace("Called async disableExternalNonContainerDatabaseOperationsInsights");
+        final DisableExternalNonContainerDatabaseOperationsInsightsRequest interceptedRequest =
+                DisableExternalNonContainerDatabaseOperationsInsightsConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DisableExternalNonContainerDatabaseOperationsInsightsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+                transformer =
+                        DisableExternalNonContainerDatabaseOperationsInsightsConverter
+                                .fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DisableExternalNonContainerDatabaseOperationsInsightsRequest,
+                        DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DisableExternalNonContainerDatabaseOperationsInsightsRequest,
+                                DisableExternalNonContainerDatabaseOperationsInsightsResponse>,
+                        java.util.concurrent.Future<
+                                DisableExternalNonContainerDatabaseOperationsInsightsResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest,
+                    DisableExternalNonContainerDatabaseOperationsInsightsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<DisableExternalPluggableDatabaseDatabaseManagementResponse>
             disableExternalPluggableDatabaseDatabaseManagement(
                     DisableExternalPluggableDatabaseDatabaseManagementRequest request,
@@ -3261,6 +3315,58 @@ public class DatabaseAsyncClient implements DatabaseAsync {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     DisableExternalPluggableDatabaseDatabaseManagementRequest,
                     DisableExternalPluggableDatabaseDatabaseManagementResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DisableExternalPluggableDatabaseOperationsInsightsResponse>
+            disableExternalPluggableDatabaseOperationsInsights(
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DisableExternalPluggableDatabaseOperationsInsightsRequest,
+                                    DisableExternalPluggableDatabaseOperationsInsightsResponse>
+                            handler) {
+        LOG.trace("Called async disableExternalPluggableDatabaseOperationsInsights");
+        final DisableExternalPluggableDatabaseOperationsInsightsRequest interceptedRequest =
+                DisableExternalPluggableDatabaseOperationsInsightsConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DisableExternalPluggableDatabaseOperationsInsightsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        DisableExternalPluggableDatabaseOperationsInsightsResponse>
+                transformer =
+                        DisableExternalPluggableDatabaseOperationsInsightsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DisableExternalPluggableDatabaseOperationsInsightsRequest,
+                        DisableExternalPluggableDatabaseOperationsInsightsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DisableExternalPluggableDatabaseOperationsInsightsRequest,
+                                DisableExternalPluggableDatabaseOperationsInsightsResponse>,
+                        java.util.concurrent.Future<
+                                DisableExternalPluggableDatabaseOperationsInsightsResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest,
+                    DisableExternalPluggableDatabaseOperationsInsightsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -3524,6 +3630,59 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+            enableExternalNonContainerDatabaseOperationsInsights(
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    EnableExternalNonContainerDatabaseOperationsInsightsRequest,
+                                    EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+                            handler) {
+        LOG.trace("Called async enableExternalNonContainerDatabaseOperationsInsights");
+        final EnableExternalNonContainerDatabaseOperationsInsightsRequest interceptedRequest =
+                EnableExternalNonContainerDatabaseOperationsInsightsConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                EnableExternalNonContainerDatabaseOperationsInsightsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+                transformer =
+                        EnableExternalNonContainerDatabaseOperationsInsightsConverter
+                                .fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        EnableExternalNonContainerDatabaseOperationsInsightsRequest,
+                        EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                EnableExternalNonContainerDatabaseOperationsInsightsRequest,
+                                EnableExternalNonContainerDatabaseOperationsInsightsResponse>,
+                        java.util.concurrent.Future<
+                                EnableExternalNonContainerDatabaseOperationsInsightsResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest,
+                    EnableExternalNonContainerDatabaseOperationsInsightsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<EnableExternalPluggableDatabaseDatabaseManagementResponse>
             enableExternalPluggableDatabaseDatabaseManagement(
                     EnableExternalPluggableDatabaseDatabaseManagementRequest request,
@@ -3563,6 +3722,58 @@ public class DatabaseAsyncClient implements DatabaseAsync {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     EnableExternalPluggableDatabaseDatabaseManagementRequest,
                     EnableExternalPluggableDatabaseDatabaseManagementResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<EnableExternalPluggableDatabaseOperationsInsightsResponse>
+            enableExternalPluggableDatabaseOperationsInsights(
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    EnableExternalPluggableDatabaseOperationsInsightsRequest,
+                                    EnableExternalPluggableDatabaseOperationsInsightsResponse>
+                            handler) {
+        LOG.trace("Called async enableExternalPluggableDatabaseOperationsInsights");
+        final EnableExternalPluggableDatabaseOperationsInsightsRequest interceptedRequest =
+                EnableExternalPluggableDatabaseOperationsInsightsConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                EnableExternalPluggableDatabaseOperationsInsightsConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        EnableExternalPluggableDatabaseOperationsInsightsResponse>
+                transformer =
+                        EnableExternalPluggableDatabaseOperationsInsightsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        EnableExternalPluggableDatabaseOperationsInsightsRequest,
+                        EnableExternalPluggableDatabaseOperationsInsightsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                EnableExternalPluggableDatabaseOperationsInsightsRequest,
+                                EnableExternalPluggableDatabaseOperationsInsightsResponse>,
+                        java.util.concurrent.Future<
+                                EnableExternalPluggableDatabaseOperationsInsightsResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest,
+                    EnableExternalPluggableDatabaseOperationsInsightsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -2623,6 +2623,44 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public DisableExternalNonContainerDatabaseOperationsInsightsResponse
+            disableExternalNonContainerDatabaseOperationsInsights(
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest request) {
+        LOG.trace("Called disableExternalNonContainerDatabaseOperationsInsights");
+        final DisableExternalNonContainerDatabaseOperationsInsightsRequest interceptedRequest =
+                DisableExternalNonContainerDatabaseOperationsInsightsConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DisableExternalNonContainerDatabaseOperationsInsightsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+                transformer =
+                        DisableExternalNonContainerDatabaseOperationsInsightsConverter
+                                .fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public DisableExternalPluggableDatabaseDatabaseManagementResponse
             disableExternalPluggableDatabaseDatabaseManagement(
                     DisableExternalPluggableDatabaseDatabaseManagementRequest request) {
@@ -2638,6 +2676,43 @@ public class DatabaseClient implements Database {
                         DisableExternalPluggableDatabaseDatabaseManagementResponse>
                 transformer =
                         DisableExternalPluggableDatabaseDatabaseManagementConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DisableExternalPluggableDatabaseOperationsInsightsResponse
+            disableExternalPluggableDatabaseOperationsInsights(
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest request) {
+        LOG.trace("Called disableExternalPluggableDatabaseOperationsInsights");
+        final DisableExternalPluggableDatabaseOperationsInsightsRequest interceptedRequest =
+                DisableExternalPluggableDatabaseOperationsInsightsConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DisableExternalPluggableDatabaseOperationsInsightsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        DisableExternalPluggableDatabaseOperationsInsightsResponse>
+                transformer =
+                        DisableExternalPluggableDatabaseOperationsInsightsConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -2842,6 +2917,48 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public EnableExternalNonContainerDatabaseOperationsInsightsResponse
+            enableExternalNonContainerDatabaseOperationsInsights(
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest request) {
+        LOG.trace("Called enableExternalNonContainerDatabaseOperationsInsights");
+        final EnableExternalNonContainerDatabaseOperationsInsightsRequest interceptedRequest =
+                EnableExternalNonContainerDatabaseOperationsInsightsConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                EnableExternalNonContainerDatabaseOperationsInsightsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+                transformer =
+                        EnableExternalNonContainerDatabaseOperationsInsightsConverter
+                                .fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getEnableExternalNonContainerDatabaseOperationsInsightsDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public EnableExternalPluggableDatabaseDatabaseManagementResponse
             enableExternalPluggableDatabaseDatabaseManagement(
                     EnableExternalPluggableDatabaseDatabaseManagementRequest request) {
@@ -2876,6 +2993,47 @@ public class DatabaseClient implements Database {
                                                 ib,
                                                 retriedRequest
                                                         .getEnableExternalPluggableDatabaseDatabaseManagementDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public EnableExternalPluggableDatabaseOperationsInsightsResponse
+            enableExternalPluggableDatabaseOperationsInsights(
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest request) {
+        LOG.trace("Called enableExternalPluggableDatabaseOperationsInsights");
+        final EnableExternalPluggableDatabaseOperationsInsightsRequest interceptedRequest =
+                EnableExternalPluggableDatabaseOperationsInsightsConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                EnableExternalPluggableDatabaseOperationsInsightsConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        EnableExternalPluggableDatabaseOperationsInsightsResponse>
+                transformer =
+                        EnableExternalPluggableDatabaseOperationsInsightsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getEnableExternalPluggableDatabaseOperationsInsightsDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
@@ -3513,6 +3513,73 @@ public class DatabaseWaiters {
      * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest,
+                    DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+            forDisableExternalNonContainerDatabaseOperationsInsights(
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest request) {
+        return forDisableExternalNonContainerDatabaseOperationsInsights(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest,
+                    DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+            forDisableExternalNonContainerDatabaseOperationsInsights(
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<
+                        DisableExternalNonContainerDatabaseOperationsInsightsResponse>() {
+                    @Override
+                    public DisableExternalNonContainerDatabaseOperationsInsightsResponse call()
+                            throws Exception {
+                        final DisableExternalNonContainerDatabaseOperationsInsightsResponse
+                                response =
+                                        client
+                                                .disableExternalNonContainerDatabaseOperationsInsights(
+                                                        request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
                     DisableExternalPluggableDatabaseDatabaseManagementRequest,
                     DisableExternalPluggableDatabaseDatabaseManagementResponse>
             forDisableExternalPluggableDatabaseDatabaseManagement(
@@ -3552,6 +3619,70 @@ public class DatabaseWaiters {
                             throws Exception {
                         final DisableExternalPluggableDatabaseDatabaseManagementResponse response =
                                 client.disableExternalPluggableDatabaseDatabaseManagement(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest,
+                    DisableExternalPluggableDatabaseOperationsInsightsResponse>
+            forDisableExternalPluggableDatabaseOperationsInsights(
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest request) {
+        return forDisableExternalPluggableDatabaseOperationsInsights(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest,
+                    DisableExternalPluggableDatabaseOperationsInsightsResponse>
+            forDisableExternalPluggableDatabaseOperationsInsights(
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<
+                        DisableExternalPluggableDatabaseOperationsInsightsResponse>() {
+                    @Override
+                    public DisableExternalPluggableDatabaseOperationsInsightsResponse call()
+                            throws Exception {
+                        final DisableExternalPluggableDatabaseOperationsInsightsResponse response =
+                                client.disableExternalPluggableDatabaseOperationsInsights(request);
 
                         final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
                                 getWorkRequestRequest =
@@ -3771,6 +3902,72 @@ public class DatabaseWaiters {
      * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest,
+                    EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+            forEnableExternalNonContainerDatabaseOperationsInsights(
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest request) {
+        return forEnableExternalNonContainerDatabaseOperationsInsights(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest,
+                    EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+            forEnableExternalNonContainerDatabaseOperationsInsights(
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<
+                        EnableExternalNonContainerDatabaseOperationsInsightsResponse>() {
+                    @Override
+                    public EnableExternalNonContainerDatabaseOperationsInsightsResponse call()
+                            throws Exception {
+                        final EnableExternalNonContainerDatabaseOperationsInsightsResponse
+                                response =
+                                        client.enableExternalNonContainerDatabaseOperationsInsights(
+                                                request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
                     EnableExternalPluggableDatabaseDatabaseManagementRequest,
                     EnableExternalPluggableDatabaseDatabaseManagementResponse>
             forEnableExternalPluggableDatabaseDatabaseManagement(
@@ -3810,6 +4007,70 @@ public class DatabaseWaiters {
                             throws Exception {
                         final EnableExternalPluggableDatabaseDatabaseManagementResponse response =
                                 client.enableExternalPluggableDatabaseDatabaseManagement(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest,
+                    EnableExternalPluggableDatabaseOperationsInsightsResponse>
+            forEnableExternalPluggableDatabaseOperationsInsights(
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest request) {
+        return forEnableExternalPluggableDatabaseOperationsInsights(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest,
+                    EnableExternalPluggableDatabaseOperationsInsightsResponse>
+            forEnableExternalPluggableDatabaseOperationsInsights(
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<
+                        EnableExternalPluggableDatabaseOperationsInsightsResponse>() {
+                    @Override
+                    public EnableExternalPluggableDatabaseOperationsInsightsResponse call()
+                            throws Exception {
+                        final EnableExternalPluggableDatabaseOperationsInsightsResponse response =
+                                client.enableExternalPluggableDatabaseOperationsInsights(request);
 
                         final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
                                 getWorkRequestRequest =

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DisableExternalNonContainerDatabaseOperationsInsightsConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DisableExternalNonContainerDatabaseOperationsInsightsConverter.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DisableExternalNonContainerDatabaseOperationsInsightsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .DisableExternalNonContainerDatabaseOperationsInsightsRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .DisableExternalNonContainerDatabaseOperationsInsightsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .DisableExternalNonContainerDatabaseOperationsInsightsRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExternalNonContainerDatabaseId(),
+                "externalNonContainerDatabaseId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("externalnoncontainerdatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExternalNonContainerDatabaseId()))
+                        .path("actions")
+                        .path("disableOperationsInsights");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .DisableExternalNonContainerDatabaseOperationsInsightsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .DisableExternalNonContainerDatabaseOperationsInsightsResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .DisableExternalNonContainerDatabaseOperationsInsightsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.DisableExternalNonContainerDatabaseOperationsInsightsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .DisableExternalNonContainerDatabaseOperationsInsightsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .DisableExternalNonContainerDatabaseOperationsInsightsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .DisableExternalNonContainerDatabaseOperationsInsightsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DisableExternalPluggableDatabaseOperationsInsightsConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/DisableExternalPluggableDatabaseOperationsInsightsConverter.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DisableExternalPluggableDatabaseOperationsInsightsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .DisableExternalPluggableDatabaseOperationsInsightsRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .DisableExternalPluggableDatabaseOperationsInsightsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .DisableExternalPluggableDatabaseOperationsInsightsRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExternalPluggableDatabaseId(),
+                "externalPluggableDatabaseId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("externalpluggabledatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExternalPluggableDatabaseId()))
+                        .path("actions")
+                        .path("disableOperationsInsights");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .DisableExternalPluggableDatabaseOperationsInsightsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .DisableExternalPluggableDatabaseOperationsInsightsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .DisableExternalPluggableDatabaseOperationsInsightsResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .DisableExternalPluggableDatabaseOperationsInsightsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.DisableExternalPluggableDatabaseOperationsInsightsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .DisableExternalPluggableDatabaseOperationsInsightsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .DisableExternalPluggableDatabaseOperationsInsightsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .DisableExternalPluggableDatabaseOperationsInsightsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/EnableExternalNonContainerDatabaseOperationsInsightsConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/EnableExternalNonContainerDatabaseOperationsInsightsConverter.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class EnableExternalNonContainerDatabaseOperationsInsightsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .EnableExternalNonContainerDatabaseOperationsInsightsRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .EnableExternalNonContainerDatabaseOperationsInsightsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .EnableExternalNonContainerDatabaseOperationsInsightsRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExternalNonContainerDatabaseId(),
+                "externalNonContainerDatabaseId must not be blank");
+        Validate.notNull(
+                request.getEnableExternalNonContainerDatabaseOperationsInsightsDetails(),
+                "enableExternalNonContainerDatabaseOperationsInsightsDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("externalnoncontainerdatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExternalNonContainerDatabaseId()))
+                        .path("actions")
+                        .path("enableOperationsInsights");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .EnableExternalNonContainerDatabaseOperationsInsightsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .EnableExternalNonContainerDatabaseOperationsInsightsResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .EnableExternalNonContainerDatabaseOperationsInsightsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.EnableExternalNonContainerDatabaseOperationsInsightsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .EnableExternalNonContainerDatabaseOperationsInsightsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .EnableExternalNonContainerDatabaseOperationsInsightsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .EnableExternalNonContainerDatabaseOperationsInsightsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/EnableExternalPluggableDatabaseOperationsInsightsConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/EnableExternalPluggableDatabaseOperationsInsightsConverter.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class EnableExternalPluggableDatabaseOperationsInsightsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .EnableExternalPluggableDatabaseOperationsInsightsRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .EnableExternalPluggableDatabaseOperationsInsightsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .EnableExternalPluggableDatabaseOperationsInsightsRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getExternalPluggableDatabaseId(),
+                "externalPluggableDatabaseId must not be blank");
+        Validate.notNull(
+                request.getEnableExternalPluggableDatabaseOperationsInsightsDetails(),
+                "enableExternalPluggableDatabaseOperationsInsightsDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("externalpluggabledatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getExternalPluggableDatabaseId()))
+                        .path("actions")
+                        .path("enableOperationsInsights");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .EnableExternalPluggableDatabaseOperationsInsightsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .EnableExternalPluggableDatabaseOperationsInsightsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .EnableExternalPluggableDatabaseOperationsInsightsResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .EnableExternalPluggableDatabaseOperationsInsightsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.EnableExternalPluggableDatabaseOperationsInsightsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .EnableExternalPluggableDatabaseOperationsInsightsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .EnableExternalPluggableDatabaseOperationsInsightsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .EnableExternalPluggableDatabaseOperationsInsightsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseDataguardAssociation.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseDataguardAssociation.java
@@ -247,7 +247,8 @@ public class AutonomousContainerDatabaseDataguardAssociation {
     @com.fasterxml.jackson.annotation.JsonProperty("autonomousContainerDatabaseId")
     String autonomousContainerDatabaseId;
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Role {
@@ -293,7 +294,8 @@ public class AutonomousContainerDatabaseDataguardAssociation {
         }
     };
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("role")
     Role role;
@@ -375,7 +377,8 @@ public class AutonomousContainerDatabaseDataguardAssociation {
     @com.fasterxml.jackson.annotation.JsonProperty("peerAutonomousContainerDatabaseId")
     String peerAutonomousContainerDatabaseId;
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum PeerRole {
@@ -422,7 +425,8 @@ public class AutonomousContainerDatabaseDataguardAssociation {
         }
     };
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("peerRole")
     PeerRole peerRole;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -579,6 +579,15 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+        private java.util.List<CustomerContact> customerContacts;
+
+        public Builder customerContacts(java.util.List<CustomerContact> customerContacts) {
+            this.customerContacts = customerContacts;
+            this.__explicitlySet__.add("customerContacts");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -645,7 +654,8 @@ public class AutonomousDatabase {
                             role,
                             availableUpgradeVersions,
                             keyStoreId,
-                            keyStoreWalletName);
+                            keyStoreWalletName,
+                            customerContacts);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -715,7 +725,8 @@ public class AutonomousDatabase {
                             .role(o.getRole())
                             .availableUpgradeVersions(o.getAvailableUpgradeVersions())
                             .keyStoreId(o.getKeyStoreId())
-                            .keyStoreWalletName(o.getKeyStoreWalletName());
+                            .keyStoreWalletName(o.getKeyStoreWalletName())
+                            .customerContacts(o.getCustomerContacts());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -1614,7 +1625,8 @@ public class AutonomousDatabase {
     @com.fasterxml.jackson.annotation.JsonProperty("standbyDb")
     AutonomousDatabaseStandbySummary standbyDb;
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Role {
@@ -1660,7 +1672,8 @@ public class AutonomousDatabase {
         }
     };
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("role")
     Role role;
@@ -1682,6 +1695,12 @@ public class AutonomousDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("keyStoreWalletName")
     String keyStoreWalletName;
+
+    /**
+     * Customer Contacts.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+    java.util.List<CustomerContact> customerContacts;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseConnectionUrls.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseConnectionUrls.java
@@ -56,13 +56,25 @@ public class AutonomousDatabaseConnectionUrls {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("graphStudioUrl")
+        private String graphStudioUrl;
+
+        public Builder graphStudioUrl(String graphStudioUrl) {
+            this.graphStudioUrl = graphStudioUrl;
+            this.__explicitlySet__.add("graphStudioUrl");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public AutonomousDatabaseConnectionUrls build() {
             AutonomousDatabaseConnectionUrls __instance__ =
                     new AutonomousDatabaseConnectionUrls(
-                            sqlDevWebUrl, apexUrl, machineLearningUserManagementUrl);
+                            sqlDevWebUrl,
+                            apexUrl,
+                            machineLearningUserManagementUrl,
+                            graphStudioUrl);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -73,7 +85,8 @@ public class AutonomousDatabaseConnectionUrls {
                     sqlDevWebUrl(o.getSqlDevWebUrl())
                             .apexUrl(o.getApexUrl())
                             .machineLearningUserManagementUrl(
-                                    o.getMachineLearningUserManagementUrl());
+                                    o.getMachineLearningUserManagementUrl())
+                            .graphStudioUrl(o.getGraphStudioUrl());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -104,6 +117,12 @@ public class AutonomousDatabaseConnectionUrls {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("machineLearningUserManagementUrl")
     String machineLearningUserManagementUrl;
+
+    /**
+     * The URL of the Graph Studio for the Autonomous Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("graphStudioUrl")
+    String graphStudioUrl;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseDataguardAssociation.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseDataguardAssociation.java
@@ -235,7 +235,8 @@ public class AutonomousDatabaseDataguardAssociation {
     @com.fasterxml.jackson.annotation.JsonProperty("autonomousDatabaseId")
     String autonomousDatabaseId;
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Role {
@@ -281,7 +282,8 @@ public class AutonomousDatabaseDataguardAssociation {
         }
     };
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("role")
     Role role;
@@ -349,7 +351,8 @@ public class AutonomousDatabaseDataguardAssociation {
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
     String lifecycleDetails;
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum PeerRole {
@@ -396,7 +399,8 @@ public class AutonomousDatabaseDataguardAssociation {
         }
     };
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("peerRole")
     PeerRole peerRole;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -581,6 +581,15 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+        private java.util.List<CustomerContact> customerContacts;
+
+        public Builder customerContacts(java.util.List<CustomerContact> customerContacts) {
+            this.customerContacts = customerContacts;
+            this.__explicitlySet__.add("customerContacts");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -647,7 +656,8 @@ public class AutonomousDatabaseSummary {
                             role,
                             availableUpgradeVersions,
                             keyStoreId,
-                            keyStoreWalletName);
+                            keyStoreWalletName,
+                            customerContacts);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -717,7 +727,8 @@ public class AutonomousDatabaseSummary {
                             .role(o.getRole())
                             .availableUpgradeVersions(o.getAvailableUpgradeVersions())
                             .keyStoreId(o.getKeyStoreId())
-                            .keyStoreWalletName(o.getKeyStoreWalletName());
+                            .keyStoreWalletName(o.getKeyStoreWalletName())
+                            .customerContacts(o.getCustomerContacts());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -1616,7 +1627,8 @@ public class AutonomousDatabaseSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("standbyDb")
     AutonomousDatabaseStandbySummary standbyDb;
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum Role {
@@ -1662,7 +1674,8 @@ public class AutonomousDatabaseSummary {
         }
     };
     /**
-     * The role of the Autonomous Data Guard-enabled Autonomous Container Database.
+     * The Data Guard role of the Autonomous Container Database, if Autonomous Data Guard is enabled.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("role")
     Role role;
@@ -1684,6 +1697,12 @@ public class AutonomousDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("keyStoreWalletName")
     String keyStoreWalletName;
+
+    /**
+     * Customer Contacts.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+    java.util.List<CustomerContact> customerContacts;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
@@ -344,6 +344,12 @@ public class CreateAutonomousDatabaseBase {
     String dbVersion;
 
     /**
+     * Customer Contacts.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+    java.util.List<CustomerContact> customerContacts;
+
+    /**
      * The source of the database: Use `NONE` for creating a new Autonomous Database. Use `DATABASE` for creating a new Autonomous Database by cloning an existing Autonomous Database.
      * <p>
      * For Autonomous Databases on [shared Exadata infrastructure](https://docs.cloud.oracle.com/Content/Database/Concepts/adboverview.htm#AEI), the following cloning options are available: Use `BACKUP_FROM_ID` for creating a new Autonomous Database from a specified backup. Use `BACKUP_FROM_TIMESTAMP` for creating a point-in-time Autonomous Database clone using backups. For more information, see [Cloning an Autonomous Database](https://docs.cloud.oracle.com/Content/Database/Tasks/adbcloning.htm).

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
@@ -252,6 +252,15 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+        private java.util.List<CustomerContact> customerContacts;
+
+        public Builder customerContacts(java.util.List<CustomerContact> customerContacts) {
+            this.customerContacts = customerContacts;
+            this.__explicitlySet__.add("customerContacts");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
         private String sourceId;
 
@@ -300,6 +309,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             freeformTags,
                             definedTags,
                             dbVersion,
+                            customerContacts,
                             sourceId,
                             cloneType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -334,6 +344,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
+                            .customerContacts(o.getCustomerContacts())
                             .sourceId(o.getSourceId())
                             .cloneType(o.getCloneType());
 
@@ -375,6 +386,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
+            java.util.List<CustomerContact> customerContacts,
             String sourceId,
             CloneType cloneType) {
         super(
@@ -401,7 +413,8 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                 privateEndpointLabel,
                 freeformTags,
                 definedTags,
-                dbVersion);
+                dbVersion,
+                customerContacts);
         this.sourceId = sourceId;
         this.cloneType = cloneType;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
@@ -252,6 +252,15 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+        private java.util.List<CustomerContact> customerContacts;
+
+        public Builder customerContacts(java.util.List<CustomerContact> customerContacts) {
+            this.customerContacts = customerContacts;
+            this.__explicitlySet__.add("customerContacts");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -281,7 +290,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             privateEndpointLabel,
                             freeformTags,
                             definedTags,
-                            dbVersion);
+                            dbVersion,
+                            customerContacts);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -313,7 +323,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             .privateEndpointLabel(o.getPrivateEndpointLabel())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
-                            .dbVersion(o.getDbVersion());
+                            .dbVersion(o.getDbVersion())
+                            .customerContacts(o.getCustomerContacts());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -352,7 +363,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             String privateEndpointLabel,
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
-            String dbVersion) {
+            String dbVersion,
+            java.util.List<CustomerContact> customerContacts) {
         super(
                 compartmentId,
                 dbName,
@@ -377,7 +389,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                 privateEndpointLabel,
                 freeformTags,
                 definedTags,
-                dbVersion);
+                dbVersion,
+                customerContacts);
     }
 
     @com.fasterxml.jackson.annotation.JsonIgnore

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
@@ -252,6 +252,15 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+        private java.util.List<CustomerContact> customerContacts;
+
+        public Builder customerContacts(java.util.List<CustomerContact> customerContacts) {
+            this.customerContacts = customerContacts;
+            this.__explicitlySet__.add("customerContacts");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("autonomousDatabaseBackupId")
         private String autonomousDatabaseBackupId;
 
@@ -300,6 +309,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             freeformTags,
                             definedTags,
                             dbVersion,
+                            customerContacts,
                             autonomousDatabaseBackupId,
                             cloneType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -334,6 +344,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
+                            .customerContacts(o.getCustomerContacts())
                             .autonomousDatabaseBackupId(o.getAutonomousDatabaseBackupId())
                             .cloneType(o.getCloneType());
 
@@ -375,6 +386,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
+            java.util.List<CustomerContact> customerContacts,
             String autonomousDatabaseBackupId,
             CloneType cloneType) {
         super(
@@ -401,7 +413,8 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                 privateEndpointLabel,
                 freeformTags,
                 definedTags,
-                dbVersion);
+                dbVersion,
+                customerContacts);
         this.autonomousDatabaseBackupId = autonomousDatabaseBackupId;
         this.cloneType = cloneType;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
@@ -253,6 +253,15 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+        private java.util.List<CustomerContact> customerContacts;
+
+        public Builder customerContacts(java.util.List<CustomerContact> customerContacts) {
+            this.customerContacts = customerContacts;
+            this.__explicitlySet__.add("customerContacts");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("autonomousDatabaseId")
         private String autonomousDatabaseId;
 
@@ -310,6 +319,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             freeformTags,
                             definedTags,
                             dbVersion,
+                            customerContacts,
                             autonomousDatabaseId,
                             timestamp,
                             cloneType);
@@ -345,6 +355,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
+                            .customerContacts(o.getCustomerContacts())
                             .autonomousDatabaseId(o.getAutonomousDatabaseId())
                             .timestamp(o.getTimestamp())
                             .cloneType(o.getCloneType());
@@ -387,6 +398,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
+            java.util.List<CustomerContact> customerContacts,
             String autonomousDatabaseId,
             java.util.Date timestamp,
             CloneType cloneType) {
@@ -414,7 +426,8 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                 privateEndpointLabel,
                 freeformTags,
                 definedTags,
-                dbVersion);
+                dbVersion,
+                customerContacts);
         this.autonomousDatabaseId = autonomousDatabaseId;
         this.timestamp = timestamp;
         this.cloneType = cloneType;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
@@ -207,7 +207,7 @@ public class CreateDatabaseDetails {
     String databaseSoftwareImageId;
 
     /**
-     * The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+     * The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pdbName")
     String pdbName;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
@@ -252,6 +252,15 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+        private java.util.List<CustomerContact> customerContacts;
+
+        public Builder customerContacts(java.util.List<CustomerContact> customerContacts) {
+            this.customerContacts = customerContacts;
+            this.__explicitlySet__.add("customerContacts");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
         private String sourceId;
 
@@ -300,6 +309,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             freeformTags,
                             definedTags,
                             dbVersion,
+                            customerContacts,
                             sourceId,
                             refreshableMode);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -334,6 +344,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
+                            .customerContacts(o.getCustomerContacts())
                             .sourceId(o.getSourceId())
                             .refreshableMode(o.getRefreshableMode());
 
@@ -375,6 +386,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
+            java.util.List<CustomerContact> customerContacts,
             String sourceId,
             RefreshableMode refreshableMode) {
         super(
@@ -401,7 +413,8 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                 privateEndpointLabel,
                 freeformTags,
                 definedTags,
-                dbVersion);
+                dbVersion,
+                customerContacts);
         this.sourceId = sourceId;
         this.refreshableMode = refreshableMode;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CustomerContact.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CustomerContact.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The object holds customer email contact for Oracle Autonomous Databases.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = CustomerContact.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CustomerContact {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("email")
+        private String email;
+
+        public Builder email(String email) {
+            this.email = email;
+            this.__explicitlySet__.add("email");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CustomerContact build() {
+            CustomerContact __instance__ = new CustomerContact(email);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CustomerContact o) {
+            Builder copiedBuilder = email(o.getEmail());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The email address of an Oracle Autonomous Database contact.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("email")
+    String email;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/Database.java
@@ -345,7 +345,7 @@ public class Database {
     String dbName;
 
     /**
-     * The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+     * The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pdbName")
     String pdbName;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSummary.java
@@ -350,7 +350,7 @@ public class DatabaseSummary {
     String dbName;
 
     /**
-     * The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of eight alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
+     * The name of the pluggable database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. Pluggable database should not be same as database name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pdbName")
     String pdbName;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/EnableExternalDatabaseOperationsInsightsDetailsBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/EnableExternalDatabaseOperationsInsightsDetailsBase.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details to enable Operations Insights on the external database.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EnableExternalDatabaseOperationsInsightsDetailsBase.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EnableExternalDatabaseOperationsInsightsDetailsBase {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("externalDatabaseConnectorId")
+        private String externalDatabaseConnectorId;
+
+        public Builder externalDatabaseConnectorId(String externalDatabaseConnectorId) {
+            this.externalDatabaseConnectorId = externalDatabaseConnectorId;
+            this.__explicitlySet__.add("externalDatabaseConnectorId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EnableExternalDatabaseOperationsInsightsDetailsBase build() {
+            EnableExternalDatabaseOperationsInsightsDetailsBase __instance__ =
+                    new EnableExternalDatabaseOperationsInsightsDetailsBase(
+                            externalDatabaseConnectorId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EnableExternalDatabaseOperationsInsightsDetailsBase o) {
+            Builder copiedBuilder = externalDatabaseConnectorId(o.getExternalDatabaseConnectorId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the
+     * {@link #createExternalDatabaseConnectorDetails(CreateExternalDatabaseConnectorDetailsRequest) createExternalDatabaseConnectorDetails}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalDatabaseConnectorId")
+    String externalDatabaseConnectorId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/EnableExternalNonContainerDatabaseOperationsInsightsDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/EnableExternalNonContainerDatabaseOperationsInsightsDetails.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details to enable Operations Insights on the external non-container database
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EnableExternalNonContainerDatabaseOperationsInsightsDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EnableExternalNonContainerDatabaseOperationsInsightsDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("externalDatabaseConnectorId")
+        private String externalDatabaseConnectorId;
+
+        public Builder externalDatabaseConnectorId(String externalDatabaseConnectorId) {
+            this.externalDatabaseConnectorId = externalDatabaseConnectorId;
+            this.__explicitlySet__.add("externalDatabaseConnectorId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EnableExternalNonContainerDatabaseOperationsInsightsDetails build() {
+            EnableExternalNonContainerDatabaseOperationsInsightsDetails __instance__ =
+                    new EnableExternalNonContainerDatabaseOperationsInsightsDetails(
+                            externalDatabaseConnectorId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EnableExternalNonContainerDatabaseOperationsInsightsDetails o) {
+            Builder copiedBuilder = externalDatabaseConnectorId(o.getExternalDatabaseConnectorId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the
+     * {@link #createExternalDatabaseConnectorDetails(CreateExternalDatabaseConnectorDetailsRequest) createExternalDatabaseConnectorDetails}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalDatabaseConnectorId")
+    String externalDatabaseConnectorId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/EnableExternalPluggableDatabaseOperationsInsightsDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/EnableExternalPluggableDatabaseOperationsInsightsDetails.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details to enable Operations Insights on the external pluggable database
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EnableExternalPluggableDatabaseOperationsInsightsDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EnableExternalPluggableDatabaseOperationsInsightsDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("externalDatabaseConnectorId")
+        private String externalDatabaseConnectorId;
+
+        public Builder externalDatabaseConnectorId(String externalDatabaseConnectorId) {
+            this.externalDatabaseConnectorId = externalDatabaseConnectorId;
+            this.__explicitlySet__.add("externalDatabaseConnectorId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EnableExternalPluggableDatabaseOperationsInsightsDetails build() {
+            EnableExternalPluggableDatabaseOperationsInsightsDetails __instance__ =
+                    new EnableExternalPluggableDatabaseOperationsInsightsDetails(
+                            externalDatabaseConnectorId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EnableExternalPluggableDatabaseOperationsInsightsDetails o) {
+            Builder copiedBuilder = externalDatabaseConnectorId(o.getExternalDatabaseConnectorId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the
+     * {@link #createExternalDatabaseConnectorDetails(CreateExternalDatabaseConnectorDetailsRequest) createExternalDatabaseConnectorDetails}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("externalDatabaseConnectorId")
+    String externalDatabaseConnectorId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalNonContainerDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalNonContainerDatabase.java
@@ -26,6 +26,15 @@ public class ExternalNonContainerDatabase {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConfig")
+        private OperationsInsightsConfig operationsInsightsConfig;
+
+        public Builder operationsInsightsConfig(OperationsInsightsConfig operationsInsightsConfig) {
+            this.operationsInsightsConfig = operationsInsightsConfig;
+            this.__explicitlySet__.add("operationsInsightsConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -186,6 +195,7 @@ public class ExternalNonContainerDatabase {
         public ExternalNonContainerDatabase build() {
             ExternalNonContainerDatabase __instance__ =
                     new ExternalNonContainerDatabase(
+                            operationsInsightsConfig,
                             compartmentId,
                             freeformTags,
                             definedTags,
@@ -210,7 +220,8 @@ public class ExternalNonContainerDatabase {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ExternalNonContainerDatabase o) {
             Builder copiedBuilder =
-                    compartmentId(o.getCompartmentId())
+                    operationsInsightsConfig(o.getOperationsInsightsConfig())
+                            .compartmentId(o.getCompartmentId())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .displayName(o.getDisplayName())
@@ -239,6 +250,9 @@ public class ExternalNonContainerDatabase {
     public static Builder builder() {
         return new Builder();
     }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConfig")
+    OperationsInsightsConfig operationsInsightsConfig;
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalNonContainerDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalNonContainerDatabaseSummary.java
@@ -28,6 +28,15 @@ public class ExternalNonContainerDatabaseSummary {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConfig")
+        private OperationsInsightsConfig operationsInsightsConfig;
+
+        public Builder operationsInsightsConfig(OperationsInsightsConfig operationsInsightsConfig) {
+            this.operationsInsightsConfig = operationsInsightsConfig;
+            this.__explicitlySet__.add("operationsInsightsConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -188,6 +197,7 @@ public class ExternalNonContainerDatabaseSummary {
         public ExternalNonContainerDatabaseSummary build() {
             ExternalNonContainerDatabaseSummary __instance__ =
                     new ExternalNonContainerDatabaseSummary(
+                            operationsInsightsConfig,
                             compartmentId,
                             freeformTags,
                             definedTags,
@@ -212,7 +222,8 @@ public class ExternalNonContainerDatabaseSummary {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ExternalNonContainerDatabaseSummary o) {
             Builder copiedBuilder =
-                    compartmentId(o.getCompartmentId())
+                    operationsInsightsConfig(o.getOperationsInsightsConfig())
+                            .compartmentId(o.getCompartmentId())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .displayName(o.getDisplayName())
@@ -241,6 +252,9 @@ public class ExternalNonContainerDatabaseSummary {
     public static Builder builder() {
         return new Builder();
     }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConfig")
+    OperationsInsightsConfig operationsInsightsConfig;
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalPluggableDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalPluggableDatabase.java
@@ -44,6 +44,15 @@ public class ExternalPluggableDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConfig")
+        private OperationsInsightsConfig operationsInsightsConfig;
+
+        public Builder operationsInsightsConfig(OperationsInsightsConfig operationsInsightsConfig) {
+            this.operationsInsightsConfig = operationsInsightsConfig;
+            this.__explicitlySet__.add("operationsInsightsConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -206,6 +215,7 @@ public class ExternalPluggableDatabase {
                     new ExternalPluggableDatabase(
                             sourceId,
                             externalContainerDatabaseId,
+                            operationsInsightsConfig,
                             compartmentId,
                             freeformTags,
                             definedTags,
@@ -232,6 +242,7 @@ public class ExternalPluggableDatabase {
             Builder copiedBuilder =
                     sourceId(o.getSourceId())
                             .externalContainerDatabaseId(o.getExternalContainerDatabaseId())
+                            .operationsInsightsConfig(o.getOperationsInsightsConfig())
                             .compartmentId(o.getCompartmentId())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
@@ -278,6 +289,9 @@ public class ExternalPluggableDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("externalContainerDatabaseId")
     String externalContainerDatabaseId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConfig")
+    OperationsInsightsConfig operationsInsightsConfig;
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalPluggableDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalPluggableDatabaseSummary.java
@@ -45,6 +45,15 @@ public class ExternalPluggableDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConfig")
+        private OperationsInsightsConfig operationsInsightsConfig;
+
+        public Builder operationsInsightsConfig(OperationsInsightsConfig operationsInsightsConfig) {
+            this.operationsInsightsConfig = operationsInsightsConfig;
+            this.__explicitlySet__.add("operationsInsightsConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
@@ -207,6 +216,7 @@ public class ExternalPluggableDatabaseSummary {
                     new ExternalPluggableDatabaseSummary(
                             sourceId,
                             externalContainerDatabaseId,
+                            operationsInsightsConfig,
                             compartmentId,
                             freeformTags,
                             definedTags,
@@ -233,6 +243,7 @@ public class ExternalPluggableDatabaseSummary {
             Builder copiedBuilder =
                     sourceId(o.getSourceId())
                             .externalContainerDatabaseId(o.getExternalContainerDatabaseId())
+                            .operationsInsightsConfig(o.getOperationsInsightsConfig())
                             .compartmentId(o.getCompartmentId())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
@@ -279,6 +290,9 @@ public class ExternalPluggableDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("externalContainerDatabaseId")
     String externalContainerDatabaseId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConfig")
+    OperationsInsightsConfig operationsInsightsConfig;
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/OperationsInsightsConfig.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/OperationsInsightsConfig.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The configuration of Operations Insights for the external database
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OperationsInsightsConfig.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OperationsInsightsConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsStatus")
+        private OperationsInsightsStatus operationsInsightsStatus;
+
+        public Builder operationsInsightsStatus(OperationsInsightsStatus operationsInsightsStatus) {
+            this.operationsInsightsStatus = operationsInsightsStatus;
+            this.__explicitlySet__.add("operationsInsightsStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConnectorId")
+        private String operationsInsightsConnectorId;
+
+        public Builder operationsInsightsConnectorId(String operationsInsightsConnectorId) {
+            this.operationsInsightsConnectorId = operationsInsightsConnectorId;
+            this.__explicitlySet__.add("operationsInsightsConnectorId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OperationsInsightsConfig build() {
+            OperationsInsightsConfig __instance__ =
+                    new OperationsInsightsConfig(
+                            operationsInsightsStatus, operationsInsightsConnectorId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OperationsInsightsConfig o) {
+            Builder copiedBuilder =
+                    operationsInsightsStatus(o.getOperationsInsightsStatus())
+                            .operationsInsightsConnectorId(o.getOperationsInsightsConnectorId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The status of Operations Insights
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum OperationsInsightsStatus {
+        Enabling("ENABLING"),
+        Enabled("ENABLED"),
+        Disabling("DISABLING"),
+        NotEnabled("NOT_ENABLED"),
+        FailedEnabling("FAILED_ENABLING"),
+        FailedDisabling("FAILED_DISABLING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, OperationsInsightsStatus> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (OperationsInsightsStatus v : OperationsInsightsStatus.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        OperationsInsightsStatus(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static OperationsInsightsStatus create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'OperationsInsightsStatus', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The status of Operations Insights
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsStatus")
+    OperationsInsightsStatus operationsInsightsStatus;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the
+     * {@link #createExternalDatabaseConnectorDetails(CreateExternalDatabaseConnectorDetailsRequest) createExternalDatabaseConnectorDetails}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("operationsInsightsConnectorId")
+    String operationsInsightsConnectorId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
@@ -246,6 +246,15 @@ public class UpdateAutonomousDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+        private java.util.List<CustomerContact> customerContacts;
+
+        public Builder customerContacts(java.util.List<CustomerContact> customerContacts) {
+            this.customerContacts = customerContacts;
+            this.__explicitlySet__.add("customerContacts");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -275,7 +284,8 @@ public class UpdateAutonomousDatabaseDetails {
                             permissionLevel,
                             subnetId,
                             privateEndpointLabel,
-                            nsgIds);
+                            nsgIds,
+                            customerContacts);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -306,7 +316,8 @@ public class UpdateAutonomousDatabaseDetails {
                             .permissionLevel(o.getPermissionLevel())
                             .subnetId(o.getSubnetId())
                             .privateEndpointLabel(o.getPrivateEndpointLabel())
-                            .nsgIds(o.getNsgIds());
+                            .nsgIds(o.getNsgIds())
+                            .customerContacts(o.getCustomerContacts());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -713,6 +724,12 @@ public class UpdateAutonomousDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
     java.util.List<String> nsgIds;
+
+    /**
+     * Customer Contacts. Setting this to an empty list removes all customer contacts of an Oracle Autonomous Database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
+    java.util.List<CustomerContact> customerContacts;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/DisableExternalNonContainerDatabaseOperationsInsightsRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/DisableExternalNonContainerDatabaseOperationsInsightsRequest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/DisableExternalNonContainerDatabaseOperationsInsightsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DisableExternalNonContainerDatabaseOperationsInsightsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DisableExternalNonContainerDatabaseOperationsInsightsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The external non-container database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String externalNonContainerDatabaseId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DisableExternalNonContainerDatabaseOperationsInsightsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DisableExternalNonContainerDatabaseOperationsInsightsRequest o) {
+            externalNonContainerDatabaseId(o.getExternalNonContainerDatabaseId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DisableExternalNonContainerDatabaseOperationsInsightsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DisableExternalNonContainerDatabaseOperationsInsightsRequest
+         */
+        public DisableExternalNonContainerDatabaseOperationsInsightsRequest build() {
+            DisableExternalNonContainerDatabaseOperationsInsightsRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/DisableExternalPluggableDatabaseOperationsInsightsRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/DisableExternalPluggableDatabaseOperationsInsightsRequest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/DisableExternalPluggableDatabaseOperationsInsightsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DisableExternalPluggableDatabaseOperationsInsightsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DisableExternalPluggableDatabaseOperationsInsightsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ExternalPluggableDatabaseId [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String externalPluggableDatabaseId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DisableExternalPluggableDatabaseOperationsInsightsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DisableExternalPluggableDatabaseOperationsInsightsRequest o) {
+            externalPluggableDatabaseId(o.getExternalPluggableDatabaseId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DisableExternalPluggableDatabaseOperationsInsightsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DisableExternalPluggableDatabaseOperationsInsightsRequest
+         */
+        public DisableExternalPluggableDatabaseOperationsInsightsRequest build() {
+            DisableExternalPluggableDatabaseOperationsInsightsRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/EnableExternalNonContainerDatabaseOperationsInsightsRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/EnableExternalNonContainerDatabaseOperationsInsightsRequest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/EnableExternalNonContainerDatabaseOperationsInsightsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use EnableExternalNonContainerDatabaseOperationsInsightsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class EnableExternalNonContainerDatabaseOperationsInsightsRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                EnableExternalNonContainerDatabaseOperationsInsightsDetails> {
+
+    /**
+     * The external non-container database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String externalNonContainerDatabaseId;
+
+    /**
+     * Details to enable Operations Insights on the external non-container database
+     *
+     */
+    private EnableExternalNonContainerDatabaseOperationsInsightsDetails
+            enableExternalNonContainerDatabaseOperationsInsightsDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public EnableExternalNonContainerDatabaseOperationsInsightsDetails getBody$() {
+        return enableExternalNonContainerDatabaseOperationsInsightsDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    EnableExternalNonContainerDatabaseOperationsInsightsRequest,
+                    EnableExternalNonContainerDatabaseOperationsInsightsDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(EnableExternalNonContainerDatabaseOperationsInsightsRequest o) {
+            externalNonContainerDatabaseId(o.getExternalNonContainerDatabaseId());
+            enableExternalNonContainerDatabaseOperationsInsightsDetails(
+                    o.getEnableExternalNonContainerDatabaseOperationsInsightsDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of EnableExternalNonContainerDatabaseOperationsInsightsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of EnableExternalNonContainerDatabaseOperationsInsightsRequest
+         */
+        public EnableExternalNonContainerDatabaseOperationsInsightsRequest build() {
+            EnableExternalNonContainerDatabaseOperationsInsightsRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(EnableExternalNonContainerDatabaseOperationsInsightsDetails body) {
+            enableExternalNonContainerDatabaseOperationsInsightsDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/EnableExternalPluggableDatabaseOperationsInsightsRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/EnableExternalPluggableDatabaseOperationsInsightsRequest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/EnableExternalPluggableDatabaseOperationsInsightsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use EnableExternalPluggableDatabaseOperationsInsightsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class EnableExternalPluggableDatabaseOperationsInsightsRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                EnableExternalPluggableDatabaseOperationsInsightsDetails> {
+
+    /**
+     * The ExternalPluggableDatabaseId [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String externalPluggableDatabaseId;
+
+    /**
+     * Details to enable Operations Insights on the external pluggable database
+     *
+     */
+    private EnableExternalPluggableDatabaseOperationsInsightsDetails
+            enableExternalPluggableDatabaseOperationsInsightsDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public EnableExternalPluggableDatabaseOperationsInsightsDetails getBody$() {
+        return enableExternalPluggableDatabaseOperationsInsightsDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    EnableExternalPluggableDatabaseOperationsInsightsRequest,
+                    EnableExternalPluggableDatabaseOperationsInsightsDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(EnableExternalPluggableDatabaseOperationsInsightsRequest o) {
+            externalPluggableDatabaseId(o.getExternalPluggableDatabaseId());
+            enableExternalPluggableDatabaseOperationsInsightsDetails(
+                    o.getEnableExternalPluggableDatabaseOperationsInsightsDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of EnableExternalPluggableDatabaseOperationsInsightsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of EnableExternalPluggableDatabaseOperationsInsightsRequest
+         */
+        public EnableExternalPluggableDatabaseOperationsInsightsRequest build() {
+            EnableExternalPluggableDatabaseOperationsInsightsRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(EnableExternalPluggableDatabaseOperationsInsightsDetails body) {
+            enableExternalPluggableDatabaseOperationsInsightsDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/DisableExternalNonContainerDatabaseOperationsInsightsResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/DisableExternalNonContainerDatabaseOperationsInsightsResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class DisableExternalNonContainerDatabaseOperationsInsightsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DisableExternalNonContainerDatabaseOperationsInsightsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/DisableExternalPluggableDatabaseOperationsInsightsResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/DisableExternalPluggableDatabaseOperationsInsightsResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class DisableExternalPluggableDatabaseOperationsInsightsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DisableExternalPluggableDatabaseOperationsInsightsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/EnableExternalNonContainerDatabaseOperationsInsightsResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/EnableExternalNonContainerDatabaseOperationsInsightsResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class EnableExternalNonContainerDatabaseOperationsInsightsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(EnableExternalNonContainerDatabaseOperationsInsightsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/EnableExternalPluggableDatabaseOperationsInsightsResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/EnableExternalPluggableDatabaseOperationsInsightsResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class EnableExternalPluggableDatabaseOperationsInsightsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     */
+    private String etag;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(EnableExternalPluggableDatabaseOperationsInsightsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalog.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalog.java
@@ -1170,6 +1170,16 @@ public interface DataCatalog extends AutoCloseable {
     SearchCriteriaResponse searchCriteria(SearchCriteriaRequest request);
 
     /**
+     * Returns a list of potential string matches for a given input string.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datacatalog/SuggestMatchesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SuggestMatches API.
+     */
+    SuggestMatchesResponse suggestMatches(SuggestMatchesRequest request);
+
+    /**
      * Test the connection by connecting to the data asset using credentials in the metadata.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogAsync.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogAsync.java
@@ -1732,6 +1732,21 @@ public interface DataCatalogAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Returns a list of potential string matches for a given input string.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SuggestMatchesResponse> suggestMatches(
+            SuggestMatchesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<SuggestMatchesRequest, SuggestMatchesResponse>
+                    handler);
+
+    /**
      * Test the connection by connecting to the data asset using credentials in the metadata.
      *
      * @param request The request object containing the details to send

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogAsyncClient.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogAsyncClient.java
@@ -4701,6 +4701,45 @@ public class DataCatalogAsyncClient implements DataCatalogAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<SuggestMatchesResponse> suggestMatches(
+            SuggestMatchesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            SuggestMatchesRequest, SuggestMatchesResponse>
+                    handler) {
+        LOG.trace("Called async suggestMatches");
+        final SuggestMatchesRequest interceptedRequest =
+                SuggestMatchesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SuggestMatchesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, SuggestMatchesResponse>
+                transformer = SuggestMatchesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<SuggestMatchesRequest, SuggestMatchesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SuggestMatchesRequest, SuggestMatchesResponse>,
+                        java.util.concurrent.Future<SuggestMatchesResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SuggestMatchesRequest, SuggestMatchesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<TestConnectionResponse> testConnection(
             TestConnectionRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogClient.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/DataCatalogClient.java
@@ -3729,6 +3729,35 @@ public class DataCatalogClient implements DataCatalog {
     }
 
     @Override
+    public SuggestMatchesResponse suggestMatches(SuggestMatchesRequest request) {
+        LOG.trace("Called suggestMatches");
+        final SuggestMatchesRequest interceptedRequest =
+                SuggestMatchesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SuggestMatchesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, SuggestMatchesResponse>
+                transformer = SuggestMatchesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public TestConnectionResponse testConnection(TestConnectionRequest request) {
         LOG.trace("Called testConnection");
         final TestConnectionRequest interceptedRequest =

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListAttributesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListAttributesConverter.java
@@ -56,6 +56,22 @@ public class ListAttributesConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getBusinessName() != null) {
+            target =
+                    target.queryParam(
+                            "businessName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBusinessName()));
+        }
+
+        if (request.getDisplayOrBusinessNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayOrBusinessNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayOrBusinessNameContains()));
+        }
+
         if (request.getDisplayNameContains() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListEntitiesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListEntitiesConverter.java
@@ -51,6 +51,30 @@ public class ListEntitiesConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getBusinessName() != null) {
+            target =
+                    target.queryParam(
+                            "businessName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBusinessName()));
+        }
+
+        if (request.getDisplayOrBusinessNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayOrBusinessNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayOrBusinessNameContains()));
+        }
+
+        if (request.getTypeKey() != null) {
+            target =
+                    target.queryParam(
+                            "typeKey",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTypeKey()));
+        }
+
         if (request.getDisplayNameContains() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListFoldersConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListFoldersConverter.java
@@ -51,6 +51,22 @@ public class ListFoldersConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getBusinessName() != null) {
+            target =
+                    target.queryParam(
+                            "businessName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBusinessName()));
+        }
+
+        if (request.getDisplayOrBusinessNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "displayOrBusinessNameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayOrBusinessNameContains()));
+        }
+
         if (request.getDisplayNameContains() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListJobsConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/ListJobsConverter.java
@@ -110,6 +110,14 @@ public class ListJobsConverter {
                                     request.getJobDefinitionKey()));
         }
 
+        if (request.getDataAssetKey() != null) {
+            target =
+                    target.queryParam(
+                            "dataAssetKey",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDataAssetKey()));
+        }
+
         if (request.getScheduleCronExpression() != null) {
             target =
                     target.queryParam(

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/SuggestMatchesConverter.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/internal/http/SuggestMatchesConverter.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.datacatalog.model.*;
+import com.oracle.bmc.datacatalog.requests.*;
+import com.oracle.bmc.datacatalog.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.extern.slf4j.Slf4j
+public class SuggestMatchesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.datacatalog.requests.SuggestMatchesRequest interceptRequest(
+            com.oracle.bmc.datacatalog.requests.SuggestMatchesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.datacatalog.requests.SuggestMatchesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getCatalogId(), "catalogId must not be blank");
+        Validate.notNull(request.getInputText(), "inputText is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190325")
+                        .path("catalogs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getCatalogId()))
+                        .path("actions")
+                        .path("suggest");
+
+        if (request.getTimeout() != null) {
+            target =
+                    target.queryParam(
+                            "timeout",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeout()));
+        }
+
+        target =
+                target.queryParam(
+                        "inputText",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getInputText()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.datacatalog.responses.SuggestMatchesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.datacatalog.responses.SuggestMatchesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.datacatalog.responses.SuggestMatchesResponse>() {
+                            @Override
+                            public com.oracle.bmc.datacatalog.responses.SuggestMatchesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.datacatalog.responses.SuggestMatchesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        SuggestResults>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        SuggestResults.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<SuggestResults> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.datacatalog.responses.SuggestMatchesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.datacatalog.responses
+                                                        .SuggestMatchesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.suggestResults(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.datacatalog.responses.SuggestMatchesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Attribute.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Attribute.java
@@ -44,6 +44,15 @@ public class Attribute {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -296,6 +305,7 @@ public class Attribute {
                     new Attribute(
                             key,
                             displayName,
+                            businessName,
                             description,
                             entityKey,
                             lifecycleState,
@@ -332,6 +342,7 @@ public class Attribute {
             Builder copiedBuilder =
                     key(o.getKey())
                             .displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .entityKey(o.getEntityKey())
                             .lifecycleState(o.getLifecycleState())
@@ -385,6 +396,12 @@ public class Attribute {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of the attribute.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/AttributeSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/AttributeSummary.java
@@ -42,6 +42,15 @@ public class AttributeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -204,6 +213,16 @@ public class AttributeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+        private java.util.List<CustomPropertyGetUsage> customPropertyMembers;
+
+        public Builder customPropertyMembers(
+                java.util.List<CustomPropertyGetUsage> customPropertyMembers) {
+            this.customPropertyMembers = customPropertyMembers;
+            this.__explicitlySet__.add("customPropertyMembers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("associatedRuleTypes")
         private java.util.List<RuleType> associatedRuleTypes;
 
@@ -221,6 +240,7 @@ public class AttributeSummary {
                     new AttributeSummary(
                             key,
                             displayName,
+                            businessName,
                             description,
                             entityKey,
                             externalKey,
@@ -239,6 +259,7 @@ public class AttributeSummary {
                             parentAttributeKey,
                             externalParentAttributeKey,
                             path,
+                            customPropertyMembers,
                             associatedRuleTypes);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -249,6 +270,7 @@ public class AttributeSummary {
             Builder copiedBuilder =
                     key(o.getKey())
                             .displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .entityKey(o.getEntityKey())
                             .externalKey(o.getExternalKey())
@@ -267,6 +289,7 @@ public class AttributeSummary {
                             .parentAttributeKey(o.getParentAttributeKey())
                             .externalParentAttributeKey(o.getExternalParentAttributeKey())
                             .path(o.getPath())
+                            .customPropertyMembers(o.getCustomPropertyMembers())
                             .associatedRuleTypes(o.getAssociatedRuleTypes());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -294,6 +317,12 @@ public class AttributeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of the attribute.
@@ -407,6 +436,12 @@ public class AttributeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("path")
     String path;
+
+    /**
+     * The list of customized properties along with the values for this object
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customPropertyMembers")
+    java.util.List<CustomPropertyGetUsage> customPropertyMembers;
 
     /**
      * Rule types associated with attribute.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateAttributeDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateAttributeDetails.java
@@ -35,6 +35,15 @@ public class CreateAttributeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -178,6 +187,7 @@ public class CreateAttributeDetails {
             CreateAttributeDetails __instance__ =
                     new CreateAttributeDetails(
                             displayName,
+                            businessName,
                             description,
                             externalDataType,
                             isIncrementalData,
@@ -201,6 +211,7 @@ public class CreateAttributeDetails {
         public Builder copy(CreateAttributeDetails o) {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .externalDataType(o.getExternalDataType())
                             .isIncrementalData(o.getIsIncrementalData())
@@ -236,6 +247,12 @@ public class CreateAttributeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of the attribute.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateConnectionDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateConnectionDetails.java
@@ -179,7 +179,7 @@ public class CreateConnectionDetails {
      * To determine the set of optional and required properties for a connection type, a query can be done
      * on '/types?type=connection' that returns a collection of all connection types. The appropriate connection
      * type, which will include definitions of all of it's properties, can be identified from this collection.
-     * Example: `{\"encProperties\": { \"default\": { \"password\": \"pwd\"}}}`
+     * Example: `{\"encProperties\": { \"default\": { \"password\": \"example-password\"}}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("encProperties")

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateCustomPropertyDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateCustomPropertyDetails.java
@@ -98,6 +98,15 @@ public class CreateCustomPropertyDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+        private Boolean isShownInList;
+
+        public Builder isShownInList(Boolean isShownInList) {
+            this.isShownInList = isShownInList;
+            this.__explicitlySet__.add("isShownInList");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
         private Boolean isHiddenInSearch;
 
@@ -139,6 +148,7 @@ public class CreateCustomPropertyDetails {
                             isMultiValued,
                             isHidden,
                             isEditable,
+                            isShownInList,
                             isHiddenInSearch,
                             allowedValues,
                             properties);
@@ -157,6 +167,7 @@ public class CreateCustomPropertyDetails {
                             .isMultiValued(o.getIsMultiValued())
                             .isHidden(o.getIsHidden())
                             .isEditable(o.getIsEditable())
+                            .isShownInList(o.getIsShownInList())
                             .isHiddenInSearch(o.getIsHiddenInSearch())
                             .allowedValues(o.getAllowedValues())
                             .properties(o.getProperties());
@@ -222,6 +233,12 @@ public class CreateCustomPropertyDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
     Boolean isEditable;
+
+    /**
+     * If this field is displayed in a list view of applicable objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+    Boolean isShownInList;
 
     /**
      * If this field is allowed to pop in search results

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateEntityDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateEntityDetails.java
@@ -35,6 +35,15 @@ public class CreateEntityDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -142,6 +151,7 @@ public class CreateEntityDetails {
             CreateEntityDetails __instance__ =
                     new CreateEntityDetails(
                             displayName,
+                            businessName,
                             description,
                             timeExternal,
                             isLogical,
@@ -161,6 +171,7 @@ public class CreateEntityDetails {
         public Builder copy(CreateEntityDetails o) {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .timeExternal(o.getTimeExternal())
                             .isLogical(o.getIsLogical())
@@ -192,6 +203,12 @@ public class CreateEntityDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of a data entity.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateFolderDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CreateFolderDetails.java
@@ -35,6 +35,15 @@ public class CreateFolderDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -106,6 +115,7 @@ public class CreateFolderDetails {
             CreateFolderDetails __instance__ =
                     new CreateFolderDetails(
                             displayName,
+                            businessName,
                             description,
                             customPropertyMembers,
                             properties,
@@ -121,6 +131,7 @@ public class CreateFolderDetails {
         public Builder copy(CreateFolderDetails o) {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .customPropertyMembers(o.getCustomPropertyMembers())
                             .properties(o.getProperties())
@@ -148,6 +159,12 @@ public class CreateFolderDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of a folder.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomProperty.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomProperty.java
@@ -124,6 +124,15 @@ public class CustomProperty {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+        private Boolean isShownInList;
+
+        public Builder isShownInList(Boolean isShownInList) {
+            this.isShownInList = isShownInList;
+            this.__explicitlySet__.add("isShownInList");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
         private Boolean isServiceDefined;
 
@@ -240,6 +249,7 @@ public class CustomProperty {
                             isMultiValued,
                             isHidden,
                             isEditable,
+                            isShownInList,
                             isServiceDefined,
                             isHiddenInSearch,
                             lifecycleState,
@@ -269,6 +279,7 @@ public class CustomProperty {
                             .isMultiValued(o.getIsMultiValued())
                             .isHidden(o.getIsHidden())
                             .isEditable(o.getIsEditable())
+                            .isShownInList(o.getIsShownInList())
                             .isServiceDefined(o.getIsServiceDefined())
                             .isHiddenInSearch(o.getIsHiddenInSearch())
                             .lifecycleState(o.getLifecycleState())
@@ -358,6 +369,12 @@ public class CustomProperty {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
     Boolean isEditable;
+
+    /**
+     * If this field is displayed in a list view of applicable objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+    Boolean isShownInList;
 
     /**
      * If this field is defined by service or by a user

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyGetUsage.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertyGetUsage.java
@@ -116,6 +116,15 @@ public class CustomPropertyGetUsage {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+        private Boolean isShownInList;
+
+        public Builder isShownInList(Boolean isShownInList) {
+            this.isShownInList = isShownInList;
+            this.__explicitlySet__.add("isShownInList");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isListType")
         private Boolean isListType;
 
@@ -150,6 +159,7 @@ public class CustomPropertyGetUsage {
                             isMultiValued,
                             isHidden,
                             isEditable,
+                            isShownInList,
                             isListType,
                             allowedValues);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -169,6 +179,7 @@ public class CustomPropertyGetUsage {
                             .isMultiValued(o.getIsMultiValued())
                             .isHidden(o.getIsHidden())
                             .isEditable(o.getIsEditable())
+                            .isShownInList(o.getIsShownInList())
                             .isListType(o.getIsListType())
                             .allowedValues(o.getAllowedValues());
 
@@ -243,6 +254,12 @@ public class CustomPropertyGetUsage {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
     Boolean isEditable;
+
+    /**
+     * If this field is displayed in a list view of applicable objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+    Boolean isShownInList;
 
     /**
      * Is this property allowed to have list of values

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertySummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/CustomPropertySummary.java
@@ -117,6 +117,15 @@ public class CustomPropertySummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+        private Boolean isShownInList;
+
+        public Builder isShownInList(Boolean isShownInList) {
+            this.isShownInList = isShownInList;
+            this.__explicitlySet__.add("isShownInList");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isServiceDefined")
         private Boolean isServiceDefined;
 
@@ -196,6 +205,7 @@ public class CustomPropertySummary {
                             isMultiValued,
                             isHidden,
                             isEditable,
+                            isShownInList,
                             isServiceDefined,
                             isHiddenInSearch,
                             timeCreated,
@@ -220,6 +230,7 @@ public class CustomPropertySummary {
                             .isMultiValued(o.getIsMultiValued())
                             .isHidden(o.getIsHidden())
                             .isEditable(o.getIsEditable())
+                            .isShownInList(o.getIsShownInList())
                             .isServiceDefined(o.getIsServiceDefined())
                             .isHiddenInSearch(o.getIsHiddenInSearch())
                             .timeCreated(o.getTimeCreated())
@@ -299,6 +310,12 @@ public class CustomPropertySummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
     Boolean isEditable;
+
+    /**
+     * If this field is displayed in a list view of applicable objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+    Boolean isShownInList;
 
     /**
      * If this field is defined by service or by a user

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Entity.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Entity.java
@@ -45,6 +45,15 @@ public class Entity {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -261,6 +270,7 @@ public class Entity {
                     new Entity(
                             key,
                             displayName,
+                            businessName,
                             description,
                             timeCreated,
                             timeUpdated,
@@ -293,6 +303,7 @@ public class Entity {
             Builder copiedBuilder =
                     key(o.getKey())
                             .displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
@@ -342,6 +353,12 @@ public class Entity {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of a data entity.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntitySummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/EntitySummary.java
@@ -45,6 +45,15 @@ public class EntitySummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -96,6 +105,15 @@ public class EntitySummary {
         public Builder patternKey(String patternKey) {
             this.patternKey = patternKey;
             this.__explicitlySet__.add("patternKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("typeKey")
+        private String typeKey;
+
+        public Builder typeKey(String typeKey) {
+            this.typeKey = typeKey;
+            this.__explicitlySet__.add("typeKey");
             return this;
         }
 
@@ -170,12 +188,14 @@ public class EntitySummary {
                     new EntitySummary(
                             key,
                             displayName,
+                            businessName,
                             description,
                             dataAssetKey,
                             folderKey,
                             folderName,
                             externalKey,
                             patternKey,
+                            typeKey,
                             realizedExpression,
                             path,
                             timeCreated,
@@ -192,12 +212,14 @@ public class EntitySummary {
             Builder copiedBuilder =
                     key(o.getKey())
                             .displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .dataAssetKey(o.getDataAssetKey())
                             .folderKey(o.getFolderKey())
                             .folderName(o.getFolderName())
                             .externalKey(o.getExternalKey())
                             .patternKey(o.getPatternKey())
+                            .typeKey(o.getTypeKey())
                             .realizedExpression(o.getRealizedExpression())
                             .path(o.getPath())
                             .timeCreated(o.getTimeCreated())
@@ -231,6 +253,12 @@ public class EntitySummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of a data entity.
@@ -267,6 +295,12 @@ public class EntitySummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("patternKey")
     String patternKey;
+
+    /**
+     * The type of data entity object. Type keys can be found via the '/types' endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("typeKey")
+    String typeKey;
 
     /**
      * The expression realized after resolving qualifiers . Used in deriving this logical entity

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Folder.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Folder.java
@@ -46,6 +46,15 @@ public class Folder {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -199,6 +208,7 @@ public class Folder {
                     new Folder(
                             key,
                             displayName,
+                            businessName,
                             description,
                             parentFolderKey,
                             path,
@@ -224,6 +234,7 @@ public class Folder {
             Builder copiedBuilder =
                     key(o.getKey())
                             .displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .parentFolderKey(o.getParentFolderKey())
                             .path(o.getPath())
@@ -266,6 +277,12 @@ public class Folder {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of a folder.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FolderSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/FolderSummary.java
@@ -47,6 +47,15 @@ public class FolderSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -136,6 +145,7 @@ public class FolderSummary {
                     new FolderSummary(
                             key,
                             displayName,
+                            businessName,
                             description,
                             dataAssetKey,
                             parentFolderKey,
@@ -154,6 +164,7 @@ public class FolderSummary {
             Builder copiedBuilder =
                     key(o.getKey())
                             .displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .dataAssetKey(o.getDataAssetKey())
                             .parentFolderKey(o.getParentFolderKey())
@@ -189,6 +200,12 @@ public class FolderSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of a folder.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Job.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/Job.java
@@ -204,6 +204,15 @@ public class Job {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dataAssetKey")
+        private String dataAssetKey;
+
+        public Builder dataAssetKey(String dataAssetKey) {
+            this.dataAssetKey = dataAssetKey;
+            this.__explicitlySet__.add("dataAssetKey");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
         private String errorCode;
 
@@ -257,6 +266,7 @@ public class Job {
                             createdById,
                             updatedById,
                             jobDefinitionName,
+                            dataAssetKey,
                             errorCode,
                             errorMessage,
                             uri);
@@ -287,6 +297,7 @@ public class Job {
                             .createdById(o.getCreatedById())
                             .updatedById(o.getUpdatedById())
                             .jobDefinitionName(o.getJobDefinitionName())
+                            .dataAssetKey(o.getDataAssetKey())
                             .errorCode(o.getErrorCode())
                             .errorMessage(o.getErrorMessage())
                             .uri(o.getUri());
@@ -434,6 +445,12 @@ public class Job {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("jobDefinitionName")
     String jobDefinitionName;
+
+    /**
+     * Unique key of the data asset to which this job applies, if the job involves a data asset.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataAssetKey")
+    String dataAssetKey;
 
     /**
      * Error code returned from the latest job execution for this job. Useful when the latest Job execution is in FAILED state.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobDefinitionSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobDefinitionSummary.java
@@ -155,6 +155,15 @@ public class JobDefinitionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dataAssetKey")
+        private String dataAssetKey;
+
+        public Builder dataAssetKey(String dataAssetKey) {
+            this.dataAssetKey = dataAssetKey;
+            this.__explicitlySet__.add("dataAssetKey");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -174,7 +183,8 @@ public class JobDefinitionSummary {
                             timeLatestExecutionStarted,
                             timeLatestExecutionEnded,
                             jobExecutionState,
-                            scheduleType);
+                            scheduleType,
+                            dataAssetKey);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -195,7 +205,8 @@ public class JobDefinitionSummary {
                             .timeLatestExecutionStarted(o.getTimeLatestExecutionStarted())
                             .timeLatestExecutionEnded(o.getTimeLatestExecutionEnded())
                             .jobExecutionState(o.getJobExecutionState())
-                            .scheduleType(o.getScheduleType());
+                            .scheduleType(o.getScheduleType())
+                            .dataAssetKey(o.getDataAssetKey());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -299,6 +310,12 @@ public class JobDefinitionSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scheduleType")
     JobScheduleType scheduleType;
+
+    /**
+     * Unique key of the data asset to which this job applies, if the job involves a data asset.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataAssetKey")
+    String dataAssetKey;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobSummary.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/JobSummary.java
@@ -187,6 +187,15 @@ public class JobSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dataAssetKey")
+        private String dataAssetKey;
+
+        public Builder dataAssetKey(String dataAssetKey) {
+            this.dataAssetKey = dataAssetKey;
+            this.__explicitlySet__.add("dataAssetKey");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
         private String errorCode;
 
@@ -238,6 +247,7 @@ public class JobSummary {
                             executionCount,
                             timeOfLatestExecution,
                             jobDefinitionName,
+                            dataAssetKey,
                             errorCode,
                             errorMessage,
                             executions);
@@ -266,6 +276,7 @@ public class JobSummary {
                             .executionCount(o.getExecutionCount())
                             .timeOfLatestExecution(o.getTimeOfLatestExecution())
                             .jobDefinitionName(o.getJobDefinitionName())
+                            .dataAssetKey(o.getDataAssetKey())
                             .errorCode(o.getErrorCode())
                             .errorMessage(o.getErrorMessage())
                             .executions(o.getExecutions());
@@ -399,6 +410,12 @@ public class JobSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("jobDefinitionName")
     String jobDefinitionName;
+
+    /**
+     * Unique key of the data asset to which this job applies, if the job involves a data asset.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataAssetKey")
+    String dataAssetKey;
 
     /**
      * Error code returned from the latest job execution for this job. Useful when the latest Job execution is in FAILED state.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SearchResult.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SearchResult.java
@@ -261,6 +261,24 @@ public class SearchResult {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("expression")
         private String expression;
 
@@ -312,6 +330,8 @@ public class SearchResult {
                             createdById,
                             updatedById,
                             path,
+                            businessName,
+                            lifecycleState,
                             expression,
                             customProperties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -347,6 +367,8 @@ public class SearchResult {
                             .createdById(o.getCreatedById())
                             .updatedById(o.getUpdatedById())
                             .path(o.getPath())
+                            .businessName(o.getBusinessName())
+                            .lifecycleState(o.getLifecycleState())
                             .expression(o.getExpression())
                             .customProperties(o.getCustomProperties());
 
@@ -521,6 +543,18 @@ public class SearchResult {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("path")
     String path;
+
+    /**
+     * Optional user friendly business name of the data object. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
+
+    /**
+     * The current state of the data object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
 
     /**
      * Expression for logical entities against which names of dataObjects will be matched.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SuggestListItem.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SuggestListItem.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * Details of a potential match returned from the suggest operation for the given input text.
+ * by the limit parameter.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = SuggestListItem.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SuggestListItem {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("suggestion")
+        private String suggestion;
+
+        public Builder suggestion(String suggestion) {
+            this.suggestion = suggestion;
+            this.__explicitlySet__.add("suggestion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectCount")
+        private Integer objectCount;
+
+        public Builder objectCount(Integer objectCount) {
+            this.objectCount = objectCount;
+            this.__explicitlySet__.add("objectCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SuggestListItem build() {
+            SuggestListItem __instance__ = new SuggestListItem(suggestion, objectCount);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SuggestListItem o) {
+            Builder copiedBuilder = suggestion(o.getSuggestion()).objectCount(o.getObjectCount());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Potential string match. Matching is based on the frequency of usage within the catalog.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("suggestion")
+    String suggestion;
+
+    /**
+     * The number of objects which contain this suggestion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectCount")
+    Integer objectCount;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SuggestResults.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/SuggestResults.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.model;
+
+/**
+ * The list of potential matches returned from the suggest operation for the given input text. The size of the list will be determined
+ * by the limit parameter.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = SuggestResults.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SuggestResults {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("totalCount")
+        private Integer totalCount;
+
+        public Builder totalCount(Integer totalCount) {
+            this.totalCount = totalCount;
+            this.__explicitlySet__.add("totalCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("searchLatencyInMs")
+        private Integer searchLatencyInMs;
+
+        public Builder searchLatencyInMs(Integer searchLatencyInMs) {
+            this.searchLatencyInMs = searchLatencyInMs;
+            this.__explicitlySet__.add("searchLatencyInMs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputText")
+        private String inputText;
+
+        public Builder inputText(String inputText) {
+            this.inputText = inputText;
+            this.__explicitlySet__.add("inputText");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<SuggestListItem> items;
+
+        public Builder items(java.util.List<SuggestListItem> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SuggestResults build() {
+            SuggestResults __instance__ =
+                    new SuggestResults(totalCount, searchLatencyInMs, inputText, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SuggestResults o) {
+            Builder copiedBuilder =
+                    totalCount(o.getTotalCount())
+                            .searchLatencyInMs(o.getSearchLatencyInMs())
+                            .inputText(o.getInputText())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Total number of items returned.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalCount")
+    Integer totalCount;
+
+    /**
+     * Time taken to compute the result, in milliseconds.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("searchLatencyInMs")
+    Integer searchLatencyInMs;
+
+    /**
+     * Input string for which the potential matches are computed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("inputText")
+    String inputText;
+
+    /**
+     * List of suggestions.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<SuggestListItem> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateAttributeDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateAttributeDetails.java
@@ -35,6 +35,15 @@ public class UpdateAttributeDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -178,6 +187,7 @@ public class UpdateAttributeDetails {
             UpdateAttributeDetails __instance__ =
                     new UpdateAttributeDetails(
                             displayName,
+                            businessName,
                             description,
                             externalDataType,
                             isIncrementalData,
@@ -201,6 +211,7 @@ public class UpdateAttributeDetails {
         public Builder copy(UpdateAttributeDetails o) {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .externalDataType(o.getExternalDataType())
                             .isIncrementalData(o.getIsIncrementalData())
@@ -236,6 +247,12 @@ public class UpdateAttributeDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the attribute. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of the attribute.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateConnectionDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateConnectionDetails.java
@@ -162,7 +162,7 @@ public class UpdateConnectionDetails {
      * To determine the set of optional and required properties for a connection type, a query can be done
      * on '/types?type=connection' that returns a collection of all connection types. The appropriate connection
      * type, which will include definitions of all of it's properties, can be identified from this collection.
-     * Example: `{\"encProperties\": { \"default\": { \"password\": \"pwd\"}}}`
+     * Example: `{\"encProperties\": { \"default\": { \"password\": \"example-password\"}}}`
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("encProperties")

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateCustomPropertyDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateCustomPropertyDetails.java
@@ -89,6 +89,15 @@ public class UpdateCustomPropertyDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+        private Boolean isShownInList;
+
+        public Builder isShownInList(Boolean isShownInList) {
+            this.isShownInList = isShownInList;
+            this.__explicitlySet__.add("isShownInList");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isHiddenInSearch")
         private Boolean isHiddenInSearch;
 
@@ -129,6 +138,7 @@ public class UpdateCustomPropertyDetails {
                             isMultiValued,
                             isHidden,
                             isEditable,
+                            isShownInList,
                             isHiddenInSearch,
                             allowedValues,
                             properties);
@@ -146,6 +156,7 @@ public class UpdateCustomPropertyDetails {
                             .isMultiValued(o.getIsMultiValued())
                             .isHidden(o.getIsHidden())
                             .isEditable(o.getIsEditable())
+                            .isShownInList(o.getIsShownInList())
                             .isHiddenInSearch(o.getIsHiddenInSearch())
                             .allowedValues(o.getAllowedValues())
                             .properties(o.getProperties());
@@ -205,6 +216,12 @@ public class UpdateCustomPropertyDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEditable")
     Boolean isEditable;
+
+    /**
+     * If this field is displayed in a list view of applicable objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isShownInList")
+    Boolean isShownInList;
 
     /**
      * If this field is allowed to pop in search results

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateEntityDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateEntityDetails.java
@@ -35,6 +35,15 @@ public class UpdateEntityDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -142,6 +151,7 @@ public class UpdateEntityDetails {
             UpdateEntityDetails __instance__ =
                     new UpdateEntityDetails(
                             displayName,
+                            businessName,
                             description,
                             timeExternal,
                             isLogical,
@@ -161,6 +171,7 @@ public class UpdateEntityDetails {
         public Builder copy(UpdateEntityDetails o) {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .timeExternal(o.getTimeExternal())
                             .isLogical(o.getIsLogical())
@@ -192,6 +203,12 @@ public class UpdateEntityDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the data entity. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of a data entity.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateFolderDetails.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/model/UpdateFolderDetails.java
@@ -35,6 +35,15 @@ public class UpdateFolderDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+        private String businessName;
+
+        public Builder businessName(String businessName) {
+            this.businessName = businessName;
+            this.__explicitlySet__.add("businessName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("description")
         private String description;
 
@@ -106,6 +115,7 @@ public class UpdateFolderDetails {
             UpdateFolderDetails __instance__ =
                     new UpdateFolderDetails(
                             displayName,
+                            businessName,
                             description,
                             parentFolderKey,
                             customPropertyMembers,
@@ -121,6 +131,7 @@ public class UpdateFolderDetails {
         public Builder copy(UpdateFolderDetails o) {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
+                            .businessName(o.getBusinessName())
                             .description(o.getDescription())
                             .parentFolderKey(o.getParentFolderKey())
                             .customPropertyMembers(o.getCustomPropertyMembers())
@@ -148,6 +159,12 @@ public class UpdateFolderDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * Optional user friendly business name of the folder. If set, this supplements the harvested display name of the object.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("businessName")
+    String businessName;
 
     /**
      * Detailed description of a folder.

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListAttributesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListAttributesRequest.java
@@ -40,6 +40,19 @@ public class ListAttributesRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String displayName;
 
     /**
+     * A filter to return only resources that match the entire business name given. The match is not case sensitive.
+     */
+    private String businessName;
+
+    /**
+     * A filter to return only resources that match display name or business name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayOrBusinessNameContains=Cu.*
+     * The above would match all folders with display name or business name that starts with \"Cu\".
+     *
+     */
+    private String displayOrBusinessNameContains;
+
+    /**
      * A filter to return only resources that match display name pattern given. The match is not case sensitive.
      * For Example : /folders?displayNameContains=Cu.*
      * The above would match all folders with display name that starts with \"Cu\".
@@ -313,6 +326,8 @@ public class ListAttributesRequest extends com.oracle.bmc.requests.BmcRequest<ja
             dataAssetKey(o.getDataAssetKey());
             entityKey(o.getEntityKey());
             displayName(o.getDisplayName());
+            businessName(o.getBusinessName());
+            displayOrBusinessNameContains(o.getDisplayOrBusinessNameContains());
             displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             timeCreated(o.getTimeCreated());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListEntitiesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListEntitiesRequest.java
@@ -35,6 +35,24 @@ public class ListEntitiesRequest extends com.oracle.bmc.requests.BmcRequest<java
     private String displayName;
 
     /**
+     * A filter to return only resources that match the entire business name given. The match is not case sensitive.
+     */
+    private String businessName;
+
+    /**
+     * A filter to return only resources that match display name or business name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayOrBusinessNameContains=Cu.*
+     * The above would match all folders with display name or business name that starts with \"Cu\".
+     *
+     */
+    private String displayOrBusinessNameContains;
+
+    /**
+     * The key of the object type.
+     */
+    private String typeKey;
+
+    /**
      * A filter to return only resources that match display name pattern given. The match is not case sensitive.
      * For Example : /folders?displayNameContains=Cu.*
      * The above would match all folders with display name that starts with \"Cu\".
@@ -306,6 +324,9 @@ public class ListEntitiesRequest extends com.oracle.bmc.requests.BmcRequest<java
             catalogId(o.getCatalogId());
             dataAssetKey(o.getDataAssetKey());
             displayName(o.getDisplayName());
+            businessName(o.getBusinessName());
+            displayOrBusinessNameContains(o.getDisplayOrBusinessNameContains());
+            typeKey(o.getTypeKey());
             displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             timeCreated(o.getTimeCreated());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListFoldersRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListFoldersRequest.java
@@ -35,6 +35,19 @@ public class ListFoldersRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String displayName;
 
     /**
+     * A filter to return only resources that match the entire business name given. The match is not case sensitive.
+     */
+    private String businessName;
+
+    /**
+     * A filter to return only resources that match display name or business name pattern given. The match is not case sensitive.
+     * For Example : /folders?displayOrBusinessNameContains=Cu.*
+     * The above would match all folders with display name or business name that starts with \"Cu\".
+     *
+     */
+    private String displayOrBusinessNameContains;
+
+    /**
      * A filter to return only resources that match display name pattern given. The match is not case sensitive.
      * For Example : /folders?displayNameContains=Cu.*
      * The above would match all folders with display name that starts with \"Cu\".
@@ -278,6 +291,8 @@ public class ListFoldersRequest extends com.oracle.bmc.requests.BmcRequest<java.
             catalogId(o.getCatalogId());
             dataAssetKey(o.getDataAssetKey());
             displayName(o.getDisplayName());
+            businessName(o.getBusinessName());
+            displayOrBusinessNameContains(o.getDisplayOrBusinessNameContains());
             displayNameContains(o.getDisplayNameContains());
             lifecycleState(o.getLifecycleState());
             parentFolderKey(o.getParentFolderKey());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobsRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/ListJobsRequest.java
@@ -73,6 +73,11 @@ public class ListJobsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
     private String jobDefinitionKey;
 
     /**
+     * Unique data asset key.
+     */
+    private String dataAssetKey;
+
+    /**
      * Schedule specified in the cron expression format that has seven fields for second, minute, hour, day-of-month, month, day-of-week, year.
      * It can also include special characters like * for all and ? for any. There are also pre-defined schedules that can be specified using
      * special strings. For example, @hourly will run the job every hour.
@@ -315,6 +320,7 @@ public class ListJobsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
             updatedById(o.getUpdatedById());
             jobType(o.getJobType());
             jobDefinitionKey(o.getJobDefinitionKey());
+            dataAssetKey(o.getDataAssetKey());
             scheduleCronExpression(o.getScheduleCronExpression());
             timeScheduleBegin(o.getTimeScheduleBegin());
             timeScheduleEnd(o.getTimeScheduleEnd());

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/SuggestMatchesRequest.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/requests/SuggestMatchesRequest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.requests;
+
+import com.oracle.bmc.datacatalog.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/datacatalog/SuggestMatchesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SuggestMatchesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SuggestMatchesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique catalog identifier.
+     */
+    private String catalogId;
+
+    /**
+     * Text input string used for computing potential matching suggestions.
+     *
+     */
+    private String inputText;
+
+    /**
+     * A search timeout string (for example, timeout=4000ms), bounding the search request to be executed within the
+     * specified time value and bail with the hits accumulated up to that point when expired.
+     * Defaults to no timeout.
+     *
+     */
+    private String timeout;
+
+    /**
+     * Limit for the list of potential matches returned from the Suggest API. If not specified, will default to 10.
+     *
+     */
+    private Integer limit;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SuggestMatchesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SuggestMatchesRequest o) {
+            catalogId(o.getCatalogId());
+            inputText(o.getInputText());
+            timeout(o.getTimeout());
+            limit(o.getLimit());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SuggestMatchesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SuggestMatchesRequest
+         */
+        public SuggestMatchesRequest build() {
+            SuggestMatchesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/SuggestMatchesResponse.java
+++ b/bmc-datacatalog/src/main/java/com/oracle/bmc/datacatalog/responses/SuggestMatchesResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datacatalog.responses;
+
+import com.oracle.bmc.datacatalog.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190325")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SuggestMatchesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned SuggestResults instance.
+     */
+    private SuggestResults suggestResults;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SuggestMatchesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            suggestResults(o.getSuggestResults());
+
+            return this;
+        }
+    }
+}

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,11 +17,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,11 +17,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.36.0</version>
+        <version>1.36.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -15,11 +15,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,11 +17,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -15,11 +15,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,11 +17,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,16 +17,17 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,11 +17,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -15,11 +15,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -15,11 +15,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.0</version>
+    <version>1.36.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.0</version>
+      <version>1.36.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.36.0</version>
+  <version>1.36.1</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for opting in/out of live migration on instances in the Compute service

- Support for enabling/disabling Operations Insights on external non-container and external pluggable databases in the Database service

- Support for a GraphStudio URL as a connection URL on databases in the Database service

- Support for adding customer contacts on autonomous databases in the Database service

- Support for name annotations on harvested objects in the Data Catalog service