### PR TITLE
Releasing version 1.36.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.36.2 - 2021-04-27
+### Added
+- VCN id parameters were moved from being required to being optional on all list operations in the Networking service
+- Support for RACs (real application clusters) for external container, non-container, and pluggable databases in the Database service
+- Support for data masking in the Cloud Guard service
+- Support for opting out of DNS records during instance launch, as well as attaching secondary VNICs, in the Compute service
+- Support for mutable sizes on cluster networks in the Autoscaling service
+- Support for auto-tiering on buckets in the Object Storage service
+
 ## 1.36.1 - 2021-04-20
 ### Added
 - Support for opting in/out of live migration on instances in the Compute service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -16,11 +16,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,11 +18,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,456 +19,456 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuard.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuard.java
@@ -79,6 +79,17 @@ public interface CloudGuard extends AutoCloseable {
             ChangeResponderRecipeCompartmentRequest request);
 
     /**
+     * Creates a new Data Mask Rule Definition
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/CreateDataMaskRuleExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateDataMaskRule API.
+     */
+    CreateDataMaskRuleResponse createDataMaskRule(CreateDataMaskRuleRequest request);
+
+    /**
      * Creates a DetectorRecipe
      *
      * @param request The request object containing the details to send
@@ -145,6 +156,16 @@ public interface CloudGuard extends AutoCloseable {
      */
     CreateTargetResponderRecipeResponse createTargetResponderRecipe(
             CreateTargetResponderRecipeRequest request);
+
+    /**
+     * Deletes a DataMaskRule identified by dataMaskRuleId
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/DeleteDataMaskRuleExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteDataMaskRule API.
+     */
+    DeleteDataMaskRuleResponse deleteDataMaskRule(DeleteDataMaskRuleRequest request);
 
     /**
      * Deletes a DetectorRecipe identified by detectorRecipeId
@@ -240,6 +261,16 @@ public interface CloudGuard extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/GetConfigurationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetConfiguration API.
      */
     GetConfigurationResponse getConfiguration(GetConfigurationRequest request);
+
+    /**
+     * Returns a DataMaskRule identified by DataMaskRuleId
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/GetDataMaskRuleExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetDataMaskRule API.
+     */
+    GetDataMaskRuleResponse getDataMaskRule(GetDataMaskRuleRequest request);
 
     /**
      * Returns a Detector identified by detectorId.
@@ -412,6 +443,17 @@ public interface CloudGuard extends AutoCloseable {
             ListConditionMetadataTypesRequest request);
 
     /**
+     * Returns a list of all Data Mask Rules in the root 'compartmentId' passed.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/ListDataMaskRulesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDataMaskRules API.
+     */
+    ListDataMaskRulesResponse listDataMaskRules(ListDataMaskRulesRequest request);
+
+    /**
      * Returns a list of DetectorRule associated with DetectorRecipe.
      *
      * @param request The request object containing the details to send
@@ -514,6 +556,17 @@ public interface CloudGuard extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/ListManagedListsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListManagedLists API.
      */
     ListManagedListsResponse listManagedLists(ListManagedListsRequest request);
+
+    /**
+     * Returns the list of global policy statements needed by Cloud Guard when enabling
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/ListPoliciesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListPolicies API.
+     */
+    ListPoliciesResponse listPolicies(ListPoliciesRequest request);
 
     /**
      * Returns a list of Actions done on CloudGuard Problem
@@ -957,6 +1010,16 @@ public interface CloudGuard extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/UpdateConfigurationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateConfiguration API.
      */
     UpdateConfigurationResponse updateConfiguration(UpdateConfigurationRequest request);
+
+    /**
+     * Updates a DataMaskRule identified by dataMaskRuleId
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/UpdateDataMaskRuleExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateDataMaskRule API.
+     */
+    UpdateDataMaskRuleResponse updateDataMaskRule(UpdateDataMaskRuleRequest request);
 
     /**
      * Updates a detector recipe identified by detectorRecipeId

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardAsync.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardAsync.java
@@ -99,6 +99,23 @@ public interface CloudGuardAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Creates a new Data Mask Rule Definition
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateDataMaskRuleResponse> createDataMaskRule(
+            CreateDataMaskRuleRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CreateDataMaskRuleRequest, CreateDataMaskRuleResponse>
+                    handler);
+
+    /**
      * Creates a DetectorRecipe
      *
      *
@@ -197,6 +214,22 @@ public interface CloudGuardAsync extends AutoCloseable {
             CreateTargetResponderRecipeRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             CreateTargetResponderRecipeRequest, CreateTargetResponderRecipeResponse>
+                    handler);
+
+    /**
+     * Deletes a DataMaskRule identified by dataMaskRuleId
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteDataMaskRuleResponse> deleteDataMaskRule(
+            DeleteDataMaskRuleRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteDataMaskRuleRequest, DeleteDataMaskRuleResponse>
                     handler);
 
     /**
@@ -340,6 +373,21 @@ public interface CloudGuardAsync extends AutoCloseable {
     java.util.concurrent.Future<GetConfigurationResponse> getConfiguration(
             GetConfigurationRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetConfigurationRequest, GetConfigurationResponse>
+                    handler);
+
+    /**
+     * Returns a DataMaskRule identified by DataMaskRuleId
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetDataMaskRuleResponse> getDataMaskRule(
+            GetDataMaskRuleRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetDataMaskRuleRequest, GetDataMaskRuleResponse>
                     handler);
 
     /**
@@ -602,6 +650,23 @@ public interface CloudGuardAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Returns a list of all Data Mask Rules in the root 'compartmentId' passed.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListDataMaskRulesResponse> listDataMaskRules(
+            ListDataMaskRulesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListDataMaskRulesRequest, ListDataMaskRulesResponse>
+                    handler);
+
+    /**
      * Returns a list of DetectorRule associated with DetectorRecipe.
      *
      *
@@ -744,6 +809,22 @@ public interface CloudGuardAsync extends AutoCloseable {
     java.util.concurrent.Future<ListManagedListsResponse> listManagedLists(
             ListManagedListsRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListManagedListsRequest, ListManagedListsResponse>
+                    handler);
+
+    /**
+     * Returns the list of global policy statements needed by Cloud Guard when enabling
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListPoliciesResponse> listPolicies(
+            ListPoliciesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListPoliciesRequest, ListPoliciesResponse>
                     handler);
 
     /**
@@ -1368,6 +1449,22 @@ public interface CloudGuardAsync extends AutoCloseable {
             UpdateConfigurationRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             UpdateConfigurationRequest, UpdateConfigurationResponse>
+                    handler);
+
+    /**
+     * Updates a DataMaskRule identified by dataMaskRuleId
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateDataMaskRuleResponse> updateDataMaskRule(
+            UpdateDataMaskRuleRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateDataMaskRuleRequest, UpdateDataMaskRuleResponse>
                     handler);
 
     /**

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardAsyncClient.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardAsyncClient.java
@@ -503,6 +503,46 @@ public class CloudGuardAsyncClient implements CloudGuardAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CreateDataMaskRuleResponse> createDataMaskRule(
+            CreateDataMaskRuleRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateDataMaskRuleRequest, CreateDataMaskRuleResponse>
+                    handler) {
+        LOG.trace("Called async createDataMaskRule");
+        final CreateDataMaskRuleRequest interceptedRequest =
+                CreateDataMaskRuleConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateDataMaskRuleConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateDataMaskRuleResponse>
+                transformer = CreateDataMaskRuleConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CreateDataMaskRuleRequest, CreateDataMaskRuleResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateDataMaskRuleRequest, CreateDataMaskRuleResponse>,
+                        java.util.concurrent.Future<CreateDataMaskRuleResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateDataMaskRuleRequest, CreateDataMaskRuleResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateDetectorRecipeResponse> createDetectorRecipe(
             CreateDetectorRecipeRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -743,6 +783,45 @@ public class CloudGuardAsyncClient implements CloudGuardAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     CreateTargetResponderRecipeRequest, CreateTargetResponderRecipeResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteDataMaskRuleResponse> deleteDataMaskRule(
+            DeleteDataMaskRuleRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteDataMaskRuleRequest, DeleteDataMaskRuleResponse>
+                    handler) {
+        LOG.trace("Called async deleteDataMaskRule");
+        final DeleteDataMaskRuleRequest interceptedRequest =
+                DeleteDataMaskRuleConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteDataMaskRuleConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteDataMaskRuleResponse>
+                transformer = DeleteDataMaskRuleConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteDataMaskRuleRequest, DeleteDataMaskRuleResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteDataMaskRuleRequest, DeleteDataMaskRuleResponse>,
+                        java.util.concurrent.Future<DeleteDataMaskRuleResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteDataMaskRuleRequest, DeleteDataMaskRuleResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1115,6 +1194,45 @@ public class CloudGuardAsyncClient implements CloudGuardAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetConfigurationRequest, GetConfigurationResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetDataMaskRuleResponse> getDataMaskRule(
+            GetDataMaskRuleRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetDataMaskRuleRequest, GetDataMaskRuleResponse>
+                    handler) {
+        LOG.trace("Called async getDataMaskRule");
+        final GetDataMaskRuleRequest interceptedRequest =
+                GetDataMaskRuleConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetDataMaskRuleConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetDataMaskRuleResponse>
+                transformer = GetDataMaskRuleConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetDataMaskRuleRequest, GetDataMaskRuleResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetDataMaskRuleRequest, GetDataMaskRuleResponse>,
+                        java.util.concurrent.Future<GetDataMaskRuleResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetDataMaskRuleRequest, GetDataMaskRuleResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1785,6 +1903,45 @@ public class CloudGuardAsyncClient implements CloudGuardAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListDataMaskRulesResponse> listDataMaskRules(
+            ListDataMaskRulesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListDataMaskRulesRequest, ListDataMaskRulesResponse>
+                    handler) {
+        LOG.trace("Called async listDataMaskRules");
+        final ListDataMaskRulesRequest interceptedRequest =
+                ListDataMaskRulesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDataMaskRulesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListDataMaskRulesResponse>
+                transformer = ListDataMaskRulesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListDataMaskRulesRequest, ListDataMaskRulesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListDataMaskRulesRequest, ListDataMaskRulesResponse>,
+                        java.util.concurrent.Future<ListDataMaskRulesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListDataMaskRulesRequest, ListDataMaskRulesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListDetectorRecipeDetectorRulesResponse>
             listDetectorRecipeDetectorRules(
                     ListDetectorRecipeDetectorRulesRequest request,
@@ -2057,6 +2214,44 @@ public class CloudGuardAsyncClient implements CloudGuardAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListManagedListsRequest, ListManagedListsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListPoliciesResponse> listPolicies(
+            ListPoliciesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListPoliciesRequest, ListPoliciesResponse>
+                    handler) {
+        LOG.trace("Called async listPolicies");
+        final ListPoliciesRequest interceptedRequest =
+                ListPoliciesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPoliciesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListPoliciesResponse>
+                transformer = ListPoliciesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListPoliciesRequest, ListPoliciesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListPoliciesRequest, ListPoliciesResponse>,
+                        java.util.concurrent.Future<ListPoliciesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListPoliciesRequest, ListPoliciesResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -3345,6 +3540,45 @@ public class CloudGuardAsyncClient implements CloudGuardAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     UpdateConfigurationRequest, UpdateConfigurationResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateDataMaskRuleResponse> updateDataMaskRule(
+            UpdateDataMaskRuleRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateDataMaskRuleRequest, UpdateDataMaskRuleResponse>
+                    handler) {
+        LOG.trace("Called async updateDataMaskRule");
+        final UpdateDataMaskRuleRequest interceptedRequest =
+                UpdateDataMaskRuleConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateDataMaskRuleConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateDataMaskRuleResponse>
+                transformer = UpdateDataMaskRuleConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateDataMaskRuleRequest, UpdateDataMaskRuleResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateDataMaskRuleRequest, UpdateDataMaskRuleResponse>,
+                        java.util.concurrent.Future<UpdateDataMaskRuleResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateDataMaskRuleRequest, UpdateDataMaskRuleResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardClient.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardClient.java
@@ -550,6 +550,39 @@ public class CloudGuardClient implements CloudGuard {
     }
 
     @Override
+    public CreateDataMaskRuleResponse createDataMaskRule(CreateDataMaskRuleRequest request) {
+        LOG.trace("Called createDataMaskRule");
+        final CreateDataMaskRuleRequest interceptedRequest =
+                CreateDataMaskRuleConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateDataMaskRuleConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateDataMaskRuleResponse>
+                transformer = CreateDataMaskRuleConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateDataMaskRuleDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateDetectorRecipeResponse createDetectorRecipe(CreateDetectorRecipeRequest request) {
         LOG.trace("Called createDetectorRecipe");
         final CreateDetectorRecipeRequest interceptedRequest =
@@ -749,6 +782,35 @@ public class CloudGuardClient implements CloudGuard {
                                                 retriedRequest
                                                         .getAttachTargetResponderRecipeDetails(),
                                                 retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteDataMaskRuleResponse deleteDataMaskRule(DeleteDataMaskRuleRequest request) {
+        LOG.trace("Called deleteDataMaskRule");
+        final DeleteDataMaskRuleRequest interceptedRequest =
+                DeleteDataMaskRuleConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteDataMaskRuleConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteDataMaskRuleResponse>
+                transformer = DeleteDataMaskRuleConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });
@@ -1009,6 +1071,34 @@ public class CloudGuardClient implements CloudGuard {
                 GetConfigurationConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetConfigurationResponse>
                 transformer = GetConfigurationConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetDataMaskRuleResponse getDataMaskRule(GetDataMaskRuleRequest request) {
+        LOG.trace("Called getDataMaskRule");
+        final GetDataMaskRuleRequest interceptedRequest =
+                GetDataMaskRuleConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetDataMaskRuleConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetDataMaskRuleResponse>
+                transformer = GetDataMaskRuleConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1490,6 +1580,34 @@ public class CloudGuardClient implements CloudGuard {
     }
 
     @Override
+    public ListDataMaskRulesResponse listDataMaskRules(ListDataMaskRulesRequest request) {
+        LOG.trace("Called listDataMaskRules");
+        final ListDataMaskRulesRequest interceptedRequest =
+                ListDataMaskRulesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDataMaskRulesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListDataMaskRulesResponse>
+                transformer = ListDataMaskRulesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListDetectorRecipeDetectorRulesResponse listDetectorRecipeDetectorRules(
             ListDetectorRecipeDetectorRulesRequest request) {
         LOG.trace("Called listDetectorRecipeDetectorRules");
@@ -1669,6 +1787,34 @@ public class CloudGuardClient implements CloudGuard {
                 ListManagedListsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListManagedListsResponse>
                 transformer = ListManagedListsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListPoliciesResponse listPolicies(ListPoliciesRequest request) {
+        LOG.trace("Called listPolicies");
+        final ListPoliciesRequest interceptedRequest =
+                ListPoliciesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPoliciesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListPoliciesResponse>
+                transformer = ListPoliciesConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -2597,6 +2743,38 @@ public class CloudGuardClient implements CloudGuard {
                                         client.put(
                                                 ib,
                                                 retriedRequest.getUpdateConfigurationDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateDataMaskRuleResponse updateDataMaskRule(UpdateDataMaskRuleRequest request) {
+        LOG.trace("Called updateDataMaskRule");
+        final UpdateDataMaskRuleRequest interceptedRequest =
+                UpdateDataMaskRuleConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateDataMaskRuleConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateDataMaskRuleResponse>
+                transformer = UpdateDataMaskRuleConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateDataMaskRuleDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardPaginators.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardPaginators.java
@@ -150,6 +150,119 @@ public class CloudGuardPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listDataMaskRules operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListDataMaskRulesResponse> listDataMaskRulesResponseIterator(
+            final ListDataMaskRulesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListDataMaskRulesRequest.Builder, ListDataMaskRulesRequest,
+                ListDataMaskRulesResponse>(
+                new com.google.common.base.Supplier<ListDataMaskRulesRequest.Builder>() {
+                    @Override
+                    public ListDataMaskRulesRequest.Builder get() {
+                        return ListDataMaskRulesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListDataMaskRulesResponse, String>() {
+                    @Override
+                    public String apply(ListDataMaskRulesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListDataMaskRulesRequest.Builder>,
+                        ListDataMaskRulesRequest>() {
+                    @Override
+                    public ListDataMaskRulesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListDataMaskRulesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListDataMaskRulesRequest, ListDataMaskRulesResponse>() {
+                    @Override
+                    public ListDataMaskRulesResponse apply(ListDataMaskRulesRequest request) {
+                        return client.listDataMaskRules(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.cloudguard.model.DataMaskRuleSummary} objects
+     * contained in responses from the listDataMaskRules operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.cloudguard.model.DataMaskRuleSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.cloudguard.model.DataMaskRuleSummary>
+            listDataMaskRulesRecordIterator(final ListDataMaskRulesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListDataMaskRulesRequest.Builder, ListDataMaskRulesRequest,
+                ListDataMaskRulesResponse, com.oracle.bmc.cloudguard.model.DataMaskRuleSummary>(
+                new com.google.common.base.Supplier<ListDataMaskRulesRequest.Builder>() {
+                    @Override
+                    public ListDataMaskRulesRequest.Builder get() {
+                        return ListDataMaskRulesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListDataMaskRulesResponse, String>() {
+                    @Override
+                    public String apply(ListDataMaskRulesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListDataMaskRulesRequest.Builder>,
+                        ListDataMaskRulesRequest>() {
+                    @Override
+                    public ListDataMaskRulesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListDataMaskRulesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListDataMaskRulesRequest, ListDataMaskRulesResponse>() {
+                    @Override
+                    public ListDataMaskRulesResponse apply(ListDataMaskRulesRequest request) {
+                        return client.listDataMaskRules(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListDataMaskRulesResponse,
+                        java.util.List<com.oracle.bmc.cloudguard.model.DataMaskRuleSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.cloudguard.model.DataMaskRuleSummary>
+                            apply(ListDataMaskRulesResponse response) {
+                        return response.getDataMaskRuleCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listDetectorRecipeDetectorRules operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -951,6 +1064,116 @@ public class CloudGuardPaginators {
                     public java.util.List<com.oracle.bmc.cloudguard.model.ManagedListSummary> apply(
                             ListManagedListsResponse response) {
                         return response.getManagedListCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listPolicies operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListPoliciesResponse> listPoliciesResponseIterator(
+            final ListPoliciesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListPoliciesRequest.Builder, ListPoliciesRequest, ListPoliciesResponse>(
+                new com.google.common.base.Supplier<ListPoliciesRequest.Builder>() {
+                    @Override
+                    public ListPoliciesRequest.Builder get() {
+                        return ListPoliciesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListPoliciesResponse, String>() {
+                    @Override
+                    public String apply(ListPoliciesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPoliciesRequest.Builder>,
+                        ListPoliciesRequest>() {
+                    @Override
+                    public ListPoliciesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPoliciesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListPoliciesRequest, ListPoliciesResponse>() {
+                    @Override
+                    public ListPoliciesResponse apply(ListPoliciesRequest request) {
+                        return client.listPolicies(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.cloudguard.model.PolicySummary} objects
+     * contained in responses from the listPolicies operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.cloudguard.model.PolicySummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.cloudguard.model.PolicySummary> listPoliciesRecordIterator(
+            final ListPoliciesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListPoliciesRequest.Builder, ListPoliciesRequest, ListPoliciesResponse,
+                com.oracle.bmc.cloudguard.model.PolicySummary>(
+                new com.google.common.base.Supplier<ListPoliciesRequest.Builder>() {
+                    @Override
+                    public ListPoliciesRequest.Builder get() {
+                        return ListPoliciesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListPoliciesResponse, String>() {
+                    @Override
+                    public String apply(ListPoliciesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPoliciesRequest.Builder>,
+                        ListPoliciesRequest>() {
+                    @Override
+                    public ListPoliciesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPoliciesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListPoliciesRequest, ListPoliciesResponse>() {
+                    @Override
+                    public ListPoliciesResponse apply(ListPoliciesRequest request) {
+                        return client.listPolicies(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPoliciesResponse,
+                        java.util.List<com.oracle.bmc.cloudguard.model.PolicySummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.cloudguard.model.PolicySummary> apply(
+                            ListPoliciesResponse response) {
+                        return response.getPolicyCollection().getItems();
                     }
                 });
     }

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardWaiters.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/CloudGuardWaiters.java
@@ -26,6 +26,107 @@ public class CloudGuardWaiters {
      * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<GetDataMaskRuleRequest, GetDataMaskRuleResponse>
+            forDataMaskRule(
+                    GetDataMaskRuleRequest request,
+                    com.oracle.bmc.cloudguard.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forDataMaskRule(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetDataMaskRuleRequest, GetDataMaskRuleResponse>
+            forDataMaskRule(
+                    GetDataMaskRuleRequest request,
+                    com.oracle.bmc.cloudguard.model.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forDataMaskRule(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetDataMaskRuleRequest, GetDataMaskRuleResponse>
+            forDataMaskRule(
+                    GetDataMaskRuleRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.cloudguard.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forDataMaskRule(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for DataMaskRule.
+    private com.oracle.bmc.waiter.Waiter<GetDataMaskRuleRequest, GetDataMaskRuleResponse>
+            forDataMaskRule(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetDataMaskRuleRequest request,
+                    final com.oracle.bmc.cloudguard.model.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.cloudguard.model.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetDataMaskRuleRequest, GetDataMaskRuleResponse>() {
+                            @Override
+                            public GetDataMaskRuleResponse apply(GetDataMaskRuleRequest request) {
+                                return client.getDataMaskRule(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetDataMaskRuleResponse>() {
+                            @Override
+                            public boolean apply(GetDataMaskRuleResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getDataMaskRule().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.cloudguard.model.LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetDetectorRequest, GetDetectorResponse> forDetector(
             GetDetectorRequest request,
             com.oracle.bmc.cloudguard.model.LifecycleState... targetStates) {

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/CreateDataMaskRuleConverter.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/CreateDataMaskRuleConverter.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.cloudguard.model.*;
+import com.oracle.bmc.cloudguard.requests.*;
+import com.oracle.bmc.cloudguard.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.extern.slf4j.Slf4j
+public class CreateDataMaskRuleConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.cloudguard.requests.CreateDataMaskRuleRequest interceptRequest(
+            com.oracle.bmc.cloudguard.requests.CreateDataMaskRuleRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.cloudguard.requests.CreateDataMaskRuleRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateDataMaskRuleDetails(), "createDataMaskRuleDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20200131").path("dataMaskRules");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.cloudguard.responses.CreateDataMaskRuleResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.cloudguard.responses.CreateDataMaskRuleResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.cloudguard.responses.CreateDataMaskRuleResponse>() {
+                            @Override
+                            public com.oracle.bmc.cloudguard.responses.CreateDataMaskRuleResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.cloudguard.responses.CreateDataMaskRuleResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        DataMaskRule>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        DataMaskRule.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<DataMaskRule> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.cloudguard.responses.CreateDataMaskRuleResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.cloudguard.responses
+                                                        .CreateDataMaskRuleResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.dataMaskRule(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.cloudguard.responses.CreateDataMaskRuleResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/DeleteDataMaskRuleConverter.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/DeleteDataMaskRuleConverter.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.cloudguard.model.*;
+import com.oracle.bmc.cloudguard.requests.*;
+import com.oracle.bmc.cloudguard.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.extern.slf4j.Slf4j
+public class DeleteDataMaskRuleConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.cloudguard.requests.DeleteDataMaskRuleRequest interceptRequest(
+            com.oracle.bmc.cloudguard.requests.DeleteDataMaskRuleRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.cloudguard.requests.DeleteDataMaskRuleRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDataMaskRuleId(), "dataMaskRuleId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200131")
+                        .path("dataMaskRules")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDataMaskRuleId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.cloudguard.responses.DeleteDataMaskRuleResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.cloudguard.responses.DeleteDataMaskRuleResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.cloudguard.responses.DeleteDataMaskRuleResponse>() {
+                            @Override
+                            public com.oracle.bmc.cloudguard.responses.DeleteDataMaskRuleResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.cloudguard.responses.DeleteDataMaskRuleResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.cloudguard.responses.DeleteDataMaskRuleResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.cloudguard.responses
+                                                        .DeleteDataMaskRuleResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.cloudguard.responses.DeleteDataMaskRuleResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/GetDataMaskRuleConverter.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/GetDataMaskRuleConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.cloudguard.model.*;
+import com.oracle.bmc.cloudguard.requests.*;
+import com.oracle.bmc.cloudguard.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.extern.slf4j.Slf4j
+public class GetDataMaskRuleConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.cloudguard.requests.GetDataMaskRuleRequest interceptRequest(
+            com.oracle.bmc.cloudguard.requests.GetDataMaskRuleRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.cloudguard.requests.GetDataMaskRuleRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDataMaskRuleId(), "dataMaskRuleId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200131")
+                        .path("dataMaskRules")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDataMaskRuleId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.cloudguard.responses.GetDataMaskRuleResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.cloudguard.responses.GetDataMaskRuleResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.cloudguard.responses.GetDataMaskRuleResponse>() {
+                            @Override
+                            public com.oracle.bmc.cloudguard.responses.GetDataMaskRuleResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.cloudguard.responses.GetDataMaskRuleResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        DataMaskRule>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        DataMaskRule.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<DataMaskRule> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.cloudguard.responses.GetDataMaskRuleResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.cloudguard.responses
+                                                        .GetDataMaskRuleResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.dataMaskRule(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.cloudguard.responses.GetDataMaskRuleResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/ListDataMaskRulesConverter.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/ListDataMaskRulesConverter.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.cloudguard.model.*;
+import com.oracle.bmc.cloudguard.requests.*;
+import com.oracle.bmc.cloudguard.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.extern.slf4j.Slf4j
+public class ListDataMaskRulesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.cloudguard.requests.ListDataMaskRulesRequest interceptRequest(
+            com.oracle.bmc.cloudguard.requests.ListDataMaskRulesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.cloudguard.requests.ListDataMaskRulesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20200131").path("dataMaskRules");
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getAccessLevel() != null) {
+            target =
+                    target.queryParam(
+                            "accessLevel",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getAccessLevel().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getDataMaskRuleStatus() != null) {
+            target =
+                    target.queryParam(
+                            "dataMaskRuleStatus",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDataMaskRuleStatus().getValue()));
+        }
+
+        if (request.getTargetId() != null) {
+            target =
+                    target.queryParam(
+                            "targetId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTargetId()));
+        }
+
+        if (request.getIamGroupId() != null) {
+            target =
+                    target.queryParam(
+                            "iamGroupId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIamGroupId()));
+        }
+
+        if (request.getTargetType() != null) {
+            target =
+                    target.queryParam(
+                            "targetType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTargetType()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.cloudguard.responses.ListDataMaskRulesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.cloudguard.responses.ListDataMaskRulesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.cloudguard.responses.ListDataMaskRulesResponse>() {
+                            @Override
+                            public com.oracle.bmc.cloudguard.responses.ListDataMaskRulesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.cloudguard.responses.ListDataMaskRulesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        DataMaskRuleCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        DataMaskRuleCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<DataMaskRuleCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.cloudguard.responses.ListDataMaskRulesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.cloudguard.responses
+                                                        .ListDataMaskRulesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.dataMaskRuleCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.cloudguard.responses.ListDataMaskRulesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/ListPoliciesConverter.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/ListPoliciesConverter.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.cloudguard.model.*;
+import com.oracle.bmc.cloudguard.requests.*;
+import com.oracle.bmc.cloudguard.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.extern.slf4j.Slf4j
+public class ListPoliciesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.cloudguard.requests.ListPoliciesRequest interceptRequest(
+            com.oracle.bmc.cloudguard.requests.ListPoliciesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.cloudguard.requests.ListPoliciesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20200131").path("policies");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.cloudguard.responses.ListPoliciesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.cloudguard.responses.ListPoliciesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.cloudguard.responses.ListPoliciesResponse>() {
+                            @Override
+                            public com.oracle.bmc.cloudguard.responses.ListPoliciesResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.cloudguard.responses.ListPoliciesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        PolicyCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        PolicyCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<PolicyCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.cloudguard.responses.ListPoliciesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.cloudguard.responses
+                                                        .ListPoliciesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.policyCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.cloudguard.responses.ListPoliciesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/UpdateDataMaskRuleConverter.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/internal/http/UpdateDataMaskRuleConverter.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.cloudguard.model.*;
+import com.oracle.bmc.cloudguard.requests.*;
+import com.oracle.bmc.cloudguard.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.extern.slf4j.Slf4j
+public class UpdateDataMaskRuleConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.cloudguard.requests.UpdateDataMaskRuleRequest interceptRequest(
+            com.oracle.bmc.cloudguard.requests.UpdateDataMaskRuleRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.cloudguard.requests.UpdateDataMaskRuleRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDataMaskRuleId(), "dataMaskRuleId must not be blank");
+        Validate.notNull(
+                request.getUpdateDataMaskRuleDetails(), "updateDataMaskRuleDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200131")
+                        .path("dataMaskRules")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDataMaskRuleId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.cloudguard.responses.UpdateDataMaskRuleResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.cloudguard.responses.UpdateDataMaskRuleResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.cloudguard.responses.UpdateDataMaskRuleResponse>() {
+                            @Override
+                            public com.oracle.bmc.cloudguard.responses.UpdateDataMaskRuleResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.cloudguard.responses.UpdateDataMaskRuleResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        DataMaskRule>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        DataMaskRule.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<DataMaskRule> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.cloudguard.responses.UpdateDataMaskRuleResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.cloudguard.responses
+                                                        .UpdateDataMaskRuleResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.dataMaskRule(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.cloudguard.responses.UpdateDataMaskRuleResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/AllTargetsSelected.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/AllTargetsSelected.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * All Targets selected.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AllTargetsSelected.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AllTargetsSelected extends TargetSelected {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AllTargetsSelected build() {
+            AllTargetsSelected __instance__ = new AllTargetsSelected();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AllTargetsSelected o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AllTargetsSelected() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/CreateDataMaskRuleDetails.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/CreateDataMaskRuleDetails.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * The information about new Data Mask Rule.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDataMaskRuleDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateDataMaskRuleDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("iamGroupId")
+        private String iamGroupId;
+
+        public Builder iamGroupId(String iamGroupId) {
+            this.iamGroupId = iamGroupId;
+            this.__explicitlySet__.add("iamGroupId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetSelected")
+        private TargetSelected targetSelected;
+
+        public Builder targetSelected(TargetSelected targetSelected) {
+            this.targetSelected = targetSelected;
+            this.__explicitlySet__.add("targetSelected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataMaskCategories")
+        private java.util.List<DataMaskCategory> dataMaskCategories;
+
+        public Builder dataMaskCategories(java.util.List<DataMaskCategory> dataMaskCategories) {
+            this.dataMaskCategories = dataMaskCategories;
+            this.__explicitlySet__.add("dataMaskCategories");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataMaskRuleStatus")
+        private DataMaskRuleStatus dataMaskRuleStatus;
+
+        public Builder dataMaskRuleStatus(DataMaskRuleStatus dataMaskRuleStatus) {
+            this.dataMaskRuleStatus = dataMaskRuleStatus;
+            this.__explicitlySet__.add("dataMaskRuleStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDataMaskRuleDetails build() {
+            CreateDataMaskRuleDetails __instance__ =
+                    new CreateDataMaskRuleDetails(
+                            displayName,
+                            compartmentId,
+                            description,
+                            iamGroupId,
+                            targetSelected,
+                            dataMaskCategories,
+                            dataMaskRuleStatus,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDataMaskRuleDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .description(o.getDescription())
+                            .iamGroupId(o.getIamGroupId())
+                            .targetSelected(o.getTargetSelected())
+                            .dataMaskCategories(o.getDataMaskCategories())
+                            .dataMaskRuleStatus(o.getDataMaskRuleStatus())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Data Mask Rule name
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Compartment Identifier where the resource is created
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The Data Mask Rule description.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * IAM Group id associated with the data mask rule
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("iamGroupId")
+    String iamGroupId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetSelected")
+    TargetSelected targetSelected;
+
+    /**
+     * Data Mask Categories
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataMaskCategories")
+    java.util.List<DataMaskCategory> dataMaskCategories;
+
+    /**
+     * The status of the dataMaskRule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataMaskRuleStatus")
+    DataMaskRuleStatus dataMaskRuleStatus;
+
+    /**
+     * The current state of the DataMaskRule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskCategory.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskCategory.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * Possible data masking categories
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+public enum DataMaskCategory {
+    Actor("ACTOR"),
+    Pii("PII"),
+    Phi("PHI"),
+    Financial("FINANCIAL"),
+    Location("LOCATION"),
+    Custom("CUSTOM"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, DataMaskCategory> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (DataMaskCategory v : DataMaskCategory.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    DataMaskCategory(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static DataMaskCategory create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid DataMaskCategory: " + key);
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskRule.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskRule.java
@@ -1,0 +1,317 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * Description of DataMaskRule.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DataMaskRule.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DataMaskRule {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("iamGroupId")
+        private String iamGroupId;
+
+        public Builder iamGroupId(String iamGroupId) {
+            this.iamGroupId = iamGroupId;
+            this.__explicitlySet__.add("iamGroupId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetSelected")
+        private TargetSelected targetSelected;
+
+        public Builder targetSelected(TargetSelected targetSelected) {
+            this.targetSelected = targetSelected;
+            this.__explicitlySet__.add("targetSelected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataMaskCategories")
+        private java.util.List<DataMaskCategory> dataMaskCategories;
+
+        public Builder dataMaskCategories(java.util.List<DataMaskCategory> dataMaskCategories) {
+            this.dataMaskCategories = dataMaskCategories;
+            this.__explicitlySet__.add("dataMaskCategories");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataMaskRuleStatus")
+        private DataMaskRuleStatus dataMaskRuleStatus;
+
+        public Builder dataMaskRuleStatus(DataMaskRuleStatus dataMaskRuleStatus) {
+            this.dataMaskRuleStatus = dataMaskRuleStatus;
+            this.__explicitlySet__.add("dataMaskRuleStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecyleDetails")
+        private String lifecyleDetails;
+
+        public Builder lifecyleDetails(String lifecyleDetails) {
+            this.lifecyleDetails = lifecyleDetails;
+            this.__explicitlySet__.add("lifecyleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DataMaskRule build() {
+            DataMaskRule __instance__ =
+                    new DataMaskRule(
+                            id,
+                            displayName,
+                            compartmentId,
+                            description,
+                            iamGroupId,
+                            targetSelected,
+                            dataMaskCategories,
+                            timeCreated,
+                            timeUpdated,
+                            dataMaskRuleStatus,
+                            lifecycleState,
+                            lifecyleDetails,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DataMaskRule o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .description(o.getDescription())
+                            .iamGroupId(o.getIamGroupId())
+                            .targetSelected(o.getTargetSelected())
+                            .dataMaskCategories(o.getDataMaskCategories())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .dataMaskRuleStatus(o.getDataMaskRuleStatus())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecyleDetails(o.getLifecyleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique identifier that is immutable on creation
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Data Mask Rule Identifier, can be renamed
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Compartment Identifier where the resource is created
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The data mask rule description.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * IAM Group id associated with the data mask rule
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("iamGroupId")
+    String iamGroupId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetSelected")
+    TargetSelected targetSelected;
+
+    /**
+     * Data Mask Categories
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataMaskCategories")
+    java.util.List<DataMaskCategory> dataMaskCategories;
+
+    /**
+     * The date and time the target was created. Format defined by RFC3339.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time the target was updated. Format defined by RFC3339.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * The status of the dataMaskRule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataMaskRuleStatus")
+    DataMaskRuleStatus dataMaskRuleStatus;
+
+    /**
+     * The current state of the DataMaskRule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecyleDetails")
+    String lifecyleDetails;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * System tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * System tags can be viewed by users, but can only be created by the system.
+     * <p>
+     * Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskRuleCollection.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskRuleCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * Collection of Data Mask Rule
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DataMaskRuleCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DataMaskRuleCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<DataMaskRuleSummary> items;
+
+        public Builder items(java.util.List<DataMaskRuleSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DataMaskRuleCollection build() {
+            DataMaskRuleCollection __instance__ = new DataMaskRuleCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DataMaskRuleCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of Data Mask Rule Summary
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<DataMaskRuleSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskRuleStatus.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskRuleStatus.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * The status of the dataMaskRule.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.extern.slf4j.Slf4j
+public enum DataMaskRuleStatus {
+    Enabled("ENABLED"),
+    Disabled("DISABLED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, DataMaskRuleStatus> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (DataMaskRuleStatus v : DataMaskRuleStatus.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    DataMaskRuleStatus(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static DataMaskRuleStatus create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'DataMaskRuleStatus', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskRuleSummary.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DataMaskRuleSummary.java
@@ -1,0 +1,319 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * Summary of DataMaskRule.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DataMaskRuleSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DataMaskRuleSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("iamGroupId")
+        private String iamGroupId;
+
+        public Builder iamGroupId(String iamGroupId) {
+            this.iamGroupId = iamGroupId;
+            this.__explicitlySet__.add("iamGroupId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetSelected")
+        private TargetSelected targetSelected;
+
+        public Builder targetSelected(TargetSelected targetSelected) {
+            this.targetSelected = targetSelected;
+            this.__explicitlySet__.add("targetSelected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataMaskCategories")
+        private java.util.List<DataMaskCategory> dataMaskCategories;
+
+        public Builder dataMaskCategories(java.util.List<DataMaskCategory> dataMaskCategories) {
+            this.dataMaskCategories = dataMaskCategories;
+            this.__explicitlySet__.add("dataMaskCategories");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataMaskRuleStatus")
+        private DataMaskRuleStatus dataMaskRuleStatus;
+
+        public Builder dataMaskRuleStatus(DataMaskRuleStatus dataMaskRuleStatus) {
+            this.dataMaskRuleStatus = dataMaskRuleStatus;
+            this.__explicitlySet__.add("dataMaskRuleStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecyleDetails")
+        private String lifecyleDetails;
+
+        public Builder lifecyleDetails(String lifecyleDetails) {
+            this.lifecyleDetails = lifecyleDetails;
+            this.__explicitlySet__.add("lifecyleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DataMaskRuleSummary build() {
+            DataMaskRuleSummary __instance__ =
+                    new DataMaskRuleSummary(
+                            id,
+                            displayName,
+                            compartmentId,
+                            description,
+                            iamGroupId,
+                            targetSelected,
+                            dataMaskCategories,
+                            timeCreated,
+                            timeUpdated,
+                            dataMaskRuleStatus,
+                            lifecycleState,
+                            lifecyleDetails,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DataMaskRuleSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .description(o.getDescription())
+                            .iamGroupId(o.getIamGroupId())
+                            .targetSelected(o.getTargetSelected())
+                            .dataMaskCategories(o.getDataMaskCategories())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .dataMaskRuleStatus(o.getDataMaskRuleStatus())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecyleDetails(o.getLifecyleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique identifier that is immutable on creation
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Data Mask Rule Name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Compartment Identifier where the resource is created
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The data mask rule description.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * IAM Group id associated with the data mask rule
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("iamGroupId")
+    String iamGroupId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetSelected")
+    TargetSelected targetSelected;
+
+    /**
+     * Data Mask Categories
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataMaskCategories")
+    java.util.List<DataMaskCategory> dataMaskCategories;
+
+    /**
+     * The date and time the target was created. Format defined by RFC3339.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The date and time the target was updated. Format defined by RFC3339.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * The status of the dataMaskRule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataMaskRuleStatus")
+    DataMaskRuleStatus dataMaskRuleStatus;
+
+    /**
+     * The current state of the DataMaskRule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * A message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecyleDetails")
+    String lifecyleDetails;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * System tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * System tags can be viewed by users, but can only be created by the system.
+     * <p>
+     * Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRecipe.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRecipe.java
@@ -260,13 +260,13 @@ public class DetectorRecipe {
     DetectorEnum detector;
 
     /**
-     * List of detetor rules for the detector type for recipe
+     * List of detector rules for the detector type for recipe - user input
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("detectorRules")
     java.util.List<DetectorRecipeDetectorRule> detectorRules;
 
     /**
-     * List of detetor rules for the detector type for recipe
+     * List of effective detector rules for the detector type for recipe after applying defaults
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("effectiveDetectorRules")
     java.util.List<DetectorRecipeDetectorRule> effectiveDetectorRules;

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRecipeDetectorRule.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRecipeDetectorRule.java
@@ -266,6 +266,7 @@ public class DetectorRecipeDetectorRule {
         State("STATE"),
         City("CITY"),
         Tags("TAGS"),
+        Generic("GENERIC"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRecipeDetectorRuleSummary.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRecipeDetectorRuleSummary.java
@@ -263,6 +263,7 @@ public class DetectorRecipeDetectorRuleSummary {
         State("STATE"),
         City("CITY"),
         Tags("TAGS"),
+        Generic("GENERIC"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRule.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRule.java
@@ -264,6 +264,7 @@ public class DetectorRule {
         State("STATE"),
         City("CITY"),
         Tags("TAGS"),
+        Generic("GENERIC"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRuleSummary.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/DetectorRuleSummary.java
@@ -263,6 +263,7 @@ public class DetectorRuleSummary {
         State("STATE"),
         City("CITY"),
         Tags("TAGS"),
+        Generic("GENERIC"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/ManagedListType.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/ManagedListType.java
@@ -21,6 +21,7 @@ public enum ManagedListType {
     State("STATE"),
     City("CITY"),
     Tags("TAGS"),
+    Generic("GENERIC"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/PolicyCollection.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/PolicyCollection.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * Collection of policy statements required by cloud guard
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PolicyCollection.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PolicyCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<PolicySummary> items;
+
+        public Builder items(java.util.List<PolicySummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PolicyCollection build() {
+            PolicyCollection __instance__ = new PolicyCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PolicyCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of global policy statements
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<PolicySummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/PolicySummary.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/PolicySummary.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * Global policy statement
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PolicySummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PolicySummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("policy")
+        private String policy;
+
+        public Builder policy(String policy) {
+            this.policy = policy;
+            this.__explicitlySet__.add("policy");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PolicySummary build() {
+            PolicySummary __instance__ = new PolicySummary(policy);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PolicySummary o) {
+            Builder copiedBuilder = policy(o.getPolicy());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Global policy statement
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("policy")
+    String policy;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/Problem.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/Problem.java
@@ -168,6 +168,33 @@ public class Problem {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
+        private java.util.Map<String, String> additionalDetails;
+
+        public Builder additionalDetails(java.util.Map<String, String> additionalDetails) {
+            this.additionalDetails = additionalDetails;
+            this.__explicitlySet__.add("additionalDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("recommendation")
+        private String recommendation;
+
+        public Builder recommendation(String recommendation) {
+            this.recommendation = recommendation;
+            this.__explicitlySet__.add("recommendation");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("comment")
         private String comment;
 
@@ -199,6 +226,9 @@ public class Problem {
                             lifecycleDetail,
                             detectorId,
                             targetId,
+                            additionalDetails,
+                            description,
+                            recommendation,
                             comment);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -223,6 +253,9 @@ public class Problem {
                             .lifecycleDetail(o.getLifecycleDetail())
                             .detectorId(o.getDetectorId())
                             .targetId(o.getTargetId())
+                            .additionalDetails(o.getAdditionalDetails())
+                            .description(o.getDescription())
+                            .recommendation(o.getRecommendation())
                             .comment(o.getComment());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -332,6 +365,24 @@ public class Problem {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("targetId")
     String targetId;
+
+    /**
+     * The additional details of the Problem
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
+    java.util.Map<String, String> additionalDetails;
+
+    /**
+     * Description of the problem
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Recommendation for the problem
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("recommendation")
+    String recommendation;
 
     /**
      * User Comments

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/SecurityRating.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/SecurityRating.java
@@ -14,6 +14,7 @@ public enum SecurityRating {
     Good("GOOD"),
     Fair("FAIR"),
     Poor("POOR"),
+    Na("NA"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetDetectorRecipeDetectorRule.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetDetectorRecipeDetectorRule.java
@@ -254,6 +254,7 @@ public class TargetDetectorRecipeDetectorRule {
         State("STATE"),
         City("CITY"),
         Tags("TAGS"),
+        Generic("GENERIC"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetDetectorRecipeDetectorRuleSummary.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetDetectorRecipeDetectorRuleSummary.java
@@ -251,6 +251,7 @@ public class TargetDetectorRecipeDetectorRuleSummary {
         State("STATE"),
         City("CITY"),
         Tags("TAGS"),
+        Generic("GENERIC"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetIdsSelected.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetIdsSelected.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * Target selection on basis of TargetIds.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TargetIdsSelected.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TargetIdsSelected extends TargetSelected {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("values")
+        private java.util.List<String> values;
+
+        public Builder values(java.util.List<String> values) {
+            this.values = values;
+            this.__explicitlySet__.add("values");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TargetIdsSelected build() {
+            TargetIdsSelected __instance__ = new TargetIdsSelected(values);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TargetIdsSelected o) {
+            Builder copiedBuilder = values(o.getValues());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public TargetIdsSelected(java.util.List<String> values) {
+        super();
+        this.values = values;
+    }
+
+    /**
+     * Ids of Target
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    java.util.List<String> values;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetResourceTypesSelected.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetResourceTypesSelected.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * Target selection on basis of TargetResourceTypes.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = TargetResourceTypesSelected.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TargetResourceTypesSelected extends TargetSelected {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("values")
+        private java.util.List<TargetResourceType> values;
+
+        public Builder values(java.util.List<TargetResourceType> values) {
+            this.values = values;
+            this.__explicitlySet__.add("values");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TargetResourceTypesSelected build() {
+            TargetResourceTypesSelected __instance__ = new TargetResourceTypesSelected(values);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TargetResourceTypesSelected o) {
+            Builder copiedBuilder = values(o.getValues());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public TargetResourceTypesSelected(java.util.List<TargetResourceType> values) {
+        super();
+        this.values = values;
+    }
+
+    /**
+     * Types of Targets
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    java.util.List<TargetResourceType> values;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetSelected.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/TargetSelected.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * Target Selection eg select ALL or select on basis of TargetResourceTypes or TargetIds.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind",
+    defaultImpl = TargetSelected.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AllTargetsSelected.class,
+        name = "ALL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = TargetResourceTypesSelected.class,
+        name = "TARGETTYPES"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = TargetIdsSelected.class,
+        name = "TARGETIDS"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TargetSelected {
+
+    /**
+     * Target selection.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Kind {
+        All("ALL"),
+        Targettypes("TARGETTYPES"),
+        Targetids("TARGETIDS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Kind> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Kind v : Kind.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Kind(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Kind create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Kind', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/UpdateBulkProblemStatusDetails.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/UpdateBulkProblemStatusDetails.java
@@ -44,19 +44,29 @@ public class UpdateBulkProblemStatusDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("comment")
+        private String comment;
+
+        public Builder comment(String comment) {
+            this.comment = comment;
+            this.__explicitlySet__.add("comment");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateBulkProblemStatusDetails build() {
             UpdateBulkProblemStatusDetails __instance__ =
-                    new UpdateBulkProblemStatusDetails(status, problemIds);
+                    new UpdateBulkProblemStatusDetails(status, problemIds, comment);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateBulkProblemStatusDetails o) {
-            Builder copiedBuilder = status(o.getStatus()).problemIds(o.getProblemIds());
+            Builder copiedBuilder =
+                    status(o.getStatus()).problemIds(o.getProblemIds()).comment(o.getComment());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -81,6 +91,12 @@ public class UpdateBulkProblemStatusDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("problemIds")
     java.util.List<String> problemIds;
+
+    /**
+     * User defined comment to be passed in to update the problem.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("comment")
+    String comment;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/UpdateDataMaskRuleDetails.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/model/UpdateDataMaskRuleDetails.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.model;
+
+/**
+ * The information to be updated.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateDataMaskRuleDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateDataMaskRuleDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("iamGroupId")
+        private String iamGroupId;
+
+        public Builder iamGroupId(String iamGroupId) {
+            this.iamGroupId = iamGroupId;
+            this.__explicitlySet__.add("iamGroupId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetSelected")
+        private TargetSelected targetSelected;
+
+        public Builder targetSelected(TargetSelected targetSelected) {
+            this.targetSelected = targetSelected;
+            this.__explicitlySet__.add("targetSelected");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataMaskCategories")
+        private java.util.List<DataMaskCategory> dataMaskCategories;
+
+        public Builder dataMaskCategories(java.util.List<DataMaskCategory> dataMaskCategories) {
+            this.dataMaskCategories = dataMaskCategories;
+            this.__explicitlySet__.add("dataMaskCategories");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dataMaskRuleStatus")
+        private DataMaskRuleStatus dataMaskRuleStatus;
+
+        public Builder dataMaskRuleStatus(DataMaskRuleStatus dataMaskRuleStatus) {
+            this.dataMaskRuleStatus = dataMaskRuleStatus;
+            this.__explicitlySet__.add("dataMaskRuleStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateDataMaskRuleDetails build() {
+            UpdateDataMaskRuleDetails __instance__ =
+                    new UpdateDataMaskRuleDetails(
+                            displayName,
+                            compartmentId,
+                            iamGroupId,
+                            targetSelected,
+                            dataMaskCategories,
+                            dataMaskRuleStatus,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateDataMaskRuleDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .iamGroupId(o.getIamGroupId())
+                            .targetSelected(o.getTargetSelected())
+                            .dataMaskCategories(o.getDataMaskCategories())
+                            .dataMaskRuleStatus(o.getDataMaskRuleStatus())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Data Mask Rule Name
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Compartment Identifier where the resource is created
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * IAM Group id associated with the data mask rule
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("iamGroupId")
+    String iamGroupId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetSelected")
+    TargetSelected targetSelected;
+
+    /**
+     * Data Mask Categories
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataMaskCategories")
+    java.util.List<DataMaskCategory> dataMaskCategories;
+
+    /**
+     * The status of the dataMaskRule.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dataMaskRuleStatus")
+    DataMaskRuleStatus dataMaskRuleStatus;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/CreateDataMaskRuleRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/CreateDataMaskRuleRequest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.requests;
+
+import com.oracle.bmc.cloudguard.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/CreateDataMaskRuleExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateDataMaskRuleRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateDataMaskRuleRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateDataMaskRuleDetails> {
+
+    /**
+     * Definition for the new Data Mask Rule.
+     */
+    private CreateDataMaskRuleDetails createDataMaskRuleDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateDataMaskRuleDetails getBody$() {
+        return createDataMaskRuleDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateDataMaskRuleRequest, CreateDataMaskRuleDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateDataMaskRuleRequest o) {
+            createDataMaskRuleDetails(o.getCreateDataMaskRuleDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateDataMaskRuleRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateDataMaskRuleRequest
+         */
+        public CreateDataMaskRuleRequest build() {
+            CreateDataMaskRuleRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateDataMaskRuleDetails body) {
+            createDataMaskRuleDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/DeleteDataMaskRuleRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/DeleteDataMaskRuleRequest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.requests;
+
+import com.oracle.bmc.cloudguard.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/DeleteDataMaskRuleExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteDataMaskRuleRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteDataMaskRuleRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * OCID of dataMaskRule
+     */
+    private String dataMaskRuleId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteDataMaskRuleRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteDataMaskRuleRequest o) {
+            dataMaskRuleId(o.getDataMaskRuleId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteDataMaskRuleRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteDataMaskRuleRequest
+         */
+        public DeleteDataMaskRuleRequest build() {
+            DeleteDataMaskRuleRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/GetDataMaskRuleRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/GetDataMaskRuleRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.requests;
+
+import com.oracle.bmc.cloudguard.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/GetDataMaskRuleExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetDataMaskRuleRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetDataMaskRuleRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * OCID of dataMaskRule
+     */
+    private String dataMaskRuleId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetDataMaskRuleRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetDataMaskRuleRequest o) {
+            dataMaskRuleId(o.getDataMaskRuleId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetDataMaskRuleRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetDataMaskRuleRequest
+         */
+        public GetDataMaskRuleRequest build() {
+            GetDataMaskRuleRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListDataMaskRulesRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListDataMaskRulesRequest.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.requests;
+
+import com.oracle.bmc.cloudguard.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/ListDataMaskRulesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListDataMaskRulesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListDataMaskRulesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ID of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * A filter to return only resources that match the entire display name given.
+     */
+    private String displayName;
+
+    /**
+     * The field life cycle state. Only one state can be provided. Default value for state is active. If no value is specified state is active.
+     */
+    private com.oracle.bmc.cloudguard.model.LifecycleState lifecycleState;
+
+    /**
+     * Valid values are `RESTRICTED` and `ACCESSIBLE`. Default is `RESTRICTED`.
+     * Setting this to `ACCESSIBLE` returns only those compartments for which the
+     * user has INSPECT permissions directly or indirectly (permissions can be on a
+     * resource in a subcompartment).
+     * When set to `RESTRICTED` permissions are checked and no partial results are displayed.
+     *
+     */
+    private AccessLevel accessLevel;
+
+    /**
+     * Valid values are `RESTRICTED` and `ACCESSIBLE`. Default is `RESTRICTED`.
+     * Setting this to `ACCESSIBLE` returns only those compartments for which the
+     * user has INSPECT permissions directly or indirectly (permissions can be on a
+     * resource in a subcompartment).
+     * When set to `RESTRICTED` permissions are checked and no partial results are displayed.
+     *
+     **/
+    public enum AccessLevel {
+        Restricted("RESTRICTED"),
+        Accessible("ACCESSIBLE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, AccessLevel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AccessLevel v : AccessLevel.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        AccessLevel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AccessLevel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid AccessLevel: " + key);
+        }
+    };
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     */
+    private com.oracle.bmc.cloudguard.model.SortOrders sortOrder;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+     *
+     **/
+    public enum SortBy {
+        TimeCreated("timeCreated"),
+        DisplayName("displayName"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The status of the dataMaskRule.
+     */
+    private com.oracle.bmc.cloudguard.model.DataMaskRuleStatus dataMaskRuleStatus;
+
+    /**
+     * OCID of target
+     */
+    private String targetId;
+
+    /**
+     * OCID of iamGroup
+     */
+    private String iamGroupId;
+
+    /**
+     * Type of target
+     */
+    private String targetType;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListDataMaskRulesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDataMaskRulesRequest o) {
+            compartmentId(o.getCompartmentId());
+            displayName(o.getDisplayName());
+            lifecycleState(o.getLifecycleState());
+            accessLevel(o.getAccessLevel());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            dataMaskRuleStatus(o.getDataMaskRuleStatus());
+            targetId(o.getTargetId());
+            iamGroupId(o.getIamGroupId());
+            targetType(o.getTargetType());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListDataMaskRulesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListDataMaskRulesRequest
+         */
+        public ListDataMaskRulesRequest build() {
+            ListDataMaskRulesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListDetectorRecipesRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListDetectorRecipesRequest.java
@@ -32,7 +32,7 @@ public class ListDetectorRecipesRequest extends com.oracle.bmc.requests.BmcReque
     /**
      * Default is false.
      * When set to true, the list of all Oracle Managed Resources
-     * Metadata supported by Cloud Guard is returned.
+     * Metadata supported by Cloud Guard are returned.
      *
      */
     private Boolean resourceMetadataOnly;

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListManagedListsRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListManagedListsRequest.java
@@ -32,7 +32,7 @@ public class ListManagedListsRequest extends com.oracle.bmc.requests.BmcRequest<
     /**
      * Default is false.
      * When set to true, the list of all Oracle Managed Resources
-     * Metadata supported by Cloud Guard is returned.
+     * Metadata supported by Cloud Guard are returned.
      *
      */
     private Boolean resourceMetadataOnly;

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListPoliciesRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListPoliciesRequest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.requests;
+
+import com.oracle.bmc.cloudguard.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/ListPoliciesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListPoliciesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListPoliciesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ID of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     */
+    private com.oracle.bmc.cloudguard.model.SortOrders sortOrder;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+     *
+     **/
+    public enum SortBy {
+        TimeCreated("timeCreated"),
+        DisplayName("displayName"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListPoliciesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPoliciesRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListPoliciesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListPoliciesRequest
+         */
+        public ListPoliciesRequest build() {
+            ListPoliciesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListProblemsRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListProblemsRequest.java
@@ -25,22 +25,22 @@ public class ListProblemsRequest extends com.oracle.bmc.requests.BmcRequest<java
     private String compartmentId;
 
     /**
-     * Start time for a filter. If start time is not specified, start time will be set to today's current time - 30 days.
+     * Start time for a filter. If start time is not specified, start time will be set to current time - 30 days.
      */
     private java.util.Date timeLastDetectedGreaterThanOrEqualTo;
 
     /**
-     * End time for a filter. If end time is not specified, end time will be set to today's current time.
+     * End time for a filter. If end time is not specified, end time will be set to current time.
      */
     private java.util.Date timeLastDetectedLessThanOrEqualTo;
 
     /**
-     * Start time for a filter. If start time is not specified, start time will be set to today's current time - 30 days.
+     * Start time for a filter. If start time is not specified, start time will be set to current time - 30 days.
      */
     private java.util.Date timeFirstDetectedGreaterThanOrEqualTo;
 
     /**
-     * End time for a filter. If end time is not specified, end time will be set to today's current time.
+     * End time for a filter. If end time is not specified, end time will be set to current time.
      */
     private java.util.Date timeFirstDetectedLessThanOrEqualTo;
 

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListResponderRecipesRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/ListResponderRecipesRequest.java
@@ -28,7 +28,7 @@ public class ListResponderRecipesRequest
     /**
      * Default is false.
      * When set to true, the list of all Oracle Managed Resources
-     * Metadata supported by Cloud Guard is returned.
+     * Metadata supported by Cloud Guard are returned.
      *
      */
     private Boolean resourceMetadataOnly;

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/RequestSummarizedTrendProblemsRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/RequestSummarizedTrendProblemsRequest.java
@@ -26,12 +26,12 @@ public class RequestSummarizedTrendProblemsRequest
     private String compartmentId;
 
     /**
-     * Start time for a filter. If start time is not specified, start time will be set to today's current time - 30 days.
+     * Start time for a filter. If start time is not specified, start time will be set to current time - 30 days.
      */
     private java.util.Date timeFirstDetectedGreaterThanOrEqualTo;
 
     /**
-     * End time for a filter. If end time is not specified, end time will be set to today's current time.
+     * End time for a filter. If end time is not specified, end time will be set to current time.
      */
     private java.util.Date timeFirstDetectedLessThanOrEqualTo;
 

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/UpdateDataMaskRuleRequest.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/requests/UpdateDataMaskRuleRequest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.requests;
+
+import com.oracle.bmc.cloudguard.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/cloudguard/UpdateDataMaskRuleExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateDataMaskRuleRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateDataMaskRuleRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateDataMaskRuleDetails> {
+
+    /**
+     * OCID of dataMaskRule
+     */
+    private String dataMaskRuleId;
+
+    /**
+     * The information to be updated.
+     */
+    private UpdateDataMaskRuleDetails updateDataMaskRuleDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateDataMaskRuleDetails getBody$() {
+        return updateDataMaskRuleDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateDataMaskRuleRequest, UpdateDataMaskRuleDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateDataMaskRuleRequest o) {
+            dataMaskRuleId(o.getDataMaskRuleId());
+            updateDataMaskRuleDetails(o.getUpdateDataMaskRuleDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateDataMaskRuleRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateDataMaskRuleRequest
+         */
+        public UpdateDataMaskRuleRequest build() {
+            UpdateDataMaskRuleRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateDataMaskRuleDetails body) {
+            updateDataMaskRuleDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/CreateDataMaskRuleResponse.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/CreateDataMaskRuleResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.responses;
+
+import com.oracle.bmc.cloudguard.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class CreateDataMaskRuleResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned DataMaskRule instance.
+     */
+    private DataMaskRule dataMaskRule;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateDataMaskRuleResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            dataMaskRule(o.getDataMaskRule());
+
+            return this;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/DeleteDataMaskRuleResponse.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/DeleteDataMaskRuleResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.responses;
+
+import com.oracle.bmc.cloudguard.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class DeleteDataMaskRuleResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteDataMaskRuleResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/GetDataMaskRuleResponse.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/GetDataMaskRuleResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.responses;
+
+import com.oracle.bmc.cloudguard.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetDataMaskRuleResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned DataMaskRule instance.
+     */
+    private DataMaskRule dataMaskRule;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetDataMaskRuleResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            dataMaskRule(o.getDataMaskRule());
+
+            return this;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/ListDataMaskRulesResponse.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/ListDataMaskRulesResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.responses;
+
+import com.oracle.bmc.cloudguard.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListDataMaskRulesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned DataMaskRuleCollection instance.
+     */
+    private DataMaskRuleCollection dataMaskRuleCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDataMaskRulesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            dataMaskRuleCollection(o.getDataMaskRuleCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/ListPoliciesResponse.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/ListPoliciesResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.responses;
+
+import com.oracle.bmc.cloudguard.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListPoliciesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned PolicyCollection instance.
+     */
+    private PolicyCollection policyCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPoliciesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            policyCollection(o.getPolicyCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/UpdateDataMaskRuleResponse.java
+++ b/bmc-cloudguard/src/main/java/com/oracle/bmc/cloudguard/responses/UpdateDataMaskRuleResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.cloudguard.responses;
+
+import com.oracle.bmc.cloudguard.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200131")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class UpdateDataMaskRuleResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned DataMaskRule instance.
+     */
+    private DataMaskRule dataMaskRule;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateDataMaskRuleResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            dataMaskRule(o.getDataMaskRule());
+
+            return this;
+        }
+    }
+}

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,11 +18,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,16 +18,17 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListVlansConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListVlansConverter.java
@@ -28,7 +28,6 @@ public class ListVlansConverter {
             com.oracle.bmc.core.requests.ListVlansRequest request) {
         Validate.notNull(request, "request instance is required");
         Validate.notNull(request.getCompartmentId(), "compartmentId is required");
-        Validate.notNull(request.getVcnId(), "vcnId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget().path("/20160918").path("vlans");
@@ -55,11 +54,13 @@ public class ListVlansConverter {
                                     request.getPage()));
         }
 
-        target =
-                target.queryParam(
-                        "vcnId",
-                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                request.getVcnId()));
+        if (request.getVcnId() != null) {
+            target =
+                    target.queryParam(
+                            "vcnId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getVcnId()));
+        }
 
         if (request.getDisplayName() != null) {
             target =

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVnicDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVnicDetails.java
@@ -39,6 +39,15 @@ public class CreateVnicDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("assignPrivateDnsRecord")
+        private Boolean assignPrivateDnsRecord;
+
+        public Builder assignPrivateDnsRecord(Boolean assignPrivateDnsRecord) {
+            this.assignPrivateDnsRecord = assignPrivateDnsRecord;
+            this.__explicitlySet__.add("assignPrivateDnsRecord");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -128,6 +137,7 @@ public class CreateVnicDetails {
             CreateVnicDetails __instance__ =
                     new CreateVnicDetails(
                             assignPublicIp,
+                            assignPrivateDnsRecord,
                             definedTags,
                             displayName,
                             freeformTags,
@@ -145,6 +155,7 @@ public class CreateVnicDetails {
         public Builder copy(CreateVnicDetails o) {
             Builder copiedBuilder =
                     assignPublicIp(o.getAssignPublicIp())
+                            .assignPrivateDnsRecord(o.getAssignPrivateDnsRecord())
                             .definedTags(o.getDefinedTags())
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
@@ -195,6 +206,17 @@ public class CreateVnicDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("assignPublicIp")
     Boolean assignPublicIp;
+
+    /**
+     * Whether the VNIC should be assigned a DNS record. If set to false, there will be no DNS record
+     * registration for the VNIC. If set to true, the DNS record will be registered. The default
+     * value is true.
+     * <p>
+     * If you specify a `hostnameLabel`, then `assignPrivateDnsRecord` must be set to true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("assignPrivateDnsRecord")
+    Boolean assignPrivateDnsRecord;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationCreateVnicDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationCreateVnicDetails.java
@@ -37,6 +37,15 @@ public class InstanceConfigurationCreateVnicDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("assignPrivateDnsRecord")
+        private Boolean assignPrivateDnsRecord;
+
+        public Builder assignPrivateDnsRecord(Boolean assignPrivateDnsRecord) {
+            this.assignPrivateDnsRecord = assignPrivateDnsRecord;
+            this.__explicitlySet__.add("assignPrivateDnsRecord");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -117,6 +126,7 @@ public class InstanceConfigurationCreateVnicDetails {
             InstanceConfigurationCreateVnicDetails __instance__ =
                     new InstanceConfigurationCreateVnicDetails(
                             assignPublicIp,
+                            assignPrivateDnsRecord,
                             definedTags,
                             displayName,
                             freeformTags,
@@ -133,6 +143,7 @@ public class InstanceConfigurationCreateVnicDetails {
         public Builder copy(InstanceConfigurationCreateVnicDetails o) {
             Builder copiedBuilder =
                     assignPublicIp(o.getAssignPublicIp())
+                            .assignPrivateDnsRecord(o.getAssignPrivateDnsRecord())
                             .definedTags(o.getDefinedTags())
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
@@ -161,6 +172,14 @@ public class InstanceConfigurationCreateVnicDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("assignPublicIp")
     Boolean assignPublicIp;
+
+    /**
+     * Whether the VNIC should be assigned a private DNS record. See the `assignPrivateDnsRecord` attribute of {@link CreateVnicDetails}
+     * for more information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("assignPrivateDnsRecord")
+    Boolean assignPrivateDnsRecord;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateClusterNetworkDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateClusterNetworkDetails.java
@@ -54,12 +54,23 @@ public class UpdateClusterNetworkDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("instancePools")
+        private java.util.List<UpdateClusterNetworkInstancePoolDetails> instancePools;
+
+        public Builder instancePools(
+                java.util.List<UpdateClusterNetworkInstancePoolDetails> instancePools) {
+            this.instancePools = instancePools;
+            this.__explicitlySet__.add("instancePools");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateClusterNetworkDetails build() {
             UpdateClusterNetworkDetails __instance__ =
-                    new UpdateClusterNetworkDetails(definedTags, displayName, freeformTags);
+                    new UpdateClusterNetworkDetails(
+                            definedTags, displayName, freeformTags, instancePools);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -69,7 +80,8 @@ public class UpdateClusterNetworkDetails {
             Builder copiedBuilder =
                     definedTags(o.getDefinedTags())
                             .displayName(o.getDisplayName())
-                            .freeformTags(o.getFreeformTags());
+                            .freeformTags(o.getFreeformTags())
+                            .instancePools(o.getInstancePools());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -110,6 +122,13 @@ public class UpdateClusterNetworkDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
+
+    /**
+     * The instance pools in the cluster network to update.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instancePools")
+    java.util.List<UpdateClusterNetworkInstancePoolDetails> instancePools;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateClusterNetworkInstancePoolDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateClusterNetworkInstancePoolDetails.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * The data to update an instance pool within a cluster network.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateClusterNetworkInstancePoolDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateClusterNetworkInstancePoolDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("size")
+        private Integer size;
+
+        public Builder size(Integer size) {
+            this.size = size;
+            this.__explicitlySet__.add("size");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateClusterNetworkInstancePoolDetails build() {
+            UpdateClusterNetworkInstancePoolDetails __instance__ =
+                    new UpdateClusterNetworkInstancePoolDetails(
+                            id, definedTags, displayName, freeformTags, size);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateClusterNetworkInstancePoolDetails o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .definedTags(o.getDefinedTags())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .size(o.getSize());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the instance pool.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * A user-friendly name for the instance pool. Does not have to be unique, and it's
+     * changeable. Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * The number of instances that should be in the instance pool.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("size")
+    Integer size;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListVlansRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListVlansRequest.java
@@ -25,11 +25,6 @@ public class ListVlansRequest extends com.oracle.bmc.requests.BmcRequest<java.la
     private String compartmentId;
 
     /**
-     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
-     */
-    private String vcnId;
-
-    /**
      * For list pagination. The maximum number of results per page, or items to return in a paginated
      * \"List\" call. For important details about how pagination works, see
      * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
@@ -46,6 +41,11 @@ public class ListVlansRequest extends com.oracle.bmc.requests.BmcRequest<java.la
      *
      */
     private String page;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the VCN.
+     */
+    private String vcnId;
 
     /**
      * A filter to return only resources that match the given display name exactly.
@@ -203,9 +203,9 @@ public class ListVlansRequest extends com.oracle.bmc.requests.BmcRequest<java.la
          */
         public Builder copy(ListVlansRequest o) {
             compartmentId(o.getCompartmentId());
-            vcnId(o.getVcnId());
             limit(o.getLimit());
             page(o.getPage());
+            vcnId(o.getVcnId());
             displayName(o.getDisplayName());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,16 +18,17 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalContainerDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalContainerDatabase.java
@@ -172,6 +172,15 @@ public class ExternalContainerDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+        private DatabaseConfiguration databaseConfiguration;
+
+        public Builder databaseConfiguration(DatabaseConfiguration databaseConfiguration) {
+            this.databaseConfiguration = databaseConfiguration;
+            this.__explicitlySet__.add("databaseConfiguration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
         private DatabaseManagementConfig databaseManagementConfig;
 
@@ -203,6 +212,7 @@ public class ExternalContainerDatabase {
                             characterSet,
                             ncharacterSet,
                             dbPacks,
+                            databaseConfiguration,
                             databaseManagementConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -227,6 +237,7 @@ public class ExternalContainerDatabase {
                             .characterSet(o.getCharacterSet())
                             .ncharacterSet(o.getNcharacterSet())
                             .dbPacks(o.getDbPacks())
+                            .databaseConfiguration(o.getDatabaseConfiguration())
                             .databaseManagementConfig(o.getDatabaseManagementConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -446,6 +457,57 @@ public class ExternalContainerDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbPacks")
     String dbPacks;
+    /**
+     * The Oracle Database configuration
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DatabaseConfiguration {
+        Rac("RAC"),
+        SingleInstance("SINGLE_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DatabaseConfiguration> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DatabaseConfiguration v : DatabaseConfiguration.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DatabaseConfiguration(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DatabaseConfiguration create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DatabaseConfiguration', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The Oracle Database configuration
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+    DatabaseConfiguration databaseConfiguration;
 
     @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
     DatabaseManagementConfig databaseManagementConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalContainerDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalContainerDatabaseSummary.java
@@ -172,6 +172,15 @@ public class ExternalContainerDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+        private DatabaseConfiguration databaseConfiguration;
+
+        public Builder databaseConfiguration(DatabaseConfiguration databaseConfiguration) {
+            this.databaseConfiguration = databaseConfiguration;
+            this.__explicitlySet__.add("databaseConfiguration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
         private DatabaseManagementConfig databaseManagementConfig;
 
@@ -203,6 +212,7 @@ public class ExternalContainerDatabaseSummary {
                             characterSet,
                             ncharacterSet,
                             dbPacks,
+                            databaseConfiguration,
                             databaseManagementConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -227,6 +237,7 @@ public class ExternalContainerDatabaseSummary {
                             .characterSet(o.getCharacterSet())
                             .ncharacterSet(o.getNcharacterSet())
                             .dbPacks(o.getDbPacks())
+                            .databaseConfiguration(o.getDatabaseConfiguration())
                             .databaseManagementConfig(o.getDatabaseManagementConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -446,6 +457,57 @@ public class ExternalContainerDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbPacks")
     String dbPacks;
+    /**
+     * The Oracle Database configuration
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DatabaseConfiguration {
+        Rac("RAC"),
+        SingleInstance("SINGLE_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DatabaseConfiguration> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DatabaseConfiguration v : DatabaseConfiguration.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DatabaseConfiguration(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DatabaseConfiguration create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DatabaseConfiguration', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The Oracle Database configuration
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+    DatabaseConfiguration databaseConfiguration;
 
     @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
     DatabaseManagementConfig databaseManagementConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalDatabaseBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalDatabaseBase.java
@@ -172,6 +172,15 @@ public class ExternalDatabaseBase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+        private DatabaseConfiguration databaseConfiguration;
+
+        public Builder databaseConfiguration(DatabaseConfiguration databaseConfiguration) {
+            this.databaseConfiguration = databaseConfiguration;
+            this.__explicitlySet__.add("databaseConfiguration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
         private DatabaseManagementConfig databaseManagementConfig;
 
@@ -203,6 +212,7 @@ public class ExternalDatabaseBase {
                             characterSet,
                             ncharacterSet,
                             dbPacks,
+                            databaseConfiguration,
                             databaseManagementConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -227,6 +237,7 @@ public class ExternalDatabaseBase {
                             .characterSet(o.getCharacterSet())
                             .ncharacterSet(o.getNcharacterSet())
                             .dbPacks(o.getDbPacks())
+                            .databaseConfiguration(o.getDatabaseConfiguration())
                             .databaseManagementConfig(o.getDatabaseManagementConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -424,6 +435,46 @@ public class ExternalDatabaseBase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbPacks")
     String dbPacks;
+    /**
+     * The Oracle Database configuration
+     **/
+    public enum DatabaseConfiguration {
+        Rac("RAC"),
+        SingleInstance("SINGLE_INSTANCE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, DatabaseConfiguration> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DatabaseConfiguration v : DatabaseConfiguration.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        DatabaseConfiguration(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DatabaseConfiguration create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid DatabaseConfiguration: " + key);
+        }
+    };
+    /**
+     * The Oracle Database configuration
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+    DatabaseConfiguration databaseConfiguration;
 
     @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
     DatabaseManagementConfig databaseManagementConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalNonContainerDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalNonContainerDatabase.java
@@ -180,6 +180,15 @@ public class ExternalNonContainerDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+        private DatabaseConfiguration databaseConfiguration;
+
+        public Builder databaseConfiguration(DatabaseConfiguration databaseConfiguration) {
+            this.databaseConfiguration = databaseConfiguration;
+            this.__explicitlySet__.add("databaseConfiguration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
         private DatabaseManagementConfig databaseManagementConfig;
 
@@ -212,6 +221,7 @@ public class ExternalNonContainerDatabase {
                             characterSet,
                             ncharacterSet,
                             dbPacks,
+                            databaseConfiguration,
                             databaseManagementConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -237,6 +247,7 @@ public class ExternalNonContainerDatabase {
                             .characterSet(o.getCharacterSet())
                             .ncharacterSet(o.getNcharacterSet())
                             .dbPacks(o.getDbPacks())
+                            .databaseConfiguration(o.getDatabaseConfiguration())
                             .databaseManagementConfig(o.getDatabaseManagementConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -459,6 +470,57 @@ public class ExternalNonContainerDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbPacks")
     String dbPacks;
+    /**
+     * The Oracle Database configuration
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DatabaseConfiguration {
+        Rac("RAC"),
+        SingleInstance("SINGLE_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DatabaseConfiguration> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DatabaseConfiguration v : DatabaseConfiguration.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DatabaseConfiguration(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DatabaseConfiguration create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DatabaseConfiguration', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The Oracle Database configuration
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+    DatabaseConfiguration databaseConfiguration;
 
     @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
     DatabaseManagementConfig databaseManagementConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalNonContainerDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalNonContainerDatabaseSummary.java
@@ -182,6 +182,15 @@ public class ExternalNonContainerDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+        private DatabaseConfiguration databaseConfiguration;
+
+        public Builder databaseConfiguration(DatabaseConfiguration databaseConfiguration) {
+            this.databaseConfiguration = databaseConfiguration;
+            this.__explicitlySet__.add("databaseConfiguration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
         private DatabaseManagementConfig databaseManagementConfig;
 
@@ -214,6 +223,7 @@ public class ExternalNonContainerDatabaseSummary {
                             characterSet,
                             ncharacterSet,
                             dbPacks,
+                            databaseConfiguration,
                             databaseManagementConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -239,6 +249,7 @@ public class ExternalNonContainerDatabaseSummary {
                             .characterSet(o.getCharacterSet())
                             .ncharacterSet(o.getNcharacterSet())
                             .dbPacks(o.getDbPacks())
+                            .databaseConfiguration(o.getDatabaseConfiguration())
                             .databaseManagementConfig(o.getDatabaseManagementConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -461,6 +472,57 @@ public class ExternalNonContainerDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbPacks")
     String dbPacks;
+    /**
+     * The Oracle Database configuration
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DatabaseConfiguration {
+        Rac("RAC"),
+        SingleInstance("SINGLE_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DatabaseConfiguration> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DatabaseConfiguration v : DatabaseConfiguration.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DatabaseConfiguration(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DatabaseConfiguration create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DatabaseConfiguration', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The Oracle Database configuration
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+    DatabaseConfiguration databaseConfiguration;
 
     @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
     DatabaseManagementConfig databaseManagementConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalPluggableDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalPluggableDatabase.java
@@ -198,6 +198,15 @@ public class ExternalPluggableDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+        private DatabaseConfiguration databaseConfiguration;
+
+        public Builder databaseConfiguration(DatabaseConfiguration databaseConfiguration) {
+            this.databaseConfiguration = databaseConfiguration;
+            this.__explicitlySet__.add("databaseConfiguration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
         private DatabaseManagementConfig databaseManagementConfig;
 
@@ -232,6 +241,7 @@ public class ExternalPluggableDatabase {
                             characterSet,
                             ncharacterSet,
                             dbPacks,
+                            databaseConfiguration,
                             databaseManagementConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -259,6 +269,7 @@ public class ExternalPluggableDatabase {
                             .characterSet(o.getCharacterSet())
                             .ncharacterSet(o.getNcharacterSet())
                             .dbPacks(o.getDbPacks())
+                            .databaseConfiguration(o.getDatabaseConfiguration())
                             .databaseManagementConfig(o.getDatabaseManagementConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -498,6 +509,57 @@ public class ExternalPluggableDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbPacks")
     String dbPacks;
+    /**
+     * The Oracle Database configuration
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DatabaseConfiguration {
+        Rac("RAC"),
+        SingleInstance("SINGLE_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DatabaseConfiguration> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DatabaseConfiguration v : DatabaseConfiguration.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DatabaseConfiguration(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DatabaseConfiguration create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DatabaseConfiguration', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The Oracle Database configuration
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+    DatabaseConfiguration databaseConfiguration;
 
     @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
     DatabaseManagementConfig databaseManagementConfig;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalPluggableDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExternalPluggableDatabaseSummary.java
@@ -199,6 +199,15 @@ public class ExternalPluggableDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+        private DatabaseConfiguration databaseConfiguration;
+
+        public Builder databaseConfiguration(DatabaseConfiguration databaseConfiguration) {
+            this.databaseConfiguration = databaseConfiguration;
+            this.__explicitlySet__.add("databaseConfiguration");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
         private DatabaseManagementConfig databaseManagementConfig;
 
@@ -233,6 +242,7 @@ public class ExternalPluggableDatabaseSummary {
                             characterSet,
                             ncharacterSet,
                             dbPacks,
+                            databaseConfiguration,
                             databaseManagementConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -260,6 +270,7 @@ public class ExternalPluggableDatabaseSummary {
                             .characterSet(o.getCharacterSet())
                             .ncharacterSet(o.getNcharacterSet())
                             .dbPacks(o.getDbPacks())
+                            .databaseConfiguration(o.getDatabaseConfiguration())
                             .databaseManagementConfig(o.getDatabaseManagementConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -499,6 +510,57 @@ public class ExternalPluggableDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbPacks")
     String dbPacks;
+    /**
+     * The Oracle Database configuration
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum DatabaseConfiguration {
+        Rac("RAC"),
+        SingleInstance("SINGLE_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, DatabaseConfiguration> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (DatabaseConfiguration v : DatabaseConfiguration.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        DatabaseConfiguration(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static DatabaseConfiguration create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'DatabaseConfiguration', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The Oracle Database configuration
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseConfiguration")
+    DatabaseConfiguration databaseConfiguration;
 
     @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
     DatabaseManagementConfig databaseManagementConfig;

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigration.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigration.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 
 /**
- * Provides users the ability to perform Zero Downtime migration operations
+ * Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
 public interface DatabaseMigration extends AutoCloseable {
@@ -57,7 +57,7 @@ public interface DatabaseMigration extends AutoCloseable {
     AbortJobResponse abortJob(AbortJobRequest request);
 
     /**
-     * Used to configure a ODMS Agent Compartment Id.
+     * Used to configure an ODMS Agent Compartment ID.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -68,7 +68,7 @@ public interface DatabaseMigration extends AutoCloseable {
     ChangeAgentCompartmentResponse changeAgentCompartment(ChangeAgentCompartmentRequest request);
 
     /**
-     * Used to change the Databasee Connection compartment.
+     * Used to change the Database Connection compartment.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -116,7 +116,7 @@ public interface DatabaseMigration extends AutoCloseable {
 
     /**
      * Create a Migration resource that contains all the details to perform the
-     * database migration operation like source and destination database
+     * database migration operation, such as source and destination database
      * details, credentials, etc.
      *
      * @param request The request object containing the details to send
@@ -128,7 +128,7 @@ public interface DatabaseMigration extends AutoCloseable {
     CreateMigrationResponse createMigration(CreateMigrationRequest request);
 
     /**
-     * Delete the ODMS Agent represented by the given ODMS Agent id.
+     * Delete the ODMS Agent represented by the specified ODMS Agent ID.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -382,7 +382,7 @@ public interface DatabaseMigration extends AutoCloseable {
     StartMigrationResponse startMigration(StartMigrationRequest request);
 
     /**
-     * Modifies the ODMS Agent represented by the given ODMS agent Id.
+     * Modifies the ODMS Agent represented by the given ODMS Agent ID.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -393,7 +393,7 @@ public interface DatabaseMigration extends AutoCloseable {
     UpdateAgentResponse updateAgent(UpdateAgentRequest request);
 
     /**
-     * Update a Database Connection resource details.
+     * Update Database Connection resource details.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -404,7 +404,7 @@ public interface DatabaseMigration extends AutoCloseable {
     UpdateConnectionResponse updateConnection(UpdateConnectionRequest request);
 
     /**
-     * Update a Migration Job resource details.
+     * Update Migration Job resource details.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -415,7 +415,7 @@ public interface DatabaseMigration extends AutoCloseable {
     UpdateJobResponse updateJob(UpdateJobRequest request);
 
     /**
-     * Update a Migration resource details.
+     * Update Migration resource details.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsync.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsync.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 
 /**
- * Provides users the ability to perform Zero Downtime migration operations
+ * Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
 public interface DatabaseMigrationAsync extends AutoCloseable {
@@ -61,7 +61,7 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<AbortJobRequest, AbortJobResponse> handler);
 
     /**
-     * Used to configure a ODMS Agent Compartment Id.
+     * Used to configure an ODMS Agent Compartment ID.
      *
      *
      * @param request The request object containing the details to send
@@ -78,7 +78,7 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Used to change the Databasee Connection compartment.
+     * Used to change the Database Connection compartment.
      *
      *
      * @param request The request object containing the details to send
@@ -146,7 +146,7 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
 
     /**
      * Create a Migration resource that contains all the details to perform the
-     * database migration operation like source and destination database
+     * database migration operation, such as source and destination database
      * details, credentials, etc.
      *
      *
@@ -163,7 +163,7 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Delete the ODMS Agent represented by the given ODMS Agent id.
+     * Delete the ODMS Agent represented by the specified ODMS Agent ID.
      *
      *
      * @param request The request object containing the details to send
@@ -530,7 +530,7 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Modifies the ODMS Agent represented by the given ODMS agent Id.
+     * Modifies the ODMS Agent represented by the given ODMS Agent ID.
      *
      *
      * @param request The request object containing the details to send
@@ -545,7 +545,7 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<UpdateAgentRequest, UpdateAgentResponse> handler);
 
     /**
-     * Update a Database Connection resource details.
+     * Update Database Connection resource details.
      *
      *
      * @param request The request object containing the details to send
@@ -561,7 +561,7 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Update a Migration Job resource details.
+     * Update Migration Job resource details.
      *
      *
      * @param request The request object containing the details to send
@@ -576,7 +576,7 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<UpdateJobRequest, UpdateJobResponse> handler);
 
     /**
-     * Update a Migration resource details.
+     * Update Migration resource details.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdminCredentials.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdminCredentials.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Database Admin Credentials details.
+ * Database Administrator Credentials details.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -60,7 +60,7 @@ public class AdminCredentials {
     }
 
     /**
-     * Admin username
+     * Administrator username
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("username")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Agent.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Agent.java
@@ -252,7 +252,7 @@ public class Agent {
     java.util.Date timeUpdated;
 
     /**
-     * The current state of the ODMS On Prem Agent.
+     * The current state of the ODMS on-premises Agent.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Results of a Agent search. Contains AgentSummary items.
+ * Results of an Agent search. Contains AgentSummary items.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentImageCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentImageCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Results of a ODMS Agent Image search. Contains AgentImageSummary items.
+ * Results of an ODMS Agent Image search. Contains AgentImageSummary items.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentSummary.java
@@ -234,7 +234,7 @@ public class AgentSummary {
     java.util.Date timeUpdated;
 
     /**
-     * The current state of the ODMS On Prem Agent.
+     * The current state of the ODMS on-premises Agent.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ChangeAgentCompartmentDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ChangeAgentCompartmentDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * ChangeAgentCompartmentDetails description
+ * Change Agent compartment details
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CloneMigrationDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CloneMigrationDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Details to specify that will override an existing Migration configuration that will be cloned.
+ * Details that will override an existing Migration configuration that will be cloned.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -181,7 +181,7 @@ public class CloneMigrationDetails {
     String compartmentId;
 
     /**
-     * The OCID of the registered On-Prem ODMS Agent. Required for OFFLINE Migrations.
+     * The OCID of the registered on-premises ODMS Agent. Only valid for Offline Logical Migrations.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("agentId")
@@ -195,7 +195,7 @@ public class CloneMigrationDetails {
     String sourceDatabaseConnectionId;
 
     /**
-     * The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+     * The OCID of the Source Container Database Connection. Only used for Online migrations.
      * Only Connections of type Non-Autonomous can be used as source container databases.
      *
      **/

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAdminCredentials.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAdminCredentials.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Database Admin Credentials details.
+ * Database Administrator Credentials details.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -71,14 +71,14 @@ public class CreateAdminCredentials {
     }
 
     /**
-     * Admin username
+     * Administrator username
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("username")
     String username;
 
     /**
-     * Admin password
+     * Administrator password
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpParameters.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpParameters.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Optional parameters for Datapump Export and Import. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-62324358-2F26-4A94-B69F-1075D53FA96D__BABDECJE
+ * Optional parameters for Data Pump Export and Import. Refer to [Configuring Optional Initial Load Advanced Settings](https://docs.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED)
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -121,7 +121,7 @@ public class CreateDataPumpParameters {
     }
 
     /**
-     * False to force datapump worker process to run on one instance.
+     * Set to false to force Data Pump worker process to run on one instance.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isCluster")
@@ -142,14 +142,14 @@ public class CreateDataPumpParameters {
     DataPumpTableExistsAction tableExistsAction;
 
     /**
-     * Exclude paratemers for export and import.
+     * Exclude paratemers for Export and Import.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("excludeParameters")
     java.util.List<DataPumpExcludeParameters> excludeParameters;
 
     /**
-     * Maximum number of worker processes that can be used for a Datapump Import job.
+     * Maximum number of worker processes that can be used for a Data Pump Import job.
      * For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
      *
      **/
@@ -157,7 +157,7 @@ public class CreateDataPumpParameters {
     Integer importParallelismDegree;
 
     /**
-     * Maximum number of worker processes that can be used for a Datapump Export job.
+     * Maximum number of worker processes that can be used for a Data Pump Export job.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("exportParallelismDegree")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpSettings.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Optional settings for Datapump Export and Import jobs
+ * Optional settings for Data Pump Export and Import jobs
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -109,8 +109,8 @@ public class CreateDataPumpSettings {
     }
 
     /**
-     * DataPump job mode.
-     * Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+     * Data Pump job mode.
+     * Refer to [link text](https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("jobMode")
@@ -121,7 +121,7 @@ public class CreateDataPumpSettings {
 
     /**
      * Defines remapping to be applied to objects as they are processed.
-     * Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+     * Refer to [DATA_REMAP](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-E75AAE6F-4EA6-4737-A752-6B62F5E9D460)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadataRemaps")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataTransferMediumDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataTransferMediumDetails.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.model;
 
 /**
  * Data Transfer Medium details for the Migration. If not specified, it will default to Database Link. Only one type
- * of medium details can be specified.
+ * of data transfer medium can be specified.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateExtract.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateExtract.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Parameters for Extract processes.
+ * Parameters for GoldenGate Extract processes.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateHub.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateHub.java
@@ -158,7 +158,7 @@ public class CreateGoldenGateHub {
     CreateAdminCredentials targetDbAdminCredentials;
 
     /**
-     * Oracle GoldenGate hub's REST endpoint.
+     * Oracle GoldenGate Microservices hub's REST endpoint.
      * Refer to https://docs.oracle.com/en/middleware/goldengate/core/19.1/securing/network.html#GUID-A709DA55-111D-455E-8942-C9BDD1E38CAA
      *
      **/
@@ -166,21 +166,21 @@ public class CreateGoldenGateHub {
     String url;
 
     /**
-     * Name of Microservices deployment to operate on source DB
+     * Name of GoldenGate Microservices deployment to operate on source database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceMicroservicesDeploymentName")
     String sourceMicroservicesDeploymentName;
 
     /**
-     * Name of Microservices deployment to operate on target DB
+     * Name of GoldenGate Microservices deployment to operate on target database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("targetMicroservicesDeploymentName")
     String targetMicroservicesDeploymentName;
 
     /**
-     * OCID of Golden Gate compute instance.
+     * OCID of GoldenGate Microservices compute instance.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("computeId")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateSettings.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Optional settings for Oracle GoldenGate processes
+ * Optional settings for GoldenGate Microservices processes
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateMigrationDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateMigrationDetails.java
@@ -233,7 +233,7 @@ public class CreateMigrationDetails {
     String compartmentId;
 
     /**
-     * The OCID of the registered ODMS Agent. Required for OFFLINE Migrations.
+     * The OCID of the registered ODMS Agent. Only valid for Offline Logical Migrations.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("agentId")
@@ -247,7 +247,7 @@ public class CreateMigrationDetails {
     String sourceDatabaseConnectionId;
 
     /**
-     * The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+     * The OCID of the Source Container Database Connection. Only used for Online migrations.
      * Only Connections of type Non-Autonomous can be used as source container databases.
      *
      **/

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateObjectStoreBucket.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateObjectStoreBucket.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * In lieu of a network database link, OCI Object Storage bucket will be used to store Datapump dump files for the migration.
+ * In lieu of a network database link, OCI Object Storage bucket will be used to store Data Pump dump files for the migration.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreatePrivateEndpoint.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreatePrivateEndpoint.java
@@ -86,7 +86,7 @@ public class CreatePrivateEndpoint {
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment to contain the
-     * private endpoint. Required if the id was not specified.
+     * private endpoint.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
@@ -94,7 +94,6 @@ public class CreatePrivateEndpoint {
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VCN where the Private Endpoint will be bound to.
-     * Required if the id was not specified.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("vcnId")
@@ -102,7 +101,7 @@ public class CreatePrivateEndpoint {
 
     /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the customer's subnet where the private endpoint VNIC
-     * will reside.  Required if the id was not specified.
+     * will reside.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateReplicat.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateReplicat.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Parameters for Replicat processes.
+ * Parameters for GoldenGate Replicat processes.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateSshDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateSshDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Details of the ssh key that will be used. Required for source database Manual and UserManagerOci connection types.
+ * Details of the SSH key that will be used. Required for source database Manual and UserManagerOci connection types.
  * Not required for source container database connections.
  *
  * <br/>
@@ -92,14 +92,14 @@ public class CreateSshDetails {
     }
 
     /**
-     * Name of the host the sshkey is valid for.
+     * Name of the host the SSH key is valid for.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("host")
     String host;
 
     /**
-     * Private ssh key string.
+     * Private SSH key string.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sshkey")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpJobMode.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpJobMode.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Estimate size of dumps that will be generated.
+ * Data Pump job modes
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpParameters.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpParameters.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Optional parameters for Datapump Export and Import. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-62324358-2F26-4A94-B69F-1075D53FA96D__BABDECJE
+ * Optional parameters for Data Pump Export and Import. Refer to [Configuring Optional Initial Load Advanced Settings](https://docs.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED)
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -121,7 +121,7 @@ public class DataPumpParameters {
     }
 
     /**
-     * False to force datapump worker process to run on one instance.
+     * Set to false to force Data Pump worker processes to run on one instance.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isCluster")
@@ -142,14 +142,14 @@ public class DataPumpParameters {
     DataPumpTableExistsAction tableExistsAction;
 
     /**
-     * Exclude paratemers for export and import.
+     * Exclude paratemers for Export and Import.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("excludeParameters")
     java.util.List<DataPumpExcludeParameters> excludeParameters;
 
     /**
-     * Maximum number of worker processes that can be used for a Datapump Import job.
+     * Maximum number of worker processes that can be used for a Data Pump Import job.
      * For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
      *
      **/
@@ -157,7 +157,7 @@ public class DataPumpParameters {
     Integer importParallelismDegree;
 
     /**
-     * Maximum number of worker processes that can be used for a Datapump Export job.
+     * Maximum number of worker processes that can be used for a Data Pump Export job.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("exportParallelismDegree")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpSettings.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Optional settings for Datapump Export and Import jobs
+ * Optional settings for Data Pump Export and Import jobs
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -107,8 +107,8 @@ public class DataPumpSettings {
     }
 
     /**
-     * DataPump job mode.
-     * Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+     * Data Pump job mode.
+     * Refer to [Data Pump Export Modes ](https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("jobMode")
@@ -119,7 +119,7 @@ public class DataPumpSettings {
 
     /**
      * Defines remapping to be applied to objects as they are processed.
-     * Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+     * Refer to [METADATA_REMAP Procedure ](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadataRemaps")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExtractPerformanceProfile.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExtractPerformanceProfile.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Estimate size of dumps that will be generated.
+ * GoldenGate Extract perfoemance profile
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GoldenGateHub.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GoldenGateHub.java
@@ -164,21 +164,21 @@ public class GoldenGateHub {
     String url;
 
     /**
-     * Name of Microservices deployment to operate on source DB
+     * Name of GoldenGate deployment to operate on source database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceMicroservicesDeploymentName")
     String sourceMicroservicesDeploymentName;
 
     /**
-     * Name of Microservices deployment to operate on target DB
+     * Name of GoldenGate deployment to operate on target database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("targetMicroservicesDeploymentName")
     String targetMicroservicesDeploymentName;
 
     /**
-     * OCID of Golden Gate compute instance.
+     * OCID of GoldenGate compute instance.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("computeId")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Job.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Job.java
@@ -225,14 +225,14 @@ public class Job {
     JobTypes type;
 
     /**
-     * The time the DB Migration Job was created. An RFC3339 formatted datetime string
+     * The time the Migration Job was created. An RFC3339 formatted datetime string
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
 
     /**
-     * The time the DB Migration Job was last updated. An RFC3339 formatted datetime string
+     * The time the Migration Job was last updated. An RFC3339 formatted datetime string
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobSummary.java
@@ -216,14 +216,14 @@ public class JobSummary {
     MigrationJobProgressSummary progress;
 
     /**
-     * The time the DB Migration Job was created. An RFC3339 formatted datetime string
+     * The time the Migration Job was created. An RFC3339 formatted datetime string
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
 
     /**
-     * The time the DB Migration Job was last updated. An RFC3339 formatted datetime string
+     * The time the Migration Job was last updated. An RFC3339 formatted datetime string
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MetadataRemap.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MetadataRemap.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.model;
 
 /**
  * Defines remapping to be applied to objects as they are processed.
- * Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+ * Refer to [METADATA_REMAP Procedure ](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -80,7 +80,7 @@ public class MetadataRemap {
     }
 
     /**
-     * Type of remap. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D__BABDJGDI
+     * Type of remap. Refer to [METADATA_REMAP Procedure ](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -128,7 +128,7 @@ public class MetadataRemap {
         }
     };
     /**
-     * Type of remap. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D__BABDJGDI
+     * Type of remap. Refer to [METADATA_REMAP Procedure ](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Migration.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Migration.java
@@ -356,14 +356,14 @@ public class Migration {
     OdmsJobPhases waitAfter;
 
     /**
-     * The OCID of the registered On-Prem ODMS Agent. Required for Offline Migrations.
+     * The OCID of the registered on-premises ODMS Agent. Only valid for Offline Migrations.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("agentId")
     String agentId;
 
     /**
-     * OCID of the Secret in the OCI vault containing the Migration credentials. Used to store Golden Gate admin user credentials.
+     * OCID of the Secret in the OCI vault containing the Migration credentials. Used to store GoldenGate administrator user credentials.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("credentialsSecretId")
@@ -438,7 +438,7 @@ public class Migration {
     java.util.Date timeLastMigration;
 
     /**
-     * The current state of the Migration Resource.
+     * The current state of the Migration resource.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationSummary.java
@@ -309,7 +309,7 @@ public class MigrationSummary {
     String executingJobId;
 
     /**
-     * The OCID of the registered On-Prem ODMS Agent. Required for Offline Migrations.
+     * The OCID of the registered on-premises ODMS Agent. Only valid for Offline Migrations.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("agentId")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationTypes.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationTypes.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Supported migration types.
+ * Supported Migration types.
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ObjectStoreBucket.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ObjectStoreBucket.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * In lieu of a network database link, OCI Object Storage bucket will be used to store Datapump dump files for the migration.
+ * In lieu of a network database link, OCI Object Storage bucket will be used to store Data Pump dump files for the migration.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Replicat.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Replicat.java
@@ -89,14 +89,14 @@ public class Replicat {
     Integer mapParallelism;
 
     /**
-     * Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+     * Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("minApplyParallelism")
     Integer minApplyParallelism;
 
     /**
-     * Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+     * Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("maxApplyParallelism")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/SshDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/SshDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Details of the ssh key that will be used.
+ * Details of the SSH key that will be used.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -79,7 +79,7 @@ public class SshDetails {
     }
 
     /**
-     * Name of the host the sshkey is valid for.
+     * Name of the host the SSH key is valid for.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("host")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAdminCredentials.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAdminCredentials.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Database Admin Credentials details. An empty object would result in the removal of the stored details.
+ * Database Administrator Credentials details. An empty object would result in the removal of the stored details.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -71,14 +71,14 @@ public class UpdateAdminCredentials {
     }
 
     /**
-     * Admin username
+     * Administrator username
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("username")
     String username;
 
     /**
-     * Admin password
+     * Administrator password
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("password")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpParameters.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpParameters.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Optional parameters for Datapump Export and Import. Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-62324358-2F26-4A94-B69F-1075D53FA96D__BABDECJE
+ * Optional parameters for Data Pump Export and Import. Refer to [Configuring Optional Initial Load Advanced Settings](https://docs-uat.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED)
  * If an empty object is specified, the stored Data Pump Parameter details will be removed.
  *
  * <br/>
@@ -122,7 +122,7 @@ public class UpdateDataPumpParameters {
     }
 
     /**
-     * False to force datapump worker process to run on one instance.
+     * Set to false to force Data Pump worker processes to run on one instance.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isCluster")
@@ -143,14 +143,14 @@ public class UpdateDataPumpParameters {
     DataPumpTableExistsAction tableExistsAction;
 
     /**
-     * Exclude paratemers for export and import. If specified, the stored list will be replaced.
+     * Exclude paratemers for Export and Import. If specified, the stored list will be replaced.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("excludeParameters")
     java.util.List<DataPumpExcludeParameters> excludeParameters;
 
     /**
-     * Maximum number of worker processes that can be used for a Datapump Import job.
+     * Maximum number of worker processes that can be used for a Data Pump Import job.
      * For an Autonomous Database, ODMS will automatically query its CPU core count and set this property.
      *
      **/
@@ -158,7 +158,7 @@ public class UpdateDataPumpParameters {
     Integer importParallelismDegree;
 
     /**
-     * Maximum number of worker processes that can be used for a Datapump Export job.
+     * Maximum number of worker processes that can be used for a Data Pump Export job.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("exportParallelismDegree")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpSettings.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Optional settings for Datapump Export and Import jobs
+ * Optional settings for Data Pump Export and Import jobs
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -109,8 +109,8 @@ public class UpdateDataPumpSettings {
     }
 
     /**
-     * DataPump job mode.
-     * Refer to docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-92C2CB46-8BC9-414D-B62E-79CD788C1E62__BABBDEHD
+     * Data Pump job mode.
+     * Refer to [Data Pump Export Modes ](https://docs.oracle.com/en/database/oracle/oracle-database/19/sutil/oracle-data-pump-export-utility.html#GUID-8E497131-6B9B-4CC8-AA50-35F480CAC2C4)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("jobMode")
@@ -120,8 +120,8 @@ public class UpdateDataPumpSettings {
     UpdateDataPumpParameters dataPumpParameters;
 
     /**
-     * Defines remapping to be applied to objects as they are processed.
-     * Refer to https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/ODMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D.
+     * Defines remappings to be applied to objects as they are processed.
+     * Refer to [METADATA_REMAP Procedure ](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
      * If specified, the list will be replaced entirely. Empty list will remove stored Metadata Remap details.
      *
      **/

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataTransferMediumDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataTransferMediumDetails.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.model;
 
 /**
  * Data Transfer Medium details for the Migration.
- * Only one type of medium details can be specified and will replace the stored Data Transfer Medium details.
+ * Only one type of data transfer medium can be specified and will replace the stored Data Transfer Medium details.
  * If an empty object is specified, the stored Data Transfer Medium details will be removed.
  *
  * <br/>

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateHub.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateHub.java
@@ -166,21 +166,21 @@ public class UpdateGoldenGateHub {
     String url;
 
     /**
-     * Name of Microservices deployment to operate on source DB
+     * Name of GoldenGate deployment to operate on source database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceMicroservicesDeploymentName")
     String sourceMicroservicesDeploymentName;
 
     /**
-     * Name of Microservices deployment to operate on target DB
+     * Name of GoldenGate deployment to operate on target database
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("targetMicroservicesDeploymentName")
     String targetMicroservicesDeploymentName;
 
     /**
-     * OCID of Golden Gate compute instance. An empty value will remove the stored computeId.
+     * OCID of GoldenGate compute instance. An empty value will remove the stored computeId.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("computeId")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateSettings.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.model;
 
 /**
  * Optional settings for Oracle GoldenGate processes
- * If an empty object is specified, the stored Golden Gate Settings details will be removed.
+ * If an empty object is specified, the stored GoldenGate Settings details will be removed.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateMigrationDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateMigrationDetails.java
@@ -229,9 +229,9 @@ public class UpdateMigrationDetails {
     String sourceDatabaseConnectionId;
 
     /**
-     * The OCID of the Source Container Database Connection. Only used for ONLINE migrations.
+     * The OCID of the Source Container Database Connection. Only used for Online migrations.
      * Only Connections of type Non-Autonomous can be used as source container databases.
-     * An empty value would remove the stored Connection Id.
+     * An empty value would remove the stored Connection ID.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceContainerDatabaseConnectionId")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateReplicat.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateReplicat.java
@@ -90,14 +90,14 @@ public class UpdateReplicat {
     Integer mapParallelism;
 
     /**
-     * Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+     * Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("minApplyParallelism")
     Integer minApplyParallelism;
 
     /**
-     * Defines the range in which the Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
+     * Defines the range in which Replicat automatically adjusts its apply parallelism (valid for Parallel Replicat)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("maxApplyParallelism")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateSshDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateSshDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Details of the ssh key that will be used.
+ * Details of the SSH key that will be used.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -91,14 +91,14 @@ public class UpdateSshDetails {
     }
 
     /**
-     * Name of the host the sshkey is valid for.
+     * Name of the host the SSH key is valid for.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("host")
     String host;
 
     /**
-     * Private ssh key string.
+     * Private SSH key string.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sshkey")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestError.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestError.java
@@ -80,7 +80,7 @@ public class WorkRequestError {
 
     /**
      * A machine-usable code for the error that occured. Error codes are listed on
-     * (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+     * [API Errors](https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("code")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeConnectionCompartmentRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeConnectionCompartmentRequest.java
@@ -21,7 +21,7 @@ public class ChangeConnectionCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeConnectionCompartmentDetails> {
 
     /**
-     * The OCID of the job
+     * The OCID of the database connection
      *
      */
     private String connectionId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeMigrationCompartmentRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeMigrationCompartmentRequest.java
@@ -21,7 +21,7 @@ public class ChangeMigrationCompartmentRequest
         extends com.oracle.bmc.requests.BmcRequest<ChangeMigrationCompartmentDetails> {
 
     /**
-     * The OCID of the job
+     * The OCID of the migration
      *
      */
     private String migrationId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/CloneMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/CloneMigrationRequest.java
@@ -21,7 +21,7 @@ public class CloneMigrationRequest
         extends com.oracle.bmc.requests.BmcRequest<CloneMigrationDetails> {
 
     /**
-     * The OCID of the job
+     * The OCID of the migration
      *
      */
     private String migrationId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteConnectionRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteConnectionRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.databasemigration.model.*;
 public class DeleteConnectionRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the job
+     * The OCID of the database connection
      *
      */
     private String connectionId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteMigrationRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.databasemigration.model.*;
 public class DeleteMigrationRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the job
+     * The OCID of the migration
      *
      */
     private String migrationId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/EvaluateMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/EvaluateMigrationRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.databasemigration.model.*;
 public class EvaluateMigrationRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the job
+     * The OCID of the migration
      *
      */
     private String migrationId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetConnectionRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetConnectionRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.databasemigration.model.*;
 public class GetConnectionRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the job
+     * The OCID of the database connection
      *
      */
     private String connectionId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetMigrationRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.databasemigration.model.*;
 public class GetMigrationRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the job
+     * The OCID of the migration
      *
      */
     private String migrationId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/RetrieveSupportedPhasesRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/RetrieveSupportedPhasesRequest.java
@@ -21,7 +21,7 @@ public class RetrieveSupportedPhasesRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the job
+     * The OCID of the migration
      *
      */
     private String migrationId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/StartMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/StartMigrationRequest.java
@@ -21,7 +21,7 @@ public class StartMigrationRequest
         extends com.oracle.bmc.requests.BmcRequest<StartMigrationDetails> {
 
     /**
-     * The OCID of the job
+     * The OCID of the migration
      *
      */
     private String migrationId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateConnectionRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateConnectionRequest.java
@@ -21,7 +21,7 @@ public class UpdateConnectionRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateConnectionDetails> {
 
     /**
-     * The OCID of the job
+     * The OCID of the database connection
      *
      */
     private String connectionId;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateMigrationRequest.java
@@ -21,7 +21,7 @@ public class UpdateMigrationRequest
         extends com.oracle.bmc.requests.BmcRequest<UpdateMigrationDetails> {
 
     /**
-     * The OCID of the job
+     * The OCID of the migration
      *
      */
     private String migrationId;

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,11 +18,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,11 +18,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.36.1</version>
+        <version>1.36.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -16,11 +16,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,11 +18,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -16,11 +16,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,11 +18,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,16 +18,17 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,11 +18,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/Bucket.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/Bucket.java
@@ -212,6 +212,15 @@ public class Bucket {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autoTiering")
+        private AutoTiering autoTiering;
+
+        public Builder autoTiering(AutoTiering autoTiering) {
+            this.autoTiering = autoTiering;
+            this.__explicitlySet__.add("autoTiering");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -237,7 +246,8 @@ public class Bucket {
                             replicationEnabled,
                             isReadOnly,
                             id,
-                            versioning);
+                            versioning,
+                            autoTiering);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -264,7 +274,8 @@ public class Bucket {
                             .replicationEnabled(o.getReplicationEnabled())
                             .isReadOnly(o.getIsReadOnly())
                             .id(o.getId())
-                            .versioning(o.getVersioning());
+                            .versioning(o.getVersioning())
+                            .autoTiering(o.getAutoTiering());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -578,6 +589,63 @@ public class Bucket {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("versioning")
     Versioning versioning;
+    /**
+     * The auto tiering status on the bucket. A bucket is created with auto tiering `Disabled` by default.
+     * For auto tiering `InfrequentAccess`, objects are transitioned automatically between the 'Standard'
+     * and 'InfrequentAccess' tiers based on the access pattern of the objects.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum AutoTiering {
+        Disabled("Disabled"),
+        InfrequentAccess("InfrequentAccess"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, AutoTiering> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AutoTiering v : AutoTiering.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        AutoTiering(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AutoTiering create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'AutoTiering', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The auto tiering status on the bucket. A bucket is created with auto tiering `Disabled` by default.
+     * For auto tiering `InfrequentAccess`, objects are transitioned automatically between the 'Standard'
+     * and 'InfrequentAccess' tiers based on the access pattern of the objects.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autoTiering")
+    AutoTiering autoTiering;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/CreateBucketDetails.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/CreateBucketDetails.java
@@ -120,6 +120,15 @@ public class CreateBucketDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autoTiering")
+        private Bucket.AutoTiering autoTiering;
+
+        public Builder autoTiering(Bucket.AutoTiering autoTiering) {
+            this.autoTiering = autoTiering;
+            this.__explicitlySet__.add("autoTiering");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -135,7 +144,8 @@ public class CreateBucketDetails {
                             freeformTags,
                             definedTags,
                             kmsKeyId,
-                            versioning);
+                            versioning,
+                            autoTiering);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -152,7 +162,8 @@ public class CreateBucketDetails {
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .kmsKeyId(o.getKmsKeyId())
-                            .versioning(o.getVersioning());
+                            .versioning(o.getVersioning())
+                            .autoTiering(o.getAutoTiering());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -362,6 +373,16 @@ public class CreateBucketDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("versioning")
     Versioning versioning;
+
+    /**
+     * Set the auto tiering status on the bucket. By default, a bucket is created with auto tiering `Disabled`.
+     * Use this option to enable auto tiering during bucket creation. Objects in a bucket with auto tiering set to
+     * `InfrequentAccess` are transitioned automatically between the 'Standard' and 'InfrequentAccess'
+     * tiers based on the access pattern of the objects.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autoTiering")
+    Bucket.AutoTiering autoTiering;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/UpdateBucketDetails.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/model/UpdateBucketDetails.java
@@ -120,6 +120,15 @@ public class UpdateBucketDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autoTiering")
+        private Bucket.AutoTiering autoTiering;
+
+        public Builder autoTiering(Bucket.AutoTiering autoTiering) {
+            this.autoTiering = autoTiering;
+            this.__explicitlySet__.add("autoTiering");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -135,7 +144,8 @@ public class UpdateBucketDetails {
                             freeformTags,
                             definedTags,
                             kmsKeyId,
-                            versioning);
+                            versioning,
+                            autoTiering);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -152,7 +162,8 @@ public class UpdateBucketDetails {
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .kmsKeyId(o.getKmsKeyId())
-                            .versioning(o.getVersioning());
+                            .versioning(o.getVersioning())
+                            .autoTiering(o.getAutoTiering());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -324,6 +335,15 @@ public class UpdateBucketDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("versioning")
     Versioning versioning;
+
+    /**
+     * The auto tiering status on the bucket. If in state `InfrequentAccess`, objects are transitioned
+     * automatically between the 'Standard' and 'InfrequentAccess' tiers based on the access pattern of the objects.
+     * When auto tiering is `Disabled`, there will be no automatic transitions between storage tiers.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autoTiering")
+    Bucket.AutoTiering autoTiering;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/GetBucketRequest.java
+++ b/bmc-objectstorage/bmc-objectstorage-generated/src/main/java/com/oracle/bmc/objectstorage/requests/GetBucketRequest.java
@@ -53,21 +53,24 @@ public class GetBucketRequest extends com.oracle.bmc.requests.BmcRequest<java.la
 
     /**
      * Bucket summary includes the 'namespace', 'name', 'compartmentId', 'createdBy', 'timeCreated',
-     * and 'etag' fields. This parameter can also include 'approximateCount' (approximate number of objects) and 'approximateSize'
-     * (total approximate size in bytes of all objects). For example 'approximateCount,approximateSize'.
+     * and 'etag' fields. This parameter can also include 'approximateCount' (approximate number of objects), 'approximateSize'
+     * (total approximate size in bytes of all objects) and 'autoTiering' (state of auto tiering on the bucket).
+     * For example 'approximateCount,approximateSize,autoTiering'.
      *
      */
     private java.util.List<Fields> fields;
 
     /**
      * Bucket summary includes the 'namespace', 'name', 'compartmentId', 'createdBy', 'timeCreated',
-     * and 'etag' fields. This parameter can also include 'approximateCount' (approximate number of objects) and 'approximateSize'
-     * (total approximate size in bytes of all objects). For example 'approximateCount,approximateSize'.
+     * and 'etag' fields. This parameter can also include 'approximateCount' (approximate number of objects), 'approximateSize'
+     * (total approximate size in bytes of all objects) and 'autoTiering' (state of auto tiering on the bucket).
+     * For example 'approximateCount,approximateSize,autoTiering'.
      *
      **/
     public enum Fields {
         ApproximateCount("approximateCount"),
         ApproximateSize("approximateSize"),
+        AutoTiering("autoTiering"),
         ;
 
         private final String value;

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -16,11 +16,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -16,11 +16,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.1</version>
+    <version>1.36.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.1</version>
+      <version>1.36.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.36.1</version>
+  <version>1.36.2</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- VCN id parameters were moved from being required to being optional on all list operations in the Networking service

- Support for RACs (real application clusters) for external container, non-container, and pluggable databases in the Database service

- Support for data masking in the Cloud Guard service

- Support for opting out of DNS records during instance launch, as well as attaching secondary VNICs, in the Compute service

- Support for mutable sizes on cluster networks in the Autoscaling service

- Support for auto-tiering on buckets in the Object Storage service