### PR TITLE
Releasing version 1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.37.0 - 2021-05-25
+### Added
+- Support for the Generic Artifacts service
+- Support for the Bastion service
+- Support for reading secrets by name in the Vault service
+- Support for the isDynamic field when listing definitions in the Limits service
+- Support for getting billable image sizes in the Compute service
+- Support for getting Automatic Workload Repository (AWR) data on external databases in the Database Management service
+- Support for the VM.Standard.E3.Flex flexible compute shape with customizable OCPUs and memory on notebooks in the Data Science service
+- Support for container images and generic artifacts billing in the Registry service
+- Support for the HCX Enterprise add-on in the VMware Solution service
+
+### Breaking Changes
+- Return type of method `public com.oracle.bmc.ocvp.model.SupportedSkuSummary$Name getName()` has been changed to `com.oracle.bmc.ocvp.model.Sku` in the model `SupportedSkuSummary` in the Ocvp service
+- Class `com.oracle.bmc.ocvp.model.SupportedSkuSummary$Name` has been removed from the model `SupportedSkuSummary` in the Ocvp service
+
 ## 1.36.5 - 2021-05-18
 ### Added
 - Support for spark-submit compatible options in the Data Flow service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
 
     <!-- Explicitly pull in this version of httpclient and its httpcore dependency to address:

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -20,11 +20,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/Artifacts.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/Artifacts.java
@@ -62,6 +62,20 @@ public interface Artifacts extends AutoCloseable {
             ChangeContainerRepositoryCompartmentRequest request);
 
     /**
+     * Moves a repository into a different compartment within the same tenancy. For information about moving
+     * resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ChangeRepositoryCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeRepositoryCompartment API.
+     */
+    ChangeRepositoryCompartmentResponse changeRepositoryCompartment(
+            ChangeRepositoryCompartmentRequest request);
+
+    /**
      * Upload a signature to an image.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -82,6 +96,16 @@ public interface Artifacts extends AutoCloseable {
      */
     CreateContainerRepositoryResponse createContainerRepository(
             CreateContainerRepositoryRequest request);
+
+    /**
+     * Creates a new repository for storing artifacts.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/CreateRepositoryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateRepository API.
+     */
+    CreateRepositoryResponse createRepository(CreateRepositoryRequest request);
 
     /**
      * Delete a container image.
@@ -114,6 +138,37 @@ public interface Artifacts extends AutoCloseable {
      */
     DeleteContainerRepositoryResponse deleteContainerRepository(
             DeleteContainerRepositoryRequest request);
+
+    /**
+     * Deletes an artifact with a specified [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteGenericArtifactExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteGenericArtifact API.
+     */
+    DeleteGenericArtifactResponse deleteGenericArtifact(DeleteGenericArtifactRequest request);
+
+    /**
+     * Deletes an artifact with a specified `artifactPath` and `version`.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteGenericArtifactByPathExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteGenericArtifactByPath API.
+     */
+    DeleteGenericArtifactByPathResponse deleteGenericArtifactByPath(
+            DeleteGenericArtifactByPathRequest request);
+
+    /**
+     * Deletes the specified repository. This operation fails unless all associated artifacts are in a DELETED state. You must delete all associated artifacts before deleting a repository.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteRepositoryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteRepository API.
+     */
+    DeleteRepositoryResponse deleteRepository(DeleteRepositoryRequest request);
 
     /**
      * Get container configuration.
@@ -158,6 +213,37 @@ public interface Artifacts extends AutoCloseable {
     GetContainerRepositoryResponse getContainerRepository(GetContainerRepositoryRequest request);
 
     /**
+     * Gets information about an artifact with a specified [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetGenericArtifactExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetGenericArtifact API.
+     */
+    GetGenericArtifactResponse getGenericArtifact(GetGenericArtifactRequest request);
+
+    /**
+     * Gets information about an artifact with a specified `artifactPath` and `version`.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetGenericArtifactByPathExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetGenericArtifactByPath API.
+     */
+    GetGenericArtifactByPathResponse getGenericArtifactByPath(
+            GetGenericArtifactByPathRequest request);
+
+    /**
+     * Gets the specified repository's information.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetRepositoryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetRepository API.
+     */
+    GetRepositoryResponse getRepository(GetRepositoryRequest request);
+
+    /**
      * List container image signatures in an image.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -188,6 +274,26 @@ public interface Artifacts extends AutoCloseable {
      */
     ListContainerRepositoriesResponse listContainerRepositories(
             ListContainerRepositoriesRequest request);
+
+    /**
+     * Lists artifacts in the specified repository.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ListGenericArtifactsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListGenericArtifacts API.
+     */
+    ListGenericArtifactsResponse listGenericArtifacts(ListGenericArtifactsRequest request);
+
+    /**
+     * Lists repositories in the specified compartment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ListRepositoriesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListRepositories API.
+     */
+    ListRepositoriesResponse listRepositories(ListRepositoriesRequest request);
 
     /**
      * Remove version from container image.
@@ -230,6 +336,37 @@ public interface Artifacts extends AutoCloseable {
      */
     UpdateContainerRepositoryResponse updateContainerRepository(
             UpdateContainerRepositoryRequest request);
+
+    /**
+     * Updates the artifact with the specified [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm). You can only update the tags of an artifact.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateGenericArtifactExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateGenericArtifact API.
+     */
+    UpdateGenericArtifactResponse updateGenericArtifact(UpdateGenericArtifactRequest request);
+
+    /**
+     * Updates an artifact with a specified `artifactPath` and `version`. You can only update the tags of an artifact.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateGenericArtifactByPathExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateGenericArtifactByPath API.
+     */
+    UpdateGenericArtifactByPathResponse updateGenericArtifactByPath(
+            UpdateGenericArtifactByPathRequest request);
+
+    /**
+     * Updates the properties of a repository. You can update the `displayName` and  `description` properties.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateRepositoryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateRepository API.
+     */
+    UpdateRepositoryResponse updateRepository(UpdateRepositoryRequest request);
 
     /**
      * Gets the pre-configured waiters available for resources for this service.

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsAsync.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsAsync.java
@@ -69,6 +69,25 @@ public interface ArtifactsAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Moves a repository into a different compartment within the same tenancy. For information about moving
+     * resources between compartments, see
+     * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeRepositoryCompartmentResponse> changeRepositoryCompartment(
+            ChangeRepositoryCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeRepositoryCompartmentRequest, ChangeRepositoryCompartmentResponse>
+                    handler);
+
+    /**
      * Upload a signature to an image.
      *
      * @param request The request object containing the details to send
@@ -100,6 +119,21 @@ public interface ArtifactsAsync extends AutoCloseable {
             CreateContainerRepositoryRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             CreateContainerRepositoryRequest, CreateContainerRepositoryResponse>
+                    handler);
+
+    /**
+     * Creates a new repository for storing artifacts.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateRepositoryResponse> createRepository(
+            CreateRepositoryRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateRepositoryRequest, CreateRepositoryResponse>
                     handler);
 
     /**
@@ -150,6 +184,53 @@ public interface ArtifactsAsync extends AutoCloseable {
             DeleteContainerRepositoryRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             DeleteContainerRepositoryRequest, DeleteContainerRepositoryResponse>
+                    handler);
+
+    /**
+     * Deletes an artifact with a specified [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteGenericArtifactResponse> deleteGenericArtifact(
+            DeleteGenericArtifactRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteGenericArtifactRequest, DeleteGenericArtifactResponse>
+                    handler);
+
+    /**
+     * Deletes an artifact with a specified `artifactPath` and `version`.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteGenericArtifactByPathResponse> deleteGenericArtifactByPath(
+            DeleteGenericArtifactByPathRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            DeleteGenericArtifactByPathRequest, DeleteGenericArtifactByPathResponse>
+                    handler);
+
+    /**
+     * Deletes the specified repository. This operation fails unless all associated artifacts are in a DELETED state. You must delete all associated artifacts before deleting a repository.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteRepositoryResponse> deleteRepository(
+            DeleteRepositoryRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteRepositoryRequest, DeleteRepositoryResponse>
                     handler);
 
     /**
@@ -217,6 +298,53 @@ public interface ArtifactsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets information about an artifact with a specified [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetGenericArtifactResponse> getGenericArtifact(
+            GetGenericArtifactRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetGenericArtifactRequest, GetGenericArtifactResponse>
+                    handler);
+
+    /**
+     * Gets information about an artifact with a specified `artifactPath` and `version`.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetGenericArtifactByPathResponse> getGenericArtifactByPath(
+            GetGenericArtifactByPathRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetGenericArtifactByPathRequest, GetGenericArtifactByPathResponse>
+                    handler);
+
+    /**
+     * Gets the specified repository's information.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetRepositoryResponse> getRepository(
+            GetRepositoryRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetRepositoryRequest, GetRepositoryResponse>
+                    handler);
+
+    /**
      * List container image signatures in an image.
      *
      * @param request The request object containing the details to send
@@ -263,6 +391,37 @@ public interface ArtifactsAsync extends AutoCloseable {
             ListContainerRepositoriesRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ListContainerRepositoriesRequest, ListContainerRepositoriesResponse>
+                    handler);
+
+    /**
+     * Lists artifacts in the specified repository.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListGenericArtifactsResponse> listGenericArtifacts(
+            ListGenericArtifactsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListGenericArtifactsRequest, ListGenericArtifactsResponse>
+                    handler);
+
+    /**
+     * Lists repositories in the specified compartment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListRepositoriesResponse> listRepositories(
+            ListRepositoriesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListRepositoriesRequest, ListRepositoriesResponse>
                     handler);
 
     /**
@@ -328,5 +487,52 @@ public interface ArtifactsAsync extends AutoCloseable {
             UpdateContainerRepositoryRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             UpdateContainerRepositoryRequest, UpdateContainerRepositoryResponse>
+                    handler);
+
+    /**
+     * Updates the artifact with the specified [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm). You can only update the tags of an artifact.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateGenericArtifactResponse> updateGenericArtifact(
+            UpdateGenericArtifactRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateGenericArtifactRequest, UpdateGenericArtifactResponse>
+                    handler);
+
+    /**
+     * Updates an artifact with a specified `artifactPath` and `version`. You can only update the tags of an artifact.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateGenericArtifactByPathResponse> updateGenericArtifactByPath(
+            UpdateGenericArtifactByPathRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdateGenericArtifactByPathRequest, UpdateGenericArtifactByPathResponse>
+                    handler);
+
+    /**
+     * Updates the properties of a repository. You can update the `displayName` and  `description` properties.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateRepositoryResponse> updateRepository(
+            UpdateRepositoryRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateRepositoryRequest, UpdateRepositoryResponse>
                     handler);
 }

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsAsyncClient.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsAsyncClient.java
@@ -411,6 +411,51 @@ public class ArtifactsAsyncClient implements ArtifactsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeRepositoryCompartmentResponse>
+            changeRepositoryCompartment(
+                    ChangeRepositoryCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeRepositoryCompartmentRequest,
+                                    ChangeRepositoryCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeRepositoryCompartment");
+        final ChangeRepositoryCompartmentRequest interceptedRequest =
+                ChangeRepositoryCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeRepositoryCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeRepositoryCompartmentResponse>
+                transformer = ChangeRepositoryCompartmentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeRepositoryCompartmentRequest, ChangeRepositoryCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeRepositoryCompartmentRequest,
+                                ChangeRepositoryCompartmentResponse>,
+                        java.util.concurrent.Future<ChangeRepositoryCompartmentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeRepositoryCompartmentRequest, ChangeRepositoryCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateContainerImageSignatureResponse>
             createContainerImageSignature(
                     CreateContainerImageSignatureRequest request,
@@ -486,6 +531,46 @@ public class ArtifactsAsyncClient implements ArtifactsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     CreateContainerRepositoryRequest, CreateContainerRepositoryResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateRepositoryResponse> createRepository(
+            CreateRepositoryRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateRepositoryRequest, CreateRepositoryResponse>
+                    handler) {
+        LOG.trace("Called async createRepository");
+        final CreateRepositoryRequest interceptedRequest =
+                CreateRepositoryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateRepositoryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateRepositoryResponse>
+                transformer = CreateRepositoryConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CreateRepositoryRequest, CreateRepositoryResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateRepositoryRequest, CreateRepositoryResponse>,
+                        java.util.concurrent.Future<CreateRepositoryResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateRepositoryRequest, CreateRepositoryResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -613,6 +698,130 @@ public class ArtifactsAsyncClient implements ArtifactsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     DeleteContainerRepositoryRequest, DeleteContainerRepositoryResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteGenericArtifactResponse> deleteGenericArtifact(
+            DeleteGenericArtifactRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteGenericArtifactRequest, DeleteGenericArtifactResponse>
+                    handler) {
+        LOG.trace("Called async deleteGenericArtifact");
+        final DeleteGenericArtifactRequest interceptedRequest =
+                DeleteGenericArtifactConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteGenericArtifactConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteGenericArtifactResponse>
+                transformer = DeleteGenericArtifactConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteGenericArtifactRequest, DeleteGenericArtifactResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteGenericArtifactRequest, DeleteGenericArtifactResponse>,
+                        java.util.concurrent.Future<DeleteGenericArtifactResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteGenericArtifactRequest, DeleteGenericArtifactResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteGenericArtifactByPathResponse>
+            deleteGenericArtifactByPath(
+                    DeleteGenericArtifactByPathRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    DeleteGenericArtifactByPathRequest,
+                                    DeleteGenericArtifactByPathResponse>
+                            handler) {
+        LOG.trace("Called async deleteGenericArtifactByPath");
+        final DeleteGenericArtifactByPathRequest interceptedRequest =
+                DeleteGenericArtifactByPathConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteGenericArtifactByPathConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteGenericArtifactByPathResponse>
+                transformer = DeleteGenericArtifactByPathConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        DeleteGenericArtifactByPathRequest, DeleteGenericArtifactByPathResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteGenericArtifactByPathRequest,
+                                DeleteGenericArtifactByPathResponse>,
+                        java.util.concurrent.Future<DeleteGenericArtifactByPathResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteGenericArtifactByPathRequest, DeleteGenericArtifactByPathResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteRepositoryResponse> deleteRepository(
+            DeleteRepositoryRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteRepositoryRequest, DeleteRepositoryResponse>
+                    handler) {
+        LOG.trace("Called async deleteRepository");
+        final DeleteRepositoryRequest interceptedRequest =
+                DeleteRepositoryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteRepositoryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteRepositoryResponse>
+                transformer = DeleteRepositoryConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteRepositoryRequest, DeleteRepositoryResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteRepositoryRequest, DeleteRepositoryResponse>,
+                        java.util.concurrent.Future<DeleteRepositoryResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteRepositoryRequest, DeleteRepositoryResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -792,6 +1001,124 @@ public class ArtifactsAsyncClient implements ArtifactsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetGenericArtifactResponse> getGenericArtifact(
+            GetGenericArtifactRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetGenericArtifactRequest, GetGenericArtifactResponse>
+                    handler) {
+        LOG.trace("Called async getGenericArtifact");
+        final GetGenericArtifactRequest interceptedRequest =
+                GetGenericArtifactConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetGenericArtifactConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetGenericArtifactResponse>
+                transformer = GetGenericArtifactConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetGenericArtifactRequest, GetGenericArtifactResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetGenericArtifactRequest, GetGenericArtifactResponse>,
+                        java.util.concurrent.Future<GetGenericArtifactResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetGenericArtifactRequest, GetGenericArtifactResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetGenericArtifactByPathResponse> getGenericArtifactByPath(
+            GetGenericArtifactByPathRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetGenericArtifactByPathRequest, GetGenericArtifactByPathResponse>
+                    handler) {
+        LOG.trace("Called async getGenericArtifactByPath");
+        final GetGenericArtifactByPathRequest interceptedRequest =
+                GetGenericArtifactByPathConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetGenericArtifactByPathConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetGenericArtifactByPathResponse>
+                transformer = GetGenericArtifactByPathConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetGenericArtifactByPathRequest, GetGenericArtifactByPathResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetGenericArtifactByPathRequest, GetGenericArtifactByPathResponse>,
+                        java.util.concurrent.Future<GetGenericArtifactByPathResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetGenericArtifactByPathRequest, GetGenericArtifactByPathResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetRepositoryResponse> getRepository(
+            GetRepositoryRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetRepositoryRequest, GetRepositoryResponse>
+                    handler) {
+        LOG.trace("Called async getRepository");
+        final GetRepositoryRequest interceptedRequest =
+                GetRepositoryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetRepositoryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetRepositoryResponse>
+                transformer = GetRepositoryConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetRepositoryRequest, GetRepositoryResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetRepositoryRequest, GetRepositoryResponse>,
+                        java.util.concurrent.Future<GetRepositoryResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetRepositoryRequest, GetRepositoryResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListContainerImageSignaturesResponse>
             listContainerImageSignatures(
                     ListContainerImageSignaturesRequest request,
@@ -906,6 +1233,86 @@ public class ArtifactsAsyncClient implements ArtifactsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListContainerRepositoriesRequest, ListContainerRepositoriesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListGenericArtifactsResponse> listGenericArtifacts(
+            ListGenericArtifactsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListGenericArtifactsRequest, ListGenericArtifactsResponse>
+                    handler) {
+        LOG.trace("Called async listGenericArtifacts");
+        final ListGenericArtifactsRequest interceptedRequest =
+                ListGenericArtifactsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListGenericArtifactsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListGenericArtifactsResponse>
+                transformer = ListGenericArtifactsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListGenericArtifactsRequest, ListGenericArtifactsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListGenericArtifactsRequest, ListGenericArtifactsResponse>,
+                        java.util.concurrent.Future<ListGenericArtifactsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListGenericArtifactsRequest, ListGenericArtifactsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListRepositoriesResponse> listRepositories(
+            ListRepositoriesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListRepositoriesRequest, ListRepositoriesResponse>
+                    handler) {
+        LOG.trace("Called async listRepositories");
+        final ListRepositoriesRequest interceptedRequest =
+                ListRepositoriesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListRepositoriesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListRepositoriesResponse>
+                transformer = ListRepositoriesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListRepositoriesRequest, ListRepositoriesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListRepositoriesRequest, ListRepositoriesResponse>,
+                        java.util.concurrent.Future<ListRepositoriesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListRepositoriesRequest, ListRepositoriesResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1076,6 +1483,130 @@ public class ArtifactsAsyncClient implements ArtifactsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     UpdateContainerRepositoryRequest, UpdateContainerRepositoryResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateGenericArtifactResponse> updateGenericArtifact(
+            UpdateGenericArtifactRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateGenericArtifactRequest, UpdateGenericArtifactResponse>
+                    handler) {
+        LOG.trace("Called async updateGenericArtifact");
+        final UpdateGenericArtifactRequest interceptedRequest =
+                UpdateGenericArtifactConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateGenericArtifactConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateGenericArtifactResponse>
+                transformer = UpdateGenericArtifactConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateGenericArtifactRequest, UpdateGenericArtifactResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateGenericArtifactRequest, UpdateGenericArtifactResponse>,
+                        java.util.concurrent.Future<UpdateGenericArtifactResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateGenericArtifactRequest, UpdateGenericArtifactResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateGenericArtifactByPathResponse>
+            updateGenericArtifactByPath(
+                    UpdateGenericArtifactByPathRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateGenericArtifactByPathRequest,
+                                    UpdateGenericArtifactByPathResponse>
+                            handler) {
+        LOG.trace("Called async updateGenericArtifactByPath");
+        final UpdateGenericArtifactByPathRequest interceptedRequest =
+                UpdateGenericArtifactByPathConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateGenericArtifactByPathConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateGenericArtifactByPathResponse>
+                transformer = UpdateGenericArtifactByPathConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateGenericArtifactByPathRequest, UpdateGenericArtifactByPathResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateGenericArtifactByPathRequest,
+                                UpdateGenericArtifactByPathResponse>,
+                        java.util.concurrent.Future<UpdateGenericArtifactByPathResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateGenericArtifactByPathRequest, UpdateGenericArtifactByPathResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateRepositoryResponse> updateRepository(
+            UpdateRepositoryRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateRepositoryRequest, UpdateRepositoryResponse>
+                    handler) {
+        LOG.trace("Called async updateRepository");
+        final UpdateRepositoryRequest interceptedRequest =
+                UpdateRepositoryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateRepositoryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateRepositoryResponse>
+                transformer = UpdateRepositoryConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateRepositoryRequest, UpdateRepositoryResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateRepositoryRequest, UpdateRepositoryResponse>,
+                        java.util.concurrent.Future<UpdateRepositoryResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateRepositoryRequest, UpdateRepositoryResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsClient.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsClient.java
@@ -478,6 +478,42 @@ public class ArtifactsClient implements Artifacts {
     }
 
     @Override
+    public ChangeRepositoryCompartmentResponse changeRepositoryCompartment(
+            ChangeRepositoryCompartmentRequest request) {
+        LOG.trace("Called changeRepositoryCompartment");
+        final ChangeRepositoryCompartmentRequest interceptedRequest =
+                ChangeRepositoryCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeRepositoryCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeRepositoryCompartmentResponse>
+                transformer = ChangeRepositoryCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeRepositoryCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateContainerImageSignatureResponse createContainerImageSignature(
             CreateContainerImageSignatureRequest request) {
         LOG.trace("Called createContainerImageSignature");
@@ -543,6 +579,39 @@ public class ArtifactsClient implements Artifacts {
                                                 ib,
                                                 retriedRequest
                                                         .getCreateContainerRepositoryDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateRepositoryResponse createRepository(CreateRepositoryRequest request) {
+        LOG.trace("Called createRepository");
+        final CreateRepositoryRequest interceptedRequest =
+                CreateRepositoryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateRepositoryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateRepositoryResponse>
+                transformer = CreateRepositoryConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateRepositoryDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -620,6 +689,96 @@ public class ArtifactsClient implements Artifacts {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, DeleteContainerRepositoryResponse>
                 transformer = DeleteContainerRepositoryConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteGenericArtifactResponse deleteGenericArtifact(
+            DeleteGenericArtifactRequest request) {
+        LOG.trace("Called deleteGenericArtifact");
+        final DeleteGenericArtifactRequest interceptedRequest =
+                DeleteGenericArtifactConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteGenericArtifactConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteGenericArtifactResponse>
+                transformer = DeleteGenericArtifactConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteGenericArtifactByPathResponse deleteGenericArtifactByPath(
+            DeleteGenericArtifactByPathRequest request) {
+        LOG.trace("Called deleteGenericArtifactByPath");
+        final DeleteGenericArtifactByPathRequest interceptedRequest =
+                DeleteGenericArtifactByPathConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteGenericArtifactByPathConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, DeleteGenericArtifactByPathResponse>
+                transformer = DeleteGenericArtifactByPathConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteRepositoryResponse deleteRepository(DeleteRepositoryRequest request) {
+        LOG.trace("Called deleteRepository");
+        final DeleteRepositoryRequest interceptedRequest =
+                DeleteRepositoryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteRepositoryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteRepositoryResponse>
+                transformer = DeleteRepositoryConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -758,6 +917,91 @@ public class ArtifactsClient implements Artifacts {
     }
 
     @Override
+    public GetGenericArtifactResponse getGenericArtifact(GetGenericArtifactRequest request) {
+        LOG.trace("Called getGenericArtifact");
+        final GetGenericArtifactRequest interceptedRequest =
+                GetGenericArtifactConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetGenericArtifactConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetGenericArtifactResponse>
+                transformer = GetGenericArtifactConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetGenericArtifactByPathResponse getGenericArtifactByPath(
+            GetGenericArtifactByPathRequest request) {
+        LOG.trace("Called getGenericArtifactByPath");
+        final GetGenericArtifactByPathRequest interceptedRequest =
+                GetGenericArtifactByPathConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetGenericArtifactByPathConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetGenericArtifactByPathResponse>
+                transformer = GetGenericArtifactByPathConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetRepositoryResponse getRepository(GetRepositoryRequest request) {
+        LOG.trace("Called getRepository");
+        final GetRepositoryRequest interceptedRequest =
+                GetRepositoryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetRepositoryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetRepositoryResponse>
+                transformer = GetRepositoryConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListContainerImageSignaturesResponse listContainerImageSignatures(
             ListContainerImageSignaturesRequest request) {
         LOG.trace("Called listContainerImageSignatures");
@@ -826,6 +1070,62 @@ public class ArtifactsClient implements Artifacts {
         com.google.common.base.Function<
                         javax.ws.rs.core.Response, ListContainerRepositoriesResponse>
                 transformer = ListContainerRepositoriesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListGenericArtifactsResponse listGenericArtifacts(ListGenericArtifactsRequest request) {
+        LOG.trace("Called listGenericArtifacts");
+        final ListGenericArtifactsRequest interceptedRequest =
+                ListGenericArtifactsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListGenericArtifactsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListGenericArtifactsResponse>
+                transformer = ListGenericArtifactsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListRepositoriesResponse listRepositories(ListRepositoriesRequest request) {
+        LOG.trace("Called listRepositories");
+        final ListRepositoriesRequest interceptedRequest =
+                ListRepositoriesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListRepositoriesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListRepositoriesResponse>
+                transformer = ListRepositoriesConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -977,6 +1277,106 @@ public class ArtifactsClient implements Artifacts {
                                                 ib,
                                                 retriedRequest
                                                         .getUpdateContainerRepositoryDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateGenericArtifactResponse updateGenericArtifact(
+            UpdateGenericArtifactRequest request) {
+        LOG.trace("Called updateGenericArtifact");
+        final UpdateGenericArtifactRequest interceptedRequest =
+                UpdateGenericArtifactConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateGenericArtifactConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateGenericArtifactResponse>
+                transformer = UpdateGenericArtifactConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateGenericArtifactDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateGenericArtifactByPathResponse updateGenericArtifactByPath(
+            UpdateGenericArtifactByPathRequest request) {
+        LOG.trace("Called updateGenericArtifactByPath");
+        final UpdateGenericArtifactByPathRequest interceptedRequest =
+                UpdateGenericArtifactByPathConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateGenericArtifactByPathConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, UpdateGenericArtifactByPathResponse>
+                transformer = UpdateGenericArtifactByPathConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest
+                                                        .getUpdateGenericArtifactByPathDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateRepositoryResponse updateRepository(UpdateRepositoryRequest request) {
+        LOG.trace("Called updateRepository");
+        final UpdateRepositoryRequest interceptedRequest =
+                UpdateRepositoryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateRepositoryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateRepositoryResponse>
+                transformer = UpdateRepositoryConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateRepositoryDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsPaginators.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsPaginators.java
@@ -384,4 +384,230 @@ public class ArtifactsPaginators {
                     }
                 });
     }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listGenericArtifacts operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListGenericArtifactsResponse> listGenericArtifactsResponseIterator(
+            final ListGenericArtifactsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListGenericArtifactsRequest.Builder, ListGenericArtifactsRequest,
+                ListGenericArtifactsResponse>(
+                new com.google.common.base.Supplier<ListGenericArtifactsRequest.Builder>() {
+                    @Override
+                    public ListGenericArtifactsRequest.Builder get() {
+                        return ListGenericArtifactsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListGenericArtifactsResponse, String>() {
+                    @Override
+                    public String apply(ListGenericArtifactsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListGenericArtifactsRequest.Builder>,
+                        ListGenericArtifactsRequest>() {
+                    @Override
+                    public ListGenericArtifactsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListGenericArtifactsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListGenericArtifactsRequest, ListGenericArtifactsResponse>() {
+                    @Override
+                    public ListGenericArtifactsResponse apply(ListGenericArtifactsRequest request) {
+                        return client.listGenericArtifacts(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.artifacts.model.GenericArtifactSummary} objects
+     * contained in responses from the listGenericArtifacts operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.artifacts.model.GenericArtifactSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.artifacts.model.GenericArtifactSummary>
+            listGenericArtifactsRecordIterator(final ListGenericArtifactsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListGenericArtifactsRequest.Builder, ListGenericArtifactsRequest,
+                ListGenericArtifactsResponse,
+                com.oracle.bmc.artifacts.model.GenericArtifactSummary>(
+                new com.google.common.base.Supplier<ListGenericArtifactsRequest.Builder>() {
+                    @Override
+                    public ListGenericArtifactsRequest.Builder get() {
+                        return ListGenericArtifactsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListGenericArtifactsResponse, String>() {
+                    @Override
+                    public String apply(ListGenericArtifactsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListGenericArtifactsRequest.Builder>,
+                        ListGenericArtifactsRequest>() {
+                    @Override
+                    public ListGenericArtifactsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListGenericArtifactsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListGenericArtifactsRequest, ListGenericArtifactsResponse>() {
+                    @Override
+                    public ListGenericArtifactsResponse apply(ListGenericArtifactsRequest request) {
+                        return client.listGenericArtifacts(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListGenericArtifactsResponse,
+                        java.util.List<com.oracle.bmc.artifacts.model.GenericArtifactSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.artifacts.model.GenericArtifactSummary>
+                            apply(ListGenericArtifactsResponse response) {
+                        return response.getGenericArtifactCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listRepositories operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListRepositoriesResponse> listRepositoriesResponseIterator(
+            final ListRepositoriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListRepositoriesRequest.Builder, ListRepositoriesRequest, ListRepositoriesResponse>(
+                new com.google.common.base.Supplier<ListRepositoriesRequest.Builder>() {
+                    @Override
+                    public ListRepositoriesRequest.Builder get() {
+                        return ListRepositoriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListRepositoriesResponse, String>() {
+                    @Override
+                    public String apply(ListRepositoriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListRepositoriesRequest.Builder>,
+                        ListRepositoriesRequest>() {
+                    @Override
+                    public ListRepositoriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListRepositoriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRepositoriesRequest, ListRepositoriesResponse>() {
+                    @Override
+                    public ListRepositoriesResponse apply(ListRepositoriesRequest request) {
+                        return client.listRepositories(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.artifacts.model.RepositorySummary} objects
+     * contained in responses from the listRepositories operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.artifacts.model.RepositorySummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.artifacts.model.RepositorySummary>
+            listRepositoriesRecordIterator(final ListRepositoriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListRepositoriesRequest.Builder, ListRepositoriesRequest, ListRepositoriesResponse,
+                com.oracle.bmc.artifacts.model.RepositorySummary>(
+                new com.google.common.base.Supplier<ListRepositoriesRequest.Builder>() {
+                    @Override
+                    public ListRepositoriesRequest.Builder get() {
+                        return ListRepositoriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListRepositoriesResponse, String>() {
+                    @Override
+                    public String apply(ListRepositoriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListRepositoriesRequest.Builder>,
+                        ListRepositoriesRequest>() {
+                    @Override
+                    public ListRepositoriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListRepositoriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRepositoriesRequest, ListRepositoriesResponse>() {
+                    @Override
+                    public ListRepositoriesResponse apply(ListRepositoriesRequest request) {
+                        return client.listRepositories(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListRepositoriesResponse,
+                        java.util.List<com.oracle.bmc.artifacts.model.RepositorySummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.artifacts.model.RepositorySummary> apply(
+                            ListRepositoriesResponse response) {
+                        return response.getRepositoryCollection().getItems();
+                    }
+                });
+    }
 }

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsWaiters.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/ArtifactsWaiters.java
@@ -232,4 +232,205 @@ public class ArtifactsWaiters {
                                         .Deleted)),
                 request);
     }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetGenericArtifactRequest, GetGenericArtifactResponse>
+            forGenericArtifact(
+                    GetGenericArtifactRequest request,
+                    com.oracle.bmc.artifacts.model.GenericArtifact.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forGenericArtifact(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetGenericArtifactRequest, GetGenericArtifactResponse>
+            forGenericArtifact(
+                    GetGenericArtifactRequest request,
+                    com.oracle.bmc.artifacts.model.GenericArtifact.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forGenericArtifact(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetGenericArtifactRequest, GetGenericArtifactResponse>
+            forGenericArtifact(
+                    GetGenericArtifactRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.artifacts.model.GenericArtifact.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forGenericArtifact(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for GenericArtifact.
+    private com.oracle.bmc.waiter.Waiter<GetGenericArtifactRequest, GetGenericArtifactResponse>
+            forGenericArtifact(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetGenericArtifactRequest request,
+                    final com.oracle.bmc.artifacts.model.GenericArtifact.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.artifacts.model.GenericArtifact.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetGenericArtifactRequest, GetGenericArtifactResponse>() {
+                            @Override
+                            public GetGenericArtifactResponse apply(
+                                    GetGenericArtifactRequest request) {
+                                return client.getGenericArtifact(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetGenericArtifactResponse>() {
+                            @Override
+                            public boolean apply(GetGenericArtifactResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getGenericArtifact().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.artifacts.model.GenericArtifact.LifecycleState
+                                        .Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetRepositoryRequest, GetRepositoryResponse> forRepository(
+            GetRepositoryRequest request,
+            com.oracle.bmc.artifacts.model.Repository.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forRepository(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetRepositoryRequest, GetRepositoryResponse> forRepository(
+            GetRepositoryRequest request,
+            com.oracle.bmc.artifacts.model.Repository.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forRepository(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetRepositoryRequest, GetRepositoryResponse> forRepository(
+            GetRepositoryRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.artifacts.model.Repository.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forRepository(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Repository.
+    private com.oracle.bmc.waiter.Waiter<GetRepositoryRequest, GetRepositoryResponse> forRepository(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetRepositoryRequest request,
+            final com.oracle.bmc.artifacts.model.Repository.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.artifacts.model.Repository.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetRepositoryRequest, GetRepositoryResponse>() {
+                            @Override
+                            public GetRepositoryResponse apply(GetRepositoryRequest request) {
+                                return client.getRepository(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetRepositoryResponse>() {
+                            @Override
+                            public boolean apply(GetRepositoryResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getRepository().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.artifacts.model.Repository.LifecycleState.Deleted)),
+                request);
+    }
 }

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ChangeRepositoryCompartmentConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ChangeRepositoryCompartmentConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ChangeRepositoryCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.ChangeRepositoryCompartmentRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.ChangeRepositoryCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.ChangeRepositoryCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notNull(
+                request.getChangeRepositoryCompartmentDetails(),
+                "changeRepositoryCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.ChangeRepositoryCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.ChangeRepositoryCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .ChangeRepositoryCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .ChangeRepositoryCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.ChangeRepositoryCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses
+                                                .ChangeRepositoryCompartmentResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .ChangeRepositoryCompartmentResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses
+                                                .ChangeRepositoryCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/CreateRepositoryConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/CreateRepositoryConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CreateRepositoryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.CreateRepositoryRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.CreateRepositoryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.CreateRepositoryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateRepositoryDetails(), "createRepositoryDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("repositories");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.CreateRepositoryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.CreateRepositoryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.CreateRepositoryResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.CreateRepositoryResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.CreateRepositoryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        Repository>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        Repository.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Repository> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.CreateRepositoryResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .CreateRepositoryResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.repository(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.CreateRepositoryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteGenericArtifactByPathConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteGenericArtifactByPathConverter.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteGenericArtifactByPathConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.DeleteGenericArtifactByPathRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.DeleteGenericArtifactByPathRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.DeleteGenericArtifactByPathRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notBlank(request.getArtifactPath(), "artifactPath must not be blank");
+        Validate.notBlank(request.getVersion(), "version must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("generic")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()))
+                        .path("artifactPaths")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getArtifactPath()))
+                        .path("versions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVersion()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.DeleteGenericArtifactByPathResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.DeleteGenericArtifactByPathResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .DeleteGenericArtifactByPathResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .DeleteGenericArtifactByPathResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.DeleteGenericArtifactByPathResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses
+                                                .DeleteGenericArtifactByPathResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .DeleteGenericArtifactByPathResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses
+                                                .DeleteGenericArtifactByPathResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteGenericArtifactConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteGenericArtifactConverter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteGenericArtifactConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.DeleteGenericArtifactRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.DeleteGenericArtifactRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.DeleteGenericArtifactRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getArtifactId(), "artifactId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("generic")
+                        .path("artifacts")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getArtifactId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.DeleteGenericArtifactResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.DeleteGenericArtifactResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .DeleteGenericArtifactResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.DeleteGenericArtifactResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.DeleteGenericArtifactResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.DeleteGenericArtifactResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .DeleteGenericArtifactResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.DeleteGenericArtifactResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteRepositoryConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/DeleteRepositoryConverter.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class DeleteRepositoryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.DeleteRepositoryRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.DeleteRepositoryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.DeleteRepositoryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.DeleteRepositoryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.DeleteRepositoryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.DeleteRepositoryResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.DeleteRepositoryResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.DeleteRepositoryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.DeleteRepositoryResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .DeleteRepositoryResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.DeleteRepositoryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetGenericArtifactByPathConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetGenericArtifactByPathConverter.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetGenericArtifactByPathConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.GetGenericArtifactByPathRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.GetGenericArtifactByPathRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.GetGenericArtifactByPathRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notBlank(request.getArtifactPath(), "artifactPath must not be blank");
+        Validate.notBlank(request.getVersion(), "version must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("generic")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()))
+                        .path("artifactPaths")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getArtifactPath()))
+                        .path("versions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVersion()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.GetGenericArtifactByPathResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.GetGenericArtifactByPathResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .GetGenericArtifactByPathResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .GetGenericArtifactByPathResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.GetGenericArtifactByPathResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        GenericArtifact>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        GenericArtifact.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<GenericArtifact> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.GetGenericArtifactByPathResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .GetGenericArtifactByPathResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.genericArtifact(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.GetGenericArtifactByPathResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetGenericArtifactConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetGenericArtifactConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetGenericArtifactConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.GetGenericArtifactRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.GetGenericArtifactRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.GetGenericArtifactRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getArtifactId(), "artifactId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("generic")
+                        .path("artifacts")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getArtifactId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.GetGenericArtifactResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.GetGenericArtifactResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.GetGenericArtifactResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.GetGenericArtifactResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.GetGenericArtifactResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        GenericArtifact>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        GenericArtifact.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<GenericArtifact> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.GetGenericArtifactResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .GetGenericArtifactResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.genericArtifact(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.GetGenericArtifactResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetRepositoryConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/GetRepositoryConverter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetRepositoryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.GetRepositoryRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.GetRepositoryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.GetRepositoryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.GetRepositoryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.GetRepositoryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.GetRepositoryResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.GetRepositoryResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.GetRepositoryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        Repository>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        Repository.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Repository> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.GetRepositoryResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .GetRepositoryResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.repository(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.GetRepositoryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ListGenericArtifactsConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ListGenericArtifactsConverter.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListGenericArtifactsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.ListGenericArtifactsRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.ListGenericArtifactsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.ListGenericArtifactsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+        Validate.notNull(request.getRepositoryId(), "repositoryId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("generic").path("artifacts");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        target =
+                target.queryParam(
+                        "repositoryId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getRepositoryId()));
+
+        if (request.getId() != null) {
+            target =
+                    target.queryParam(
+                            "id",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getArtifactPath() != null) {
+            target =
+                    target.queryParam(
+                            "artifactPath",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getArtifactPath()));
+        }
+
+        if (request.getVersion() != null) {
+            target =
+                    target.queryParam(
+                            "version",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getVersion()));
+        }
+
+        if (request.getSha256() != null) {
+            target =
+                    target.queryParam(
+                            "sha256",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSha256()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.ListGenericArtifactsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.ListGenericArtifactsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.ListGenericArtifactsResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.ListGenericArtifactsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.ListGenericArtifactsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        GenericArtifactCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        GenericArtifactCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<GenericArtifactCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.ListGenericArtifactsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .ListGenericArtifactsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.genericArtifactCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.ListGenericArtifactsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ListRepositoriesConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/ListRepositoriesConverter.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListRepositoriesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.ListRepositoriesRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.ListRepositoriesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.ListRepositoriesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("repositories");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getId() != null) {
+            target =
+                    target.queryParam(
+                            "id",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getId()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getIsImmutable() != null) {
+            target =
+                    target.queryParam(
+                            "isImmutable",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsImmutable()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.ListRepositoriesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.ListRepositoriesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.ListRepositoriesResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.ListRepositoriesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.ListRepositoriesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        RepositoryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        RepositoryCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<RepositoryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.ListRepositoriesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .ListRepositoriesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.repositoryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.ListRepositoriesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateGenericArtifactByPathConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateGenericArtifactByPathConverter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateGenericArtifactByPathConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.UpdateGenericArtifactByPathRequest
+            interceptRequest(
+                    com.oracle.bmc.artifacts.requests.UpdateGenericArtifactByPathRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.UpdateGenericArtifactByPathRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notBlank(request.getArtifactPath(), "artifactPath must not be blank");
+        Validate.notBlank(request.getVersion(), "version must not be blank");
+        Validate.notNull(
+                request.getUpdateGenericArtifactByPathDetails(),
+                "updateGenericArtifactByPathDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("generic")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()))
+                        .path("artifactPaths")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getArtifactPath()))
+                        .path("versions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVersion()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.UpdateGenericArtifactByPathResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.UpdateGenericArtifactByPathResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .UpdateGenericArtifactByPathResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses
+                                            .UpdateGenericArtifactByPathResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.UpdateGenericArtifactByPathResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        GenericArtifact>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        GenericArtifact.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<GenericArtifact> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses
+                                                .UpdateGenericArtifactByPathResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .UpdateGenericArtifactByPathResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.genericArtifact(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses
+                                                .UpdateGenericArtifactByPathResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateGenericArtifactConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateGenericArtifactConverter.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateGenericArtifactConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.UpdateGenericArtifactRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.UpdateGenericArtifactRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.UpdateGenericArtifactRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getArtifactId(), "artifactId must not be blank");
+        Validate.notNull(
+                request.getUpdateGenericArtifactDetails(),
+                "updateGenericArtifactDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("generic")
+                        .path("artifacts")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getArtifactId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.UpdateGenericArtifactResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.UpdateGenericArtifactResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses
+                                        .UpdateGenericArtifactResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.UpdateGenericArtifactResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.UpdateGenericArtifactResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        GenericArtifact>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        GenericArtifact.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<GenericArtifact> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.UpdateGenericArtifactResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .UpdateGenericArtifactResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.genericArtifact(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.UpdateGenericArtifactResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateRepositoryConverter.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/internal/http/UpdateRepositoryConverter.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.artifacts.model.*;
+import com.oracle.bmc.artifacts.requests.*;
+import com.oracle.bmc.artifacts.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateRepositoryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.artifacts.requests.UpdateRepositoryRequest interceptRequest(
+            com.oracle.bmc.artifacts.requests.UpdateRepositoryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.artifacts.requests.UpdateRepositoryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notNull(
+                request.getUpdateRepositoryDetails(), "updateRepositoryDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.artifacts.responses.UpdateRepositoryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.artifacts.responses.UpdateRepositoryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.artifacts.responses.UpdateRepositoryResponse>() {
+                            @Override
+                            public com.oracle.bmc.artifacts.responses.UpdateRepositoryResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.artifacts.responses.UpdateRepositoryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        Repository>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        Repository.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Repository> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.artifacts.responses.UpdateRepositoryResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.artifacts.responses
+                                                        .UpdateRepositoryResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.repository(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.artifacts.responses.UpdateRepositoryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ChangeRepositoryCompartmentDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ChangeRepositoryCompartmentDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Details for changing a repository's compartment.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeRepositoryCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeRepositoryCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeRepositoryCompartmentDetails build() {
+            ChangeRepositoryCompartmentDetails __instance__ =
+                    new ChangeRepositoryCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeRepositoryCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment into which the repository should be moved.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepository.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepository.java
@@ -143,6 +143,15 @@ public class ContainerRepository {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("billableSizeInGBs")
+        private Long billableSizeInGBs;
+
+        public Builder billableSizeInGBs(Long billableSizeInGBs) {
+            this.billableSizeInGBs = billableSizeInGBs;
+            this.__explicitlySet__.add("billableSizeInGBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -161,7 +170,8 @@ public class ContainerRepository {
                             lifecycleState,
                             readme,
                             timeCreated,
-                            timeLastPushed);
+                            timeLastPushed,
+                            billableSizeInGBs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -181,7 +191,8 @@ public class ContainerRepository {
                             .lifecycleState(o.getLifecycleState())
                             .readme(o.getReadme())
                             .timeCreated(o.getTimeCreated())
-                            .timeLastPushed(o.getTimeLastPushed());
+                            .timeLastPushed(o.getTimeLastPushed())
+                            .billableSizeInGBs(o.getBillableSizeInGBs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -318,6 +329,12 @@ public class ContainerRepository {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeLastPushed")
     java.util.Date timeLastPushed;
+
+    /**
+     * Total storage size in GBs that will be charged.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("billableSizeInGBs")
+    Long billableSizeInGBs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepositorySummary.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/ContainerRepositorySummary.java
@@ -107,6 +107,15 @@ public class ContainerRepositorySummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("billableSizeInGBs")
+        private Long billableSizeInGBs;
+
+        public Builder billableSizeInGBs(Long billableSizeInGBs) {
+            this.billableSizeInGBs = billableSizeInGBs;
+            this.__explicitlySet__.add("billableSizeInGBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -121,7 +130,8 @@ public class ContainerRepositorySummary {
                             layerCount,
                             layersSizeInBytes,
                             lifecycleState,
-                            timeCreated);
+                            timeCreated,
+                            billableSizeInGBs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -137,7 +147,8 @@ public class ContainerRepositorySummary {
                             .layerCount(o.getLayerCount())
                             .layersSizeInBytes(o.getLayersSizeInBytes())
                             .lifecycleState(o.getLifecycleState())
-                            .timeCreated(o.getTimeCreated());
+                            .timeCreated(o.getTimeCreated())
+                            .billableSizeInGBs(o.getBillableSizeInGBs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -207,6 +218,12 @@ public class ContainerRepositorySummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    /**
+     * Total storage size in GBs that will be charged.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("billableSizeInGBs")
+    Long billableSizeInGBs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/CreateGenericRepositoryDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/CreateGenericRepositoryDetails.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Parameters needed to create an artifact repository.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateGenericRepositoryDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "repositoryType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateGenericRepositoryDetails extends CreateRepositoryDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+        private Boolean isImmutable;
+
+        public Builder isImmutable(Boolean isImmutable) {
+            this.isImmutable = isImmutable;
+            this.__explicitlySet__.add("isImmutable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateGenericRepositoryDetails build() {
+            CreateGenericRepositoryDetails __instance__ =
+                    new CreateGenericRepositoryDetails(
+                            displayName,
+                            compartmentId,
+                            description,
+                            isImmutable,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateGenericRepositoryDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .description(o.getDescription())
+                            .isImmutable(o.getIsImmutable())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateGenericRepositoryDetails(
+            String displayName,
+            String compartmentId,
+            String description,
+            Boolean isImmutable,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+        super(displayName, compartmentId, description, isImmutable, freeformTags, definedTags);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/CreateRepositoryDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/CreateRepositoryDetails.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Parameters needed to create an artifact repository.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "repositoryType",
+    defaultImpl = CreateRepositoryDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateGenericRepositoryDetails.class,
+        name = "GENERIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateRepositoryDetails {
+
+    /**
+     * A user-friendly display name for the repository. If not present, will be auto-generated. It can be modified later. Avoid entering confidential information.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the repository's compartment.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * A short description of the repository. It can be updated later.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Whether to make the repository immutable. The artifacts of an immutable repository cannot be overwritten.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+    Boolean isImmutable;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericArtifact.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericArtifact.java
@@ -1,0 +1,326 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * The metadata of the artifact.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = GenericArtifact.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class GenericArtifact {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+        private String repositoryId;
+
+        public Builder repositoryId(String repositoryId) {
+            this.repositoryId = repositoryId;
+            this.__explicitlySet__.add("repositoryId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("artifactPath")
+        private String artifactPath;
+
+        public Builder artifactPath(String artifactPath) {
+            this.artifactPath = artifactPath;
+            this.__explicitlySet__.add("artifactPath");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sha256")
+        private String sha256;
+
+        public Builder sha256(String sha256) {
+            this.sha256 = sha256;
+            this.__explicitlySet__.add("sha256");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+        private Long sizeInBytes;
+
+        public Builder sizeInBytes(Long sizeInBytes) {
+            this.sizeInBytes = sizeInBytes;
+            this.__explicitlySet__.add("sizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GenericArtifact build() {
+            GenericArtifact __instance__ =
+                    new GenericArtifact(
+                            id,
+                            displayName,
+                            compartmentId,
+                            repositoryId,
+                            artifactPath,
+                            version,
+                            sha256,
+                            sizeInBytes,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GenericArtifact o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .repositoryId(o.getRepositoryId())
+                            .artifactPath(o.getArtifactPath())
+                            .version(o.getVersion())
+                            .sha256(o.getSha256())
+                            .sizeInBytes(o.getSizeInBytes())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the artifact.
+     * <p>
+     * Example: `ocid1.genericartifact.oc1..exampleuniqueID`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The artifact name with the format of `<artifact-path>:<artifact-version>`. The artifact name is truncated to a maximum length of 255.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc:1.0.0`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository's compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+    String repositoryId;
+
+    /**
+     * A user-defined path to describe the location of an artifact. Slashes do not create a directory structure, but you can use slashes to organize the repository. An artifact path does not include an artifact version.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("artifactPath")
+    String artifactPath;
+
+    /**
+     * A user-defined string to describe the artifact version.
+     * <p>
+     * Example: `1.1.0` or `1.2-beta-2`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    /**
+     * The SHA256 digest for the artifact. When you upload an artifact to the repository, a SHA256 digest is calculated and added to the artifact properties.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sha256")
+    String sha256;
+
+    /**
+     * The size of the artifact in bytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+    Long sizeInBytes;
+    /**
+     * The current state of the artifact.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Available("AVAILABLE"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the artifact.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * An RFC 3339 timestamp indicating when the repository was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericArtifactCollection.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericArtifactCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * A list of artifacts.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = GenericArtifactCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class GenericArtifactCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<GenericArtifactSummary> items;
+
+        public Builder items(java.util.List<GenericArtifactSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GenericArtifactCollection build() {
+            GenericArtifactCollection __instance__ = new GenericArtifactCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GenericArtifactCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The listed artifacts.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<GenericArtifactSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericArtifactSummary.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericArtifactSummary.java
@@ -1,0 +1,282 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Summary information for an artifact.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = GenericArtifactSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class GenericArtifactSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+        private String repositoryId;
+
+        public Builder repositoryId(String repositoryId) {
+            this.repositoryId = repositoryId;
+            this.__explicitlySet__.add("repositoryId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("artifactPath")
+        private String artifactPath;
+
+        public Builder artifactPath(String artifactPath) {
+            this.artifactPath = artifactPath;
+            this.__explicitlySet__.add("artifactPath");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sha256")
+        private String sha256;
+
+        public Builder sha256(String sha256) {
+            this.sha256 = sha256;
+            this.__explicitlySet__.add("sha256");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+        private Long sizeInBytes;
+
+        public Builder sizeInBytes(Long sizeInBytes) {
+            this.sizeInBytes = sizeInBytes;
+            this.__explicitlySet__.add("sizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private GenericArtifact.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(GenericArtifact.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GenericArtifactSummary build() {
+            GenericArtifactSummary __instance__ =
+                    new GenericArtifactSummary(
+                            id,
+                            displayName,
+                            compartmentId,
+                            repositoryId,
+                            artifactPath,
+                            version,
+                            sha256,
+                            sizeInBytes,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GenericArtifactSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .repositoryId(o.getRepositoryId())
+                            .artifactPath(o.getArtifactPath())
+                            .version(o.getVersion())
+                            .sha256(o.getSha256())
+                            .sizeInBytes(o.getSizeInBytes())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the artifact.
+     * <p>
+     * Example: `ocid1.genericartifact.oc1..exampleuniqueID`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The artifact name with the format of `<artifact-path>:<artifact-version>`. The artifact name is truncated to a maximum length of 255.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc:1.0.0`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the artifact's compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+    String repositoryId;
+
+    /**
+     * A user-defined path to describe the location of an artifact. Slashes do not create a directory structure, but you can use slashes to organize the repository. An artifact path does not include an artifact version.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("artifactPath")
+    String artifactPath;
+
+    /**
+     * A user-defined string to describe the artifact version.
+     * <p>
+     * Example: `1.1.0` or `1.2-beta-2`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    /**
+     * The SHA256 digest for the artifact. When you upload an artifact to the repository, a SHA256 digest is calculated and added to the artifact properties.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sha256")
+    String sha256;
+
+    /**
+     * The size of the artifact in bytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+    Long sizeInBytes;
+
+    /**
+     * The current state of the generic artifact.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    GenericArtifact.LifecycleState lifecycleState;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * An RFC 3339 timestamp indicating when the artifact was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericRepository.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericRepository.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * The metadata for the artifact repository.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = GenericRepository.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "repositoryType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class GenericRepository extends Repository {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+        private Boolean isImmutable;
+
+        public Builder isImmutable(Boolean isImmutable) {
+            this.isImmutable = isImmutable;
+            this.__explicitlySet__.add("isImmutable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GenericRepository build() {
+            GenericRepository __instance__ =
+                    new GenericRepository(
+                            id,
+                            displayName,
+                            compartmentId,
+                            description,
+                            isImmutable,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GenericRepository o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .description(o.getDescription())
+                            .isImmutable(o.getIsImmutable())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public GenericRepository(
+            String id,
+            String displayName,
+            String compartmentId,
+            String description,
+            Boolean isImmutable,
+            LifecycleState lifecycleState,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Date timeCreated) {
+        super(
+                id,
+                displayName,
+                compartmentId,
+                description,
+                isImmutable,
+                lifecycleState,
+                freeformTags,
+                definedTags,
+                timeCreated);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericRepositorySummary.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/GenericRepositorySummary.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Summary information for a repository.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = GenericRepositorySummary.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "repositoryType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class GenericRepositorySummary extends RepositorySummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+        private Boolean isImmutable;
+
+        public Builder isImmutable(Boolean isImmutable) {
+            this.isImmutable = isImmutable;
+            this.__explicitlySet__.add("isImmutable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private Repository.LifecycleState lifecycleState;
+
+        public Builder lifecycleState(Repository.LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GenericRepositorySummary build() {
+            GenericRepositorySummary __instance__ =
+                    new GenericRepositorySummary(
+                            id,
+                            displayName,
+                            compartmentId,
+                            description,
+                            isImmutable,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GenericRepositorySummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .description(o.getDescription())
+                            .isImmutable(o.getIsImmutable())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public GenericRepositorySummary(
+            String id,
+            String displayName,
+            String compartmentId,
+            String description,
+            Boolean isImmutable,
+            Repository.LifecycleState lifecycleState,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags,
+            java.util.Date timeCreated) {
+        super(
+                id,
+                displayName,
+                compartmentId,
+                description,
+                isImmutable,
+                lifecycleState,
+                freeformTags,
+                definedTags,
+                timeCreated);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/Repository.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/Repository.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * The metadata for the artifact repository.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "repositoryType",
+    defaultImpl = Repository.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = GenericRepository.class,
+        name = "GENERIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class Repository {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.artifactrepository.oc1..exampleuniqueID`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The repository name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the repository's compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The repository description.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Whether the repository is immutable. The artifacts of an immutable repository cannot be overwritten.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+    Boolean isImmutable;
+    /**
+     * The current state of the repository.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Available("AVAILABLE"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * An RFC 3339 timestamp indicating when the repository was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The repository's supported artifact type.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum RepositoryType {
+        Generic("GENERIC"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, RepositoryType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RepositoryType v : RepositoryType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        RepositoryType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RepositoryType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'RepositoryType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/RepositoryCollection.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/RepositoryCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * A list of repositories.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RepositoryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RepositoryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<RepositorySummary> items;
+
+        public Builder items(java.util.List<RepositorySummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RepositoryCollection build() {
+            RepositoryCollection __instance__ = new RepositoryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RepositoryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The listed repositories.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<RepositorySummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/RepositorySummary.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/RepositorySummary.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Summary information for a repository.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "repositoryType",
+    defaultImpl = RepositorySummary.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = GenericRepositorySummary.class,
+        name = "GENERIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class RepositorySummary {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.artifactrepository.oc1..exampleuniqueID`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The repository name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the repository's compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The repository description.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Whether the repository is immutable. The artifacts of an immutable repository cannot be overwritten.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isImmutable")
+    Boolean isImmutable;
+
+    /**
+     * The current state of the artifact repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    Repository.LifecycleState lifecycleState;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * An RFC 3339 timestamp indicating when the repository was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateGenericArtifactByPathDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateGenericArtifactByPathDetails.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Details for updating an artifact by providing its `artifactPath` and `version`.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateGenericArtifactByPathDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateGenericArtifactByPathDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateGenericArtifactByPathDetails build() {
+            UpdateGenericArtifactByPathDetails __instance__ =
+                    new UpdateGenericArtifactByPathDetails(freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateGenericArtifactByPathDetails o) {
+            Builder copiedBuilder =
+                    freeformTags(o.getFreeformTags()).definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateGenericArtifactDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateGenericArtifactDetails.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Details for updating an artifact by providing its [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm).
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateGenericArtifactDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateGenericArtifactDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateGenericArtifactDetails build() {
+            UpdateGenericArtifactDetails __instance__ =
+                    new UpdateGenericArtifactDetails(freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateGenericArtifactDetails o) {
+            Builder copiedBuilder =
+                    freeformTags(o.getFreeformTags()).definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateGenericRepositoryDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateGenericRepositoryDetails.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Details for updating an artifact repository.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateGenericRepositoryDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "repositoryType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateGenericRepositoryDetails extends UpdateRepositoryDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateGenericRepositoryDetails build() {
+            UpdateGenericRepositoryDetails __instance__ =
+                    new UpdateGenericRepositoryDetails(
+                            displayName, description, freeformTags, definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateGenericRepositoryDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateGenericRepositoryDetails(
+            String displayName,
+            String description,
+            java.util.Map<String, String> freeformTags,
+            java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+        super(displayName, description, freeformTags, definedTags);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateRepositoryDetails.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/model/UpdateRepositoryDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.model;
+
+/**
+ * Details for updating a repository.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "repositoryType",
+    defaultImpl = UpdateRepositoryDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateGenericRepositoryDetails.class,
+        name = "GENERIC"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateRepositoryDetails {
+
+    /**
+     * The repository name.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The repository description.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ChangeRepositoryCompartmentRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ChangeRepositoryCompartmentRequest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ChangeRepositoryCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeRepositoryCompartmentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ChangeRepositoryCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeRepositoryCompartmentDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.artifactrepository.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * Moves a repository into a different compartment.
+     */
+    private ChangeRepositoryCompartmentDetails changeRepositoryCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeRepositoryCompartmentDetails getBody$() {
+        return changeRepositoryCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeRepositoryCompartmentRequest, ChangeRepositoryCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeRepositoryCompartmentRequest o) {
+            repositoryId(o.getRepositoryId());
+            changeRepositoryCompartmentDetails(o.getChangeRepositoryCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeRepositoryCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeRepositoryCompartmentRequest
+         */
+        public ChangeRepositoryCompartmentRequest build() {
+            ChangeRepositoryCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeRepositoryCompartmentDetails body) {
+            changeRepositoryCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/CreateRepositoryRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/CreateRepositoryRequest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/CreateRepositoryExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateRepositoryRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateRepositoryRequest
+        extends com.oracle.bmc.requests.BmcRequest<CreateRepositoryDetails> {
+
+    /**
+     * Creates a new repository for storing artifacts.
+     */
+    private CreateRepositoryDetails createRepositoryDetails;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateRepositoryDetails getBody$() {
+        return createRepositoryDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateRepositoryRequest, CreateRepositoryDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateRepositoryRequest o) {
+            createRepositoryDetails(o.getCreateRepositoryDetails());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateRepositoryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateRepositoryRequest
+         */
+        public CreateRepositoryRequest build() {
+            CreateRepositoryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateRepositoryDetails body) {
+            createRepositoryDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteGenericArtifactByPathRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteGenericArtifactByPathRequest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteGenericArtifactByPathExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteGenericArtifactByPathRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteGenericArtifactByPathRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.artifactrepository.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * A user-defined path to describe the location of an artifact. You can use slashes to organize the repository, but slashes do not create a directory structure. An artifact path does not include an artifact version.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc`
+     *
+     */
+    private String artifactPath;
+
+    /**
+     * A user-defined string to describe the artifact version.
+     * <p>
+     * Example: `1.1.2` or `1.2-beta-2`
+     *
+     */
+    private String version;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteGenericArtifactByPathRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteGenericArtifactByPathRequest o) {
+            repositoryId(o.getRepositoryId());
+            artifactPath(o.getArtifactPath());
+            version(o.getVersion());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteGenericArtifactByPathRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteGenericArtifactByPathRequest
+         */
+        public DeleteGenericArtifactByPathRequest build() {
+            DeleteGenericArtifactByPathRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteGenericArtifactRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteGenericArtifactRequest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteGenericArtifactExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteGenericArtifactRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteGenericArtifactRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the artifact.
+     * <p>
+     * Example: `ocid1.genericartifact.oc1..exampleuniqueID`
+     *
+     */
+    private String artifactId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteGenericArtifactRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteGenericArtifactRequest o) {
+            artifactId(o.getArtifactId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteGenericArtifactRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteGenericArtifactRequest
+         */
+        public DeleteGenericArtifactRequest build() {
+            DeleteGenericArtifactRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteRepositoryRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/DeleteRepositoryRequest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/DeleteRepositoryExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteRepositoryRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteRepositoryRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.artifactrepository.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteRepositoryRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteRepositoryRequest o) {
+            repositoryId(o.getRepositoryId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteRepositoryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteRepositoryRequest
+         */
+        public DeleteRepositoryRequest build() {
+            DeleteRepositoryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetGenericArtifactByPathRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetGenericArtifactByPathRequest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetGenericArtifactByPathExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetGenericArtifactByPathRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetGenericArtifactByPathRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.artifactrepository.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * A user-defined path to describe the location of an artifact. You can use slashes to organize the repository, but slashes do not create a directory structure. An artifact path does not include an artifact version.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc`
+     *
+     */
+    private String artifactPath;
+
+    /**
+     * A user-defined string to describe the artifact version.
+     * <p>
+     * Example: `1.1.2` or `1.2-beta-2`
+     *
+     */
+    private String version;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetGenericArtifactByPathRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetGenericArtifactByPathRequest o) {
+            repositoryId(o.getRepositoryId());
+            artifactPath(o.getArtifactPath());
+            version(o.getVersion());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetGenericArtifactByPathRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetGenericArtifactByPathRequest
+         */
+        public GetGenericArtifactByPathRequest build() {
+            GetGenericArtifactByPathRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetGenericArtifactRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetGenericArtifactRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetGenericArtifactExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetGenericArtifactRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetGenericArtifactRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the artifact.
+     * <p>
+     * Example: `ocid1.genericartifact.oc1..exampleuniqueID`
+     *
+     */
+    private String artifactId;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetGenericArtifactRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetGenericArtifactRequest o) {
+            artifactId(o.getArtifactId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetGenericArtifactRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetGenericArtifactRequest
+         */
+        public GetGenericArtifactRequest build() {
+            GetGenericArtifactRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetRepositoryRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/GetRepositoryRequest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/GetRepositoryExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetRepositoryRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetRepositoryRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.artifactrepository.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetRepositoryRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetRepositoryRequest o) {
+            repositoryId(o.getRepositoryId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetRepositoryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetRepositoryRequest
+         */
+        public GetRepositoryRequest build() {
+            GetRepositoryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ListGenericArtifactsRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ListGenericArtifactsRequest.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ListGenericArtifactsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListGenericArtifactsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListGenericArtifactsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * A filter to return the artifacts only for the specified repository OCID.
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * A filter to return the resources for the specified OCID.
+     *
+     */
+    private String id;
+
+    /**
+     * A filter to return only resources that match the given display name exactly.
+     *
+     */
+    private String displayName;
+
+    /**
+     * Filter results by a prefix for the `artifactPath` and and return artifacts that begin with the specified prefix in their path.
+     *
+     */
+    private String artifactPath;
+
+    /**
+     * Filter results by a prefix for `version` and return artifacts that that begin with the specified prefix in their version.
+     *
+     */
+    private String version;
+
+    /**
+     * Filter results by a specified SHA256 digest for the artifact.
+     *
+     */
+    private String sha256;
+
+    /**
+     * A filter to return only resources that match the given lifecycle state name exactly.
+     *
+     */
+    private String lifecycleState;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated
+     * \"List\" call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `50`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+     * call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListGenericArtifactsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListGenericArtifactsRequest o) {
+            compartmentId(o.getCompartmentId());
+            repositoryId(o.getRepositoryId());
+            id(o.getId());
+            displayName(o.getDisplayName());
+            artifactPath(o.getArtifactPath());
+            version(o.getVersion());
+            sha256(o.getSha256());
+            lifecycleState(o.getLifecycleState());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListGenericArtifactsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListGenericArtifactsRequest
+         */
+        public ListGenericArtifactsRequest build() {
+            ListGenericArtifactsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ListRepositoriesRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/ListRepositoriesRequest.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/ListRepositoriesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListRepositoriesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListRepositoriesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * A filter to return the resources for the specified OCID.
+     *
+     */
+    private String id;
+
+    /**
+     * A filter to return only resources that match the given display name exactly.
+     *
+     */
+    private String displayName;
+
+    /**
+     * A filter to return resources that match the isImmutable value.
+     *
+     */
+    private Boolean isImmutable;
+
+    /**
+     * A filter to return only resources that match the given lifecycle state name exactly.
+     *
+     */
+    private String lifecycleState;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated
+     * \"List\" call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: `50`
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the `opc-next-page` response header from the previous \"List\"
+     * call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order (`sortOrder`). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some \"List\" operations (for example, `ListInstances`) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these \"List\" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending (`ASC`) or descending (`DESC`). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListRepositoriesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListRepositoriesRequest o) {
+            compartmentId(o.getCompartmentId());
+            id(o.getId());
+            displayName(o.getDisplayName());
+            isImmutable(o.getIsImmutable());
+            lifecycleState(o.getLifecycleState());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListRepositoriesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListRepositoriesRequest
+         */
+        public ListRepositoriesRequest build() {
+            ListRepositoriesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateGenericArtifactByPathRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateGenericArtifactByPathRequest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateGenericArtifactByPathExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateGenericArtifactByPathRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateGenericArtifactByPathRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateGenericArtifactByPathDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.artifactrepository.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * A user-defined path to describe the location of an artifact. You can use slashes to organize the repository, but slashes do not create a directory structure. An artifact path does not include an artifact version.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc`
+     *
+     */
+    private String artifactPath;
+
+    /**
+     * A user-defined string to describe the artifact version.
+     * <p>
+     * Example: `1.1.2` or `1.2-beta-2`
+     *
+     */
+    private String version;
+
+    /**
+     * Updates an artifact with a specified `artifactPath` and `version`. You can only update the tags of an artifact.
+     */
+    private UpdateGenericArtifactByPathDetails updateGenericArtifactByPathDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateGenericArtifactByPathDetails getBody$() {
+        return updateGenericArtifactByPathDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateGenericArtifactByPathRequest, UpdateGenericArtifactByPathDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateGenericArtifactByPathRequest o) {
+            repositoryId(o.getRepositoryId());
+            artifactPath(o.getArtifactPath());
+            version(o.getVersion());
+            updateGenericArtifactByPathDetails(o.getUpdateGenericArtifactByPathDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateGenericArtifactByPathRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateGenericArtifactByPathRequest
+         */
+        public UpdateGenericArtifactByPathRequest build() {
+            UpdateGenericArtifactByPathRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateGenericArtifactByPathDetails body) {
+            updateGenericArtifactByPathDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateGenericArtifactRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateGenericArtifactRequest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateGenericArtifactExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateGenericArtifactRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateGenericArtifactRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateGenericArtifactDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the artifact.
+     * <p>
+     * Example: `ocid1.genericartifact.oc1..exampleuniqueID`
+     *
+     */
+    private String artifactId;
+
+    /**
+     * Updates the artifact with the specified [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm). You can only update the tags of an artifact.
+     */
+    private UpdateGenericArtifactDetails updateGenericArtifactDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateGenericArtifactDetails getBody$() {
+        return updateGenericArtifactDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateGenericArtifactRequest, UpdateGenericArtifactDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateGenericArtifactRequest o) {
+            artifactId(o.getArtifactId());
+            updateGenericArtifactDetails(o.getUpdateGenericArtifactDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateGenericArtifactRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateGenericArtifactRequest
+         */
+        public UpdateGenericArtifactRequest build() {
+            UpdateGenericArtifactRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateGenericArtifactDetails body) {
+            updateGenericArtifactDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateRepositoryRequest.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/requests/UpdateRepositoryRequest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.requests;
+
+import com.oracle.bmc.artifacts.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/artifacts/UpdateRepositoryExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateRepositoryRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateRepositoryRequest
+        extends com.oracle.bmc.requests.BmcRequest<UpdateRepositoryDetails> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.artifactrepository.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * Updates the properties of a repository.
+     */
+    private UpdateRepositoryDetails updateRepositoryDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
+     * parameter to the value of the etag from a previous GET or POST response for that resource. The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateRepositoryDetails getBody$() {
+        return updateRepositoryDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateRepositoryRequest, UpdateRepositoryDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateRepositoryRequest o) {
+            repositoryId(o.getRepositoryId());
+            updateRepositoryDetails(o.getUpdateRepositoryDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateRepositoryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateRepositoryRequest
+         */
+        public UpdateRepositoryRequest build() {
+            UpdateRepositoryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateRepositoryDetails body) {
+            updateRepositoryDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ChangeRepositoryCompartmentResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ChangeRepositoryCompartmentResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ChangeRepositoryCompartmentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeRepositoryCompartmentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/CreateRepositoryResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/CreateRepositoryResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class CreateRepositoryResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Repository instance.
+     */
+    private Repository repository;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateRepositoryResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            repository(o.getRepository());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteGenericArtifactByPathResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteGenericArtifactByPathResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class DeleteGenericArtifactByPathResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteGenericArtifactByPathResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteGenericArtifactResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteGenericArtifactResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class DeleteGenericArtifactResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteGenericArtifactResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteRepositoryResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/DeleteRepositoryResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class DeleteRepositoryResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteRepositoryResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetGenericArtifactByPathResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetGenericArtifactByPathResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetGenericArtifactByPathResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned GenericArtifact instance.
+     */
+    private GenericArtifact genericArtifact;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetGenericArtifactByPathResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            genericArtifact(o.getGenericArtifact());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetGenericArtifactResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetGenericArtifactResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetGenericArtifactResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned GenericArtifact instance.
+     */
+    private GenericArtifact genericArtifact;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetGenericArtifactResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            genericArtifact(o.getGenericArtifact());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetRepositoryResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/GetRepositoryResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetRepositoryResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Repository instance.
+     */
+    private Repository repository;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetRepositoryResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            repository(o.getRepository());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ListGenericArtifactsResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ListGenericArtifactsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListGenericArtifactsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned GenericArtifactCollection instance.
+     */
+    private GenericArtifactCollection genericArtifactCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListGenericArtifactsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            genericArtifactCollection(o.getGenericArtifactCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ListRepositoriesResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/ListRepositoriesResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListRepositoriesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned RepositoryCollection instance.
+     */
+    private RepositoryCollection repositoryCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListRepositoriesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            repositoryCollection(o.getRepositoryCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateGenericArtifactByPathResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateGenericArtifactByPathResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class UpdateGenericArtifactByPathResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned GenericArtifact instance.
+     */
+    private GenericArtifact genericArtifact;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateGenericArtifactByPathResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            genericArtifact(o.getGenericArtifact());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateGenericArtifactResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateGenericArtifactResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class UpdateGenericArtifactResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned GenericArtifact instance.
+     */
+    private GenericArtifact genericArtifact;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateGenericArtifactResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            genericArtifact(o.getGenericArtifact());
+
+            return this;
+        }
+    }
+}

--- a/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateRepositoryResponse.java
+++ b/bmc-artifacts/src/main/java/com/oracle/bmc/artifacts/responses/UpdateRepositoryResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.artifacts.responses;
+
+import com.oracle.bmc.artifacts.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class UpdateRepositoryResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Repository instance.
+     */
+    private Repository repository;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateRepositoryResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            repository(o.getRepository());
+
+            return this;
+        }
+    }
+}

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -22,11 +22,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.oracle.oci.sdk</groupId>
+    <artifactId>oci-java-sdk</artifactId>
+    <version>1.37.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>oci-java-sdk-bastion</artifactId>
+  <name>Oracle Cloud Infrastructure SDK - Bastion</name>
+  <description>This project contains the SDK used for Oracle Cloud Infrastructure Bastion</description>
+  <url>https://docs.cloud.oracle.com/Content/API/SDKDocs/javasdk.htm</url>
+  <dependencies>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-common</artifactId>
+      <version>1.37.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/Bastion.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/Bastion.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion;
+
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+
+/**
+ * Oracle Cloud Infrastructure Bastion provides restricted and time-limited access to target resources that don't have public endpoints. Through the configuration of a bastion, you can let authorized users connect from specific IP addresses to target resources by way of Secure Shell (SSH) sessions hosted on the bastion.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+public interface Bastion extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Moves a bastion into a different compartment.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ChangeBastionCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeBastionCompartment API.
+     */
+    ChangeBastionCompartmentResponse changeBastionCompartment(
+            ChangeBastionCompartmentRequest request);
+
+    /**
+     * Creates a new bastion. A bastion provides secured, public access to target resources in the cloud that you cannot otherwise reach from the internet. A bastion resides in a public subnet and establishes the network infrastructure needed to connect a user to a target resource in a private subnet.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/CreateBastionExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateBastion API.
+     */
+    CreateBastionResponse createBastion(CreateBastionRequest request);
+
+    /**
+     * Creates a new session in a bastion. A bastion session lets authorized users connect to a target resource for a predetermined amount of time. The Bastion service recognizes two types of sessions, managed SSH sessions and SSH port forwarding sessions. Managed SSH sessions require that the target resource has an OpenSSH server and the Oracle Cloud Agent both running.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/CreateSessionExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateSession API.
+     */
+    CreateSessionResponse createSession(CreateSessionRequest request);
+
+    /**
+     * Deletes a bastion identified by the bastion ID.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/DeleteBastionExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteBastion API.
+     */
+    DeleteBastionResponse deleteBastion(DeleteBastionRequest request);
+
+    /**
+     * Deletes a session identified by the session ID.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/DeleteSessionExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteSession API.
+     */
+    DeleteSessionResponse deleteSession(DeleteSessionRequest request);
+
+    /**
+     * Retrieves a bastion identified by the bastion ID. A bastion provides secured, public access to target resources in the cloud that you cannot otherwise reach from the internet.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/GetBastionExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetBastion API.
+     */
+    GetBastionResponse getBastion(GetBastionRequest request);
+
+    /**
+     * Retrieves a session identified by the session ID. A bastion session lets authorized users connect to a target resource for a predetermined amount of time.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/GetSessionExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetSession API.
+     */
+    GetSessionResponse getSession(GetSessionRequest request);
+
+    /**
+     * Gets the status of the work request with the given ID.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
+     */
+    GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request);
+
+    /**
+     * Retrieves a list of BastionSummary objects in a compartment. Bastions provide secured, public access to target resources in the cloud that you cannot otherwise reach from the internet.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListBastionsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListBastions API.
+     */
+    ListBastionsResponse listBastions(ListBastionsRequest request);
+
+    /**
+     * Retrieves a list of SessionSummary objects for an existing bastion. Bastion sessions let authorized users connect to a target resource for a predetermined amount of time.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListSessionsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListSessions API.
+     */
+    ListSessionsResponse listSessions(ListSessionsRequest request);
+
+    /**
+     * Return a (paginated) list of errors for a given work request.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestErrors API.
+     */
+    ListWorkRequestErrorsResponse listWorkRequestErrors(ListWorkRequestErrorsRequest request);
+
+    /**
+     * Return a (paginated) list of logs for a given work request.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestLogs API.
+     */
+    ListWorkRequestLogsResponse listWorkRequestLogs(ListWorkRequestLogsRequest request);
+
+    /**
+     * Lists the work requests in a compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.
+     */
+    ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request);
+
+    /**
+     * Updates the bastion identified by the bastion ID. A bastion provides secured, public access to target resources in the cloud that you cannot otherwise reach from the internet.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/UpdateBastionExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateBastion API.
+     */
+    UpdateBastionResponse updateBastion(UpdateBastionRequest request);
+
+    /**
+     * Updates the session identified by the session ID. A bastion session lets authorized users connect to a target resource for a predetermined amount of time.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/UpdateSessionExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateSession API.
+     */
+    UpdateSessionResponse updateSession(UpdateSessionRequest request);
+
+    /**
+     * Gets the pre-configured waiters available for resources for this service.
+     *
+     * @return The service waiters.
+     */
+    BastionWaiters getWaiters();
+
+    /**
+     * Gets the pre-configured paginators available for list operations in this service which may return multiple
+     * pages of data. These paginators provide an {@link java.lang.Iterable} interface so that service responses, or
+     * resources/records, can be iterated through without having to manually deal with pagination and page tokens.
+     *
+     * @return The service paginators.
+     */
+    BastionPaginators getPaginators();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionAsync.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionAsync.java
@@ -1,0 +1,280 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion;
+
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+
+/**
+ * Oracle Cloud Infrastructure Bastion provides restricted and time-limited access to target resources that don't have public endpoints. Through the configuration of a bastion, you can let authorized users connect from specific IP addresses to target resources by way of Secure Shell (SSH) sessions hosted on the bastion.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+public interface BastionAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Moves a bastion into a different compartment.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeBastionCompartmentResponse> changeBastionCompartment(
+            ChangeBastionCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeBastionCompartmentRequest, ChangeBastionCompartmentResponse>
+                    handler);
+
+    /**
+     * Creates a new bastion. A bastion provides secured, public access to target resources in the cloud that you cannot otherwise reach from the internet. A bastion resides in a public subnet and establishes the network infrastructure needed to connect a user to a target resource in a private subnet.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateBastionResponse> createBastion(
+            CreateBastionRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateBastionRequest, CreateBastionResponse>
+                    handler);
+
+    /**
+     * Creates a new session in a bastion. A bastion session lets authorized users connect to a target resource for a predetermined amount of time. The Bastion service recognizes two types of sessions, managed SSH sessions and SSH port forwarding sessions. Managed SSH sessions require that the target resource has an OpenSSH server and the Oracle Cloud Agent both running.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateSessionResponse> createSession(
+            CreateSessionRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateSessionRequest, CreateSessionResponse>
+                    handler);
+
+    /**
+     * Deletes a bastion identified by the bastion ID.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteBastionResponse> deleteBastion(
+            DeleteBastionRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteBastionRequest, DeleteBastionResponse>
+                    handler);
+
+    /**
+     * Deletes a session identified by the session ID.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteSessionResponse> deleteSession(
+            DeleteSessionRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteSessionRequest, DeleteSessionResponse>
+                    handler);
+
+    /**
+     * Retrieves a bastion identified by the bastion ID. A bastion provides secured, public access to target resources in the cloud that you cannot otherwise reach from the internet.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetBastionResponse> getBastion(
+            GetBastionRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetBastionRequest, GetBastionResponse> handler);
+
+    /**
+     * Retrieves a session identified by the session ID. A bastion session lets authorized users connect to a target resource for a predetermined amount of time.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetSessionResponse> getSession(
+            GetSessionRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetSessionRequest, GetSessionResponse> handler);
+
+    /**
+     * Gets the status of the work request with the given ID.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetWorkRequestResponse> getWorkRequest(
+            GetWorkRequestRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetWorkRequestRequest, GetWorkRequestResponse>
+                    handler);
+
+    /**
+     * Retrieves a list of BastionSummary objects in a compartment. Bastions provide secured, public access to target resources in the cloud that you cannot otherwise reach from the internet.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListBastionsResponse> listBastions(
+            ListBastionsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListBastionsRequest, ListBastionsResponse>
+                    handler);
+
+    /**
+     * Retrieves a list of SessionSummary objects for an existing bastion. Bastion sessions let authorized users connect to a target resource for a predetermined amount of time.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListSessionsResponse> listSessions(
+            ListSessionsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListSessionsRequest, ListSessionsResponse>
+                    handler);
+
+    /**
+     * Return a (paginated) list of errors for a given work request.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListWorkRequestErrorsResponse> listWorkRequestErrors(
+            ListWorkRequestErrorsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>
+                    handler);
+
+    /**
+     * Return a (paginated) list of logs for a given work request.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListWorkRequestLogsResponse> listWorkRequestLogs(
+            ListWorkRequestLogsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>
+                    handler);
+
+    /**
+     * Lists the work requests in a compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListWorkRequestsResponse> listWorkRequests(
+            ListWorkRequestsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListWorkRequestsRequest, ListWorkRequestsResponse>
+                    handler);
+
+    /**
+     * Updates the bastion identified by the bastion ID. A bastion provides secured, public access to target resources in the cloud that you cannot otherwise reach from the internet.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateBastionResponse> updateBastion(
+            UpdateBastionRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateBastionRequest, UpdateBastionResponse>
+                    handler);
+
+    /**
+     * Updates the session identified by the session ID. A bastion session lets authorized users connect to a target resource for a predetermined amount of time.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateSessionResponse> updateSession(
+            UpdateSessionRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateSessionRequest, UpdateSessionResponse>
+                    handler);
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionAsyncClient.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionAsyncClient.java
@@ -1,0 +1,945 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion;
+
+import com.oracle.bmc.bastion.internal.http.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+
+/**
+ * Async client implementation for Bastion service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class BastionAsyncClient implements BastionAsync {
+    /**
+     * Service instance for Bastion.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("BASTION")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://bastion.{region}.oci.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public BastionAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public BastionAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public BastionAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public BastionAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public BastionAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public BastionAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public BastionAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    public BastionAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, BastionAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public BastionAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new BastionAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<ChangeBastionCompartmentResponse> changeBastionCompartment(
+            ChangeBastionCompartmentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ChangeBastionCompartmentRequest, ChangeBastionCompartmentResponse>
+                    handler) {
+        LOG.trace("Called async changeBastionCompartment");
+        final ChangeBastionCompartmentRequest interceptedRequest =
+                ChangeBastionCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeBastionCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeBastionCompartmentResponse>
+                transformer = ChangeBastionCompartmentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeBastionCompartmentRequest, ChangeBastionCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeBastionCompartmentRequest, ChangeBastionCompartmentResponse>,
+                        java.util.concurrent.Future<ChangeBastionCompartmentResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeBastionCompartmentRequest, ChangeBastionCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateBastionResponse> createBastion(
+            CreateBastionRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<CreateBastionRequest, CreateBastionResponse>
+                    handler) {
+        LOG.trace("Called async createBastion");
+        final CreateBastionRequest interceptedRequest =
+                CreateBastionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateBastionConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateBastionResponse>
+                transformer = CreateBastionConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CreateBastionRequest, CreateBastionResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateBastionRequest, CreateBastionResponse>,
+                        java.util.concurrent.Future<CreateBastionResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateBastionRequest, CreateBastionResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateSessionResponse> createSession(
+            CreateSessionRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<CreateSessionRequest, CreateSessionResponse>
+                    handler) {
+        LOG.trace("Called async createSession");
+        final CreateSessionRequest interceptedRequest =
+                CreateSessionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateSessionConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateSessionResponse>
+                transformer = CreateSessionConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CreateSessionRequest, CreateSessionResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateSessionRequest, CreateSessionResponse>,
+                        java.util.concurrent.Future<CreateSessionResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateSessionRequest, CreateSessionResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteBastionResponse> deleteBastion(
+            DeleteBastionRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<DeleteBastionRequest, DeleteBastionResponse>
+                    handler) {
+        LOG.trace("Called async deleteBastion");
+        final DeleteBastionRequest interceptedRequest =
+                DeleteBastionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteBastionConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteBastionResponse>
+                transformer = DeleteBastionConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteBastionRequest, DeleteBastionResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteBastionRequest, DeleteBastionResponse>,
+                        java.util.concurrent.Future<DeleteBastionResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteBastionRequest, DeleteBastionResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteSessionResponse> deleteSession(
+            DeleteSessionRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<DeleteSessionRequest, DeleteSessionResponse>
+                    handler) {
+        LOG.trace("Called async deleteSession");
+        final DeleteSessionRequest interceptedRequest =
+                DeleteSessionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteSessionConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteSessionResponse>
+                transformer = DeleteSessionConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteSessionRequest, DeleteSessionResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteSessionRequest, DeleteSessionResponse>,
+                        java.util.concurrent.Future<DeleteSessionResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteSessionRequest, DeleteSessionResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetBastionResponse> getBastion(
+            GetBastionRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetBastionRequest, GetBastionResponse>
+                    handler) {
+        LOG.trace("Called async getBastion");
+        final GetBastionRequest interceptedRequest = GetBastionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetBastionConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetBastionResponse>
+                transformer = GetBastionConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetBastionRequest, GetBastionResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetBastionRequest, GetBastionResponse>,
+                        java.util.concurrent.Future<GetBastionResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetBastionRequest, GetBastionResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetSessionResponse> getSession(
+            GetSessionRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetSessionRequest, GetSessionResponse>
+                    handler) {
+        LOG.trace("Called async getSession");
+        final GetSessionRequest interceptedRequest = GetSessionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetSessionConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetSessionResponse>
+                transformer = GetSessionConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetSessionRequest, GetSessionResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetSessionRequest, GetSessionResponse>,
+                        java.util.concurrent.Future<GetSessionResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetSessionRequest, GetSessionResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetWorkRequestResponse> getWorkRequest(
+            GetWorkRequestRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetWorkRequestRequest, GetWorkRequestResponse>
+                    handler) {
+        LOG.trace("Called async getWorkRequest");
+        final GetWorkRequestRequest interceptedRequest =
+                GetWorkRequestConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetWorkRequestConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetWorkRequestResponse>
+                transformer = GetWorkRequestConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetWorkRequestRequest, GetWorkRequestResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetWorkRequestRequest, GetWorkRequestResponse>,
+                        java.util.concurrent.Future<GetWorkRequestResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetWorkRequestRequest, GetWorkRequestResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListBastionsResponse> listBastions(
+            ListBastionsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListBastionsRequest, ListBastionsResponse>
+                    handler) {
+        LOG.trace("Called async listBastions");
+        final ListBastionsRequest interceptedRequest =
+                ListBastionsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBastionsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListBastionsResponse>
+                transformer = ListBastionsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListBastionsRequest, ListBastionsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListBastionsRequest, ListBastionsResponse>,
+                        java.util.concurrent.Future<ListBastionsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListBastionsRequest, ListBastionsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListSessionsResponse> listSessions(
+            ListSessionsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListSessionsRequest, ListSessionsResponse>
+                    handler) {
+        LOG.trace("Called async listSessions");
+        final ListSessionsRequest interceptedRequest =
+                ListSessionsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListSessionsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListSessionsResponse>
+                transformer = ListSessionsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListSessionsRequest, ListSessionsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListSessionsRequest, ListSessionsResponse>,
+                        java.util.concurrent.Future<ListSessionsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListSessionsRequest, ListSessionsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListWorkRequestErrorsResponse> listWorkRequestErrors(
+            ListWorkRequestErrorsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>
+                    handler) {
+        LOG.trace("Called async listWorkRequestErrors");
+        final ListWorkRequestErrorsRequest interceptedRequest =
+                ListWorkRequestErrorsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestErrorsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListWorkRequestErrorsResponse>
+                transformer = ListWorkRequestErrorsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>,
+                        java.util.concurrent.Future<ListWorkRequestErrorsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListWorkRequestLogsResponse> listWorkRequestLogs(
+            ListWorkRequestLogsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>
+                    handler) {
+        LOG.trace("Called async listWorkRequestLogs");
+        final ListWorkRequestLogsRequest interceptedRequest =
+                ListWorkRequestLogsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestLogsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListWorkRequestLogsResponse>
+                transformer = ListWorkRequestLogsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>,
+                        java.util.concurrent.Future<ListWorkRequestLogsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListWorkRequestsResponse> listWorkRequests(
+            ListWorkRequestsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestsRequest, ListWorkRequestsResponse>
+                    handler) {
+        LOG.trace("Called async listWorkRequests");
+        final ListWorkRequestsRequest interceptedRequest =
+                ListWorkRequestsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkRequestsResponse>
+                transformer = ListWorkRequestsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListWorkRequestsRequest, ListWorkRequestsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListWorkRequestsRequest, ListWorkRequestsResponse>,
+                        java.util.concurrent.Future<ListWorkRequestsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListWorkRequestsRequest, ListWorkRequestsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateBastionResponse> updateBastion(
+            UpdateBastionRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<UpdateBastionRequest, UpdateBastionResponse>
+                    handler) {
+        LOG.trace("Called async updateBastion");
+        final UpdateBastionRequest interceptedRequest =
+                UpdateBastionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateBastionConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateBastionResponse>
+                transformer = UpdateBastionConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateBastionRequest, UpdateBastionResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateBastionRequest, UpdateBastionResponse>,
+                        java.util.concurrent.Future<UpdateBastionResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateBastionRequest, UpdateBastionResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateSessionResponse> updateSession(
+            UpdateSessionRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<UpdateSessionRequest, UpdateSessionResponse>
+                    handler) {
+        LOG.trace("Called async updateSession");
+        final UpdateSessionRequest interceptedRequest =
+                UpdateSessionConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateSessionConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateSessionResponse>
+                transformer = UpdateSessionConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateSessionRequest, UpdateSessionResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateSessionRequest, UpdateSessionResponse>,
+                        java.util.concurrent.Future<UpdateSessionResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateSessionRequest, UpdateSessionResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionClient.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionClient.java
@@ -1,0 +1,896 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion;
+
+import com.oracle.bmc.bastion.internal.http.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class BastionClient implements Bastion {
+    /**
+     * Service instance for Bastion.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("BASTION")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://bastion.{region}.oci.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    private final BastionWaiters waiters;
+
+    private final BastionPaginators paginators;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public BastionClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public BastionClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public BastionClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public BastionClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public BastionClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public BastionClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public BastionClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     */
+    public BastionClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                executorService,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * Use the {@link Builder} to get access to all these parameters.
+     *
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    protected BastionClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (executorService == null) {
+            // up to 50 (core) threads, time out after 60s idle, all daemon
+            java.util.concurrent.ThreadPoolExecutor threadPoolExecutor =
+                    new java.util.concurrent.ThreadPoolExecutor(
+                            50,
+                            50,
+                            60L,
+                            java.util.concurrent.TimeUnit.SECONDS,
+                            new java.util.concurrent.LinkedBlockingQueue<Runnable>(),
+                            new com.google.common.util.concurrent.ThreadFactoryBuilder()
+                                    .setDaemon(true)
+                                    .setNameFormat("Bastion-waiters-%d")
+                                    .build());
+            threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+            executorService = threadPoolExecutor;
+        }
+        this.waiters = new BastionWaiters(executorService, this);
+
+        this.paginators = new BastionPaginators(this);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, BastionClient> {
+        private java.util.concurrent.ExecutorService executorService;
+
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Set the ExecutorService for the client to be created.
+         * @param executorService executorService
+         * @return this builder
+         */
+        public Builder executorService(java.util.concurrent.ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public BastionClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new BastionClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint,
+                    executorService);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public ChangeBastionCompartmentResponse changeBastionCompartment(
+            ChangeBastionCompartmentRequest request) {
+        LOG.trace("Called changeBastionCompartment");
+        final ChangeBastionCompartmentRequest interceptedRequest =
+                ChangeBastionCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeBastionCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ChangeBastionCompartmentResponse>
+                transformer = ChangeBastionCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getChangeBastionCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateBastionResponse createBastion(CreateBastionRequest request) {
+        LOG.trace("Called createBastion");
+        final CreateBastionRequest interceptedRequest =
+                CreateBastionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateBastionConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateBastionResponse>
+                transformer = CreateBastionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateBastionDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateSessionResponse createSession(CreateSessionRequest request) {
+        LOG.trace("Called createSession");
+        final CreateSessionRequest interceptedRequest =
+                CreateSessionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateSessionConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateSessionResponse>
+                transformer = CreateSessionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateSessionDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteBastionResponse deleteBastion(DeleteBastionRequest request) {
+        LOG.trace("Called deleteBastion");
+        final DeleteBastionRequest interceptedRequest =
+                DeleteBastionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteBastionConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteBastionResponse>
+                transformer = DeleteBastionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteSessionResponse deleteSession(DeleteSessionRequest request) {
+        LOG.trace("Called deleteSession");
+        final DeleteSessionRequest interceptedRequest =
+                DeleteSessionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteSessionConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteSessionResponse>
+                transformer = DeleteSessionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetBastionResponse getBastion(GetBastionRequest request) {
+        LOG.trace("Called getBastion");
+        final GetBastionRequest interceptedRequest = GetBastionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetBastionConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetBastionResponse> transformer =
+                GetBastionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetSessionResponse getSession(GetSessionRequest request) {
+        LOG.trace("Called getSession");
+        final GetSessionRequest interceptedRequest = GetSessionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetSessionConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetSessionResponse> transformer =
+                GetSessionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request) {
+        LOG.trace("Called getWorkRequest");
+        final GetWorkRequestRequest interceptedRequest =
+                GetWorkRequestConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetWorkRequestConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetWorkRequestResponse>
+                transformer = GetWorkRequestConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListBastionsResponse listBastions(ListBastionsRequest request) {
+        LOG.trace("Called listBastions");
+        final ListBastionsRequest interceptedRequest =
+                ListBastionsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListBastionsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListBastionsResponse>
+                transformer = ListBastionsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListSessionsResponse listSessions(ListSessionsRequest request) {
+        LOG.trace("Called listSessions");
+        final ListSessionsRequest interceptedRequest =
+                ListSessionsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListSessionsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListSessionsResponse>
+                transformer = ListSessionsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListWorkRequestErrorsResponse listWorkRequestErrors(
+            ListWorkRequestErrorsRequest request) {
+        LOG.trace("Called listWorkRequestErrors");
+        final ListWorkRequestErrorsRequest interceptedRequest =
+                ListWorkRequestErrorsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestErrorsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkRequestErrorsResponse>
+                transformer = ListWorkRequestErrorsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListWorkRequestLogsResponse listWorkRequestLogs(ListWorkRequestLogsRequest request) {
+        LOG.trace("Called listWorkRequestLogs");
+        final ListWorkRequestLogsRequest interceptedRequest =
+                ListWorkRequestLogsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestLogsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkRequestLogsResponse>
+                transformer = ListWorkRequestLogsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request) {
+        LOG.trace("Called listWorkRequests");
+        final ListWorkRequestsRequest interceptedRequest =
+                ListWorkRequestsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkRequestsResponse>
+                transformer = ListWorkRequestsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateBastionResponse updateBastion(UpdateBastionRequest request) {
+        LOG.trace("Called updateBastion");
+        final UpdateBastionRequest interceptedRequest =
+                UpdateBastionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateBastionConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateBastionResponse>
+                transformer = UpdateBastionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateBastionDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateSessionResponse updateSession(UpdateSessionRequest request) {
+        LOG.trace("Called updateSession");
+        final UpdateSessionRequest interceptedRequest =
+                UpdateSessionConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateSessionConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateSessionResponse>
+                transformer = UpdateSessionConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateSessionDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public BastionWaiters getWaiters() {
+        return waiters;
+    }
+
+    @Override
+    public BastionPaginators getPaginators() {
+        return paginators;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionPaginators.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionPaginators.java
@@ -1,0 +1,592 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion;
+
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+
+/**
+ * Collection of helper methods that can be used to provide an {@link java.lang.Iterable} interface
+ * to any list operations of Bastion where multiple pages of data may be fetched.
+ * Two styles of iteration are supported:
+ *
+ * <ul>
+ *   <li>Iterating over the Response objects returned by the list operation. These are referred to as ResponseIterators, and the methods are suffixed with ResponseIterator. For example: <i>listUsersResponseIterator</i></li>
+ *   <li>Iterating over the resources/records being listed. These are referred to as RecordIterators, and the methods are suffixed with RecordIterator. For example: <i>listUsersRecordIterator</i></li>
+ * </ul>
+ *
+ * These iterables abstract away the need to write code to manually handle pagination via looping and using the page tokens.
+ * They will automatically fetch more data from the service when required.
+ *
+ * As an example, if we were using the ListUsers operation in IdentityService, then the {@link java.lang.Iterable} returned by calling a
+ * ResponseIterator method would iterate over the ListUsersResponse objects returned by each ListUsers call, whereas the {@link java.lang.Iterable}
+ * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
+ * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.RequiredArgsConstructor
+public class BastionPaginators {
+    private final Bastion client;
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listBastions operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListBastionsResponse> listBastionsResponseIterator(
+            final ListBastionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListBastionsRequest.Builder, ListBastionsRequest, ListBastionsResponse>(
+                new com.google.common.base.Supplier<ListBastionsRequest.Builder>() {
+                    @Override
+                    public ListBastionsRequest.Builder get() {
+                        return ListBastionsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListBastionsResponse, String>() {
+                    @Override
+                    public String apply(ListBastionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListBastionsRequest.Builder>,
+                        ListBastionsRequest>() {
+                    @Override
+                    public ListBastionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListBastionsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListBastionsRequest, ListBastionsResponse>() {
+                    @Override
+                    public ListBastionsResponse apply(ListBastionsRequest request) {
+                        return client.listBastions(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.bastion.model.BastionSummary} objects
+     * contained in responses from the listBastions operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.bastion.model.BastionSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.bastion.model.BastionSummary> listBastionsRecordIterator(
+            final ListBastionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListBastionsRequest.Builder, ListBastionsRequest, ListBastionsResponse,
+                com.oracle.bmc.bastion.model.BastionSummary>(
+                new com.google.common.base.Supplier<ListBastionsRequest.Builder>() {
+                    @Override
+                    public ListBastionsRequest.Builder get() {
+                        return ListBastionsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListBastionsResponse, String>() {
+                    @Override
+                    public String apply(ListBastionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListBastionsRequest.Builder>,
+                        ListBastionsRequest>() {
+                    @Override
+                    public ListBastionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListBastionsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListBastionsRequest, ListBastionsResponse>() {
+                    @Override
+                    public ListBastionsResponse apply(ListBastionsRequest request) {
+                        return client.listBastions(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListBastionsResponse,
+                        java.util.List<com.oracle.bmc.bastion.model.BastionSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.bastion.model.BastionSummary> apply(
+                            ListBastionsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listSessions operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListSessionsResponse> listSessionsResponseIterator(
+            final ListSessionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListSessionsRequest.Builder, ListSessionsRequest, ListSessionsResponse>(
+                new com.google.common.base.Supplier<ListSessionsRequest.Builder>() {
+                    @Override
+                    public ListSessionsRequest.Builder get() {
+                        return ListSessionsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListSessionsResponse, String>() {
+                    @Override
+                    public String apply(ListSessionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListSessionsRequest.Builder>,
+                        ListSessionsRequest>() {
+                    @Override
+                    public ListSessionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListSessionsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListSessionsRequest, ListSessionsResponse>() {
+                    @Override
+                    public ListSessionsResponse apply(ListSessionsRequest request) {
+                        return client.listSessions(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.bastion.model.SessionSummary} objects
+     * contained in responses from the listSessions operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.bastion.model.SessionSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.bastion.model.SessionSummary> listSessionsRecordIterator(
+            final ListSessionsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListSessionsRequest.Builder, ListSessionsRequest, ListSessionsResponse,
+                com.oracle.bmc.bastion.model.SessionSummary>(
+                new com.google.common.base.Supplier<ListSessionsRequest.Builder>() {
+                    @Override
+                    public ListSessionsRequest.Builder get() {
+                        return ListSessionsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListSessionsResponse, String>() {
+                    @Override
+                    public String apply(ListSessionsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListSessionsRequest.Builder>,
+                        ListSessionsRequest>() {
+                    @Override
+                    public ListSessionsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListSessionsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListSessionsRequest, ListSessionsResponse>() {
+                    @Override
+                    public ListSessionsResponse apply(ListSessionsRequest request) {
+                        return client.listSessions(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListSessionsResponse,
+                        java.util.List<com.oracle.bmc.bastion.model.SessionSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.bastion.model.SessionSummary> apply(
+                            ListSessionsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listWorkRequestErrors operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListWorkRequestErrorsResponse> listWorkRequestErrorsResponseIterator(
+            final ListWorkRequestErrorsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListWorkRequestErrorsRequest.Builder, ListWorkRequestErrorsRequest,
+                ListWorkRequestErrorsResponse>(
+                new com.google.common.base.Supplier<ListWorkRequestErrorsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestErrorsRequest.Builder get() {
+                        return ListWorkRequestErrorsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestErrorsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestErrorsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestErrorsRequest.Builder>,
+                        ListWorkRequestErrorsRequest>() {
+                    @Override
+                    public ListWorkRequestErrorsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestErrorsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>() {
+                    @Override
+                    public ListWorkRequestErrorsResponse apply(
+                            ListWorkRequestErrorsRequest request) {
+                        return client.listWorkRequestErrors(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.bastion.model.WorkRequestError} objects
+     * contained in responses from the listWorkRequestErrors operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.bastion.model.WorkRequestError} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.bastion.model.WorkRequestError>
+            listWorkRequestErrorsRecordIterator(final ListWorkRequestErrorsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListWorkRequestErrorsRequest.Builder, ListWorkRequestErrorsRequest,
+                ListWorkRequestErrorsResponse, com.oracle.bmc.bastion.model.WorkRequestError>(
+                new com.google.common.base.Supplier<ListWorkRequestErrorsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestErrorsRequest.Builder get() {
+                        return ListWorkRequestErrorsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestErrorsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestErrorsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestErrorsRequest.Builder>,
+                        ListWorkRequestErrorsRequest>() {
+                    @Override
+                    public ListWorkRequestErrorsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestErrorsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>() {
+                    @Override
+                    public ListWorkRequestErrorsResponse apply(
+                            ListWorkRequestErrorsRequest request) {
+                        return client.listWorkRequestErrors(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestErrorsResponse,
+                        java.util.List<com.oracle.bmc.bastion.model.WorkRequestError>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.bastion.model.WorkRequestError> apply(
+                            ListWorkRequestErrorsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listWorkRequestLogs operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListWorkRequestLogsResponse> listWorkRequestLogsResponseIterator(
+            final ListWorkRequestLogsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListWorkRequestLogsRequest.Builder, ListWorkRequestLogsRequest,
+                ListWorkRequestLogsResponse>(
+                new com.google.common.base.Supplier<ListWorkRequestLogsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestLogsRequest.Builder get() {
+                        return ListWorkRequestLogsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestLogsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestLogsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestLogsRequest.Builder>,
+                        ListWorkRequestLogsRequest>() {
+                    @Override
+                    public ListWorkRequestLogsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestLogsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>() {
+                    @Override
+                    public ListWorkRequestLogsResponse apply(ListWorkRequestLogsRequest request) {
+                        return client.listWorkRequestLogs(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.bastion.model.WorkRequestLogEntry} objects
+     * contained in responses from the listWorkRequestLogs operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.bastion.model.WorkRequestLogEntry} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.bastion.model.WorkRequestLogEntry>
+            listWorkRequestLogsRecordIterator(final ListWorkRequestLogsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListWorkRequestLogsRequest.Builder, ListWorkRequestLogsRequest,
+                ListWorkRequestLogsResponse, com.oracle.bmc.bastion.model.WorkRequestLogEntry>(
+                new com.google.common.base.Supplier<ListWorkRequestLogsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestLogsRequest.Builder get() {
+                        return ListWorkRequestLogsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestLogsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestLogsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestLogsRequest.Builder>,
+                        ListWorkRequestLogsRequest>() {
+                    @Override
+                    public ListWorkRequestLogsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestLogsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>() {
+                    @Override
+                    public ListWorkRequestLogsResponse apply(ListWorkRequestLogsRequest request) {
+                        return client.listWorkRequestLogs(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestLogsResponse,
+                        java.util.List<com.oracle.bmc.bastion.model.WorkRequestLogEntry>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.bastion.model.WorkRequestLogEntry> apply(
+                            ListWorkRequestLogsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listWorkRequests operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListWorkRequestsResponse> listWorkRequestsResponseIterator(
+            final ListWorkRequestsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListWorkRequestsRequest.Builder, ListWorkRequestsRequest, ListWorkRequestsResponse>(
+                new com.google.common.base.Supplier<ListWorkRequestsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestsRequest.Builder get() {
+                        return ListWorkRequestsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestsRequest.Builder>,
+                        ListWorkRequestsRequest>() {
+                    @Override
+                    public ListWorkRequestsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestsRequest, ListWorkRequestsResponse>() {
+                    @Override
+                    public ListWorkRequestsResponse apply(ListWorkRequestsRequest request) {
+                        return client.listWorkRequests(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.bastion.model.WorkRequestSummary} objects
+     * contained in responses from the listWorkRequests operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.bastion.model.WorkRequestSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.bastion.model.WorkRequestSummary> listWorkRequestsRecordIterator(
+            final ListWorkRequestsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListWorkRequestsRequest.Builder, ListWorkRequestsRequest, ListWorkRequestsResponse,
+                com.oracle.bmc.bastion.model.WorkRequestSummary>(
+                new com.google.common.base.Supplier<ListWorkRequestsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestsRequest.Builder get() {
+                        return ListWorkRequestsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestsRequest.Builder>,
+                        ListWorkRequestsRequest>() {
+                    @Override
+                    public ListWorkRequestsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestsRequest, ListWorkRequestsResponse>() {
+                    @Override
+                    public ListWorkRequestsResponse apply(ListWorkRequestsRequest request) {
+                        return client.listWorkRequests(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestsResponse,
+                        java.util.List<com.oracle.bmc.bastion.model.WorkRequestSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.bastion.model.WorkRequestSummary> apply(
+                            ListWorkRequestsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionWaiters.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/BastionWaiters.java
@@ -1,0 +1,271 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion;
+
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+
+/**
+ * Collection of helper methods to produce {@link com.oracle.bmc.waiter.Waiter}s for different
+ * resources of Bastion.
+ * <p>
+ * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.RequiredArgsConstructor
+public class BastionWaiters {
+    private final java.util.concurrent.ExecutorService executorService;
+    private final Bastion client;
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetBastionRequest, GetBastionResponse> forBastion(
+            GetBastionRequest request,
+            com.oracle.bmc.bastion.model.BastionLifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forBastion(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetBastionRequest, GetBastionResponse> forBastion(
+            GetBastionRequest request,
+            com.oracle.bmc.bastion.model.BastionLifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forBastion(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetBastionRequest, GetBastionResponse> forBastion(
+            GetBastionRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.bastion.model.BastionLifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forBastion(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Bastion.
+    private com.oracle.bmc.waiter.Waiter<GetBastionRequest, GetBastionResponse> forBastion(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetBastionRequest request,
+            final com.oracle.bmc.bastion.model.BastionLifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.bastion.model.BastionLifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetBastionRequest, GetBastionResponse>() {
+                            @Override
+                            public GetBastionResponse apply(GetBastionRequest request) {
+                                return client.getBastion(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetBastionResponse>() {
+                            @Override
+                            public boolean apply(GetBastionResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getBastion().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.bastion.model.BastionLifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetSessionRequest, GetSessionResponse> forSession(
+            GetSessionRequest request,
+            com.oracle.bmc.bastion.model.SessionLifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forSession(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetSessionRequest, GetSessionResponse> forSession(
+            GetSessionRequest request,
+            com.oracle.bmc.bastion.model.SessionLifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forSession(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetSessionRequest, GetSessionResponse> forSession(
+            GetSessionRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.bastion.model.SessionLifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forSession(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for Session.
+    private com.oracle.bmc.waiter.Waiter<GetSessionRequest, GetSessionResponse> forSession(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetSessionRequest request,
+            final com.oracle.bmc.bastion.model.SessionLifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.bastion.model.SessionLifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetSessionRequest, GetSessionResponse>() {
+                            @Override
+                            public GetSessionResponse apply(GetSessionRequest request) {
+                                return client.getSession(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetSessionResponse>() {
+                            @Override
+                            public boolean apply(GetSessionResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getSession().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.bastion.model.SessionLifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetWorkRequestRequest, GetWorkRequestResponse>
+            forWorkRequest(GetWorkRequestRequest request) {
+        return forWorkRequest(com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@linkcom.oracle.bmc.waiter. DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetWorkRequestRequest, GetWorkRequestResponse>
+            forWorkRequest(
+                    GetWorkRequestRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        return forWorkRequest(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request);
+    }
+
+    // Helper method to create a new Waiter for WorkRequest.
+    private com.oracle.bmc.waiter.Waiter<GetWorkRequestRequest, GetWorkRequestResponse>
+            forWorkRequest(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetWorkRequestRequest request) {
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetWorkRequestRequest, GetWorkRequestResponse>() {
+                            @Override
+                            public GetWorkRequestResponse apply(GetWorkRequestRequest request) {
+                                return client.getWorkRequest(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetWorkRequestResponse>() {
+                            @Override
+                            public boolean apply(GetWorkRequestResponse response) {
+                                // work requests are complete once the time finished is available
+                                return response.getWorkRequest().getTimeFinished() != null;
+                            }
+                        },
+                        false),
+                request);
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ChangeBastionCompartmentConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ChangeBastionCompartmentConverter.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class ChangeBastionCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.ChangeBastionCompartmentRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.ChangeBastionCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.ChangeBastionCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getBastionId(), "bastionId must not be blank");
+        Validate.notNull(
+                request.getChangeBastionCompartmentDetails(),
+                "changeBastionCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("bastions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBastionId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.ChangeBastionCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.ChangeBastionCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses
+                                        .ChangeBastionCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.ChangeBastionCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.ChangeBastionCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.ChangeBastionCompartmentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .ChangeBastionCompartmentResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.ChangeBastionCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/CreateBastionConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/CreateBastionConverter.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class CreateBastionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.CreateBastionRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.CreateBastionRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.CreateBastionRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCreateBastionDetails(), "createBastionDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20210331").path("bastions");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.CreateBastionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.CreateBastionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.CreateBastionResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.CreateBastionResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.CreateBastionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Bastion>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Bastion.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Bastion> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.CreateBastionResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .CreateBastionResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.bastion(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.CreateBastionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/CreateSessionConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/CreateSessionConverter.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class CreateSessionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.CreateSessionRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.CreateSessionRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.CreateSessionRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCreateSessionDetails(), "createSessionDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20210331").path("sessions");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.CreateSessionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.CreateSessionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.CreateSessionResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.CreateSessionResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.CreateSessionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Session>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Session.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Session> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.CreateSessionResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .CreateSessionResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.session(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.CreateSessionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/DeleteBastionConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/DeleteBastionConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class DeleteBastionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.DeleteBastionRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.DeleteBastionRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.DeleteBastionRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getBastionId(), "bastionId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("bastions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBastionId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.DeleteBastionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.DeleteBastionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.DeleteBastionResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.DeleteBastionResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.DeleteBastionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.DeleteBastionResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .DeleteBastionResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.DeleteBastionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/DeleteSessionConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/DeleteSessionConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class DeleteSessionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.DeleteSessionRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.DeleteSessionRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.DeleteSessionRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getSessionId(), "sessionId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("sessions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getSessionId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.DeleteSessionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.DeleteSessionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.DeleteSessionResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.DeleteSessionResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.DeleteSessionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.DeleteSessionResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .DeleteSessionResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.DeleteSessionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/GetBastionConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/GetBastionConverter.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class GetBastionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.GetBastionRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.GetBastionRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.GetBastionRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getBastionId(), "bastionId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("bastions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBastionId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.bastion.responses.GetBastionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.GetBastionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.GetBastionResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.GetBastionResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.GetBastionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Bastion>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Bastion.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Bastion> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.GetBastionResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses.GetBastionResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.bastion(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.GetBastionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/GetSessionConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/GetSessionConverter.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class GetSessionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.GetSessionRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.GetSessionRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.GetSessionRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getSessionId(), "sessionId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("sessions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getSessionId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.bastion.responses.GetSessionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.GetSessionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.GetSessionResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.GetSessionResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.GetSessionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Session>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Session.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Session> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.GetSessionResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses.GetSessionResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.session(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.GetSessionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/GetWorkRequestConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/GetWorkRequestConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class GetWorkRequestConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.GetWorkRequestRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.GetWorkRequestRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.GetWorkRequestRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkRequestId(), "workRequestId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("workRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkRequestId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.GetWorkRequestResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.GetWorkRequestResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.GetWorkRequestResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.GetWorkRequestResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.GetWorkRequestResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        WorkRequest>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        WorkRequest.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<WorkRequest> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.GetWorkRequestResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .GetWorkRequestResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.workRequest(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        retryAfterHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "retry-after");
+                                if (retryAfterHeader.isPresent()) {
+                                    builder.retryAfter(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "retry-after",
+                                                    retryAfterHeader.get().get(0),
+                                                    Float.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.GetWorkRequestResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListBastionsConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListBastionsConverter.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class ListBastionsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.ListBastionsRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.ListBastionsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.ListBastionsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20210331").path("bastions");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getBastionLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "bastionLifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBastionLifecycleState().getValue()));
+        }
+
+        if (request.getBastionId() != null) {
+            target =
+                    target.queryParam(
+                            "bastionId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBastionId()));
+        }
+
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.ListBastionsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.ListBastionsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.ListBastionsResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.ListBastionsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.ListBastionsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<BastionSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        BastionSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<BastionSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.ListBastionsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .ListBastionsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.ListBastionsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListSessionsConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListSessionsConverter.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class ListSessionsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.ListSessionsRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.ListSessionsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.ListSessionsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getBastionId(), "bastionId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20210331").path("sessions");
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        target =
+                target.queryParam(
+                        "bastionId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getBastionId()));
+
+        if (request.getSessionLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "sessionLifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSessionLifecycleState().getValue()));
+        }
+
+        if (request.getSessionId() != null) {
+            target =
+                    target.queryParam(
+                            "sessionId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSessionId()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.ListSessionsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.ListSessionsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.ListSessionsResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.ListSessionsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.ListSessionsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<SessionSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        SessionSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<SessionSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.ListSessionsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .ListSessionsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.ListSessionsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListWorkRequestErrorsConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListWorkRequestErrorsConverter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class ListWorkRequestErrorsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.ListWorkRequestErrorsRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.ListWorkRequestErrorsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.ListWorkRequestErrorsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkRequestId(), "workRequestId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("workRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkRequestId()))
+                        .path("errors");
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.ListWorkRequestErrorsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.ListWorkRequestErrorsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.ListWorkRequestErrorsResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.ListWorkRequestErrorsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.ListWorkRequestErrorsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<WorkRequestError>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        WorkRequestError>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<WorkRequestError>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.ListWorkRequestErrorsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .ListWorkRequestErrorsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.ListWorkRequestErrorsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListWorkRequestLogsConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListWorkRequestLogsConverter.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class ListWorkRequestLogsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.ListWorkRequestLogsRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.ListWorkRequestLogsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.ListWorkRequestLogsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkRequestId(), "workRequestId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("workRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkRequestId()))
+                        .path("logs");
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.ListWorkRequestLogsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.ListWorkRequestLogsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.ListWorkRequestLogsResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.ListWorkRequestLogsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.ListWorkRequestLogsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<WorkRequestLogEntry>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        WorkRequestLogEntry>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<WorkRequestLogEntry>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.ListWorkRequestLogsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .ListWorkRequestLogsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.ListWorkRequestLogsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListWorkRequestsConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/ListWorkRequestsConverter.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class ListWorkRequestsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.ListWorkRequestsRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.ListWorkRequestsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.ListWorkRequestsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20210331").path("workRequests");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.ListWorkRequestsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.ListWorkRequestsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.ListWorkRequestsResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.ListWorkRequestsResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.ListWorkRequestsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<WorkRequestSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        WorkRequestSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<WorkRequestSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.ListWorkRequestsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .ListWorkRequestsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.ListWorkRequestsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/UpdateBastionConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/UpdateBastionConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class UpdateBastionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.UpdateBastionRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.UpdateBastionRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.UpdateBastionRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getBastionId(), "bastionId must not be blank");
+        Validate.notNull(request.getUpdateBastionDetails(), "updateBastionDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("bastions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBastionId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.UpdateBastionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.UpdateBastionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.UpdateBastionResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.UpdateBastionResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.UpdateBastionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.UpdateBastionResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .UpdateBastionResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.UpdateBastionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/UpdateSessionConverter.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/internal/http/UpdateSessionConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.bastion.model.*;
+import com.oracle.bmc.bastion.requests.*;
+import com.oracle.bmc.bastion.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public class UpdateSessionConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.bastion.requests.UpdateSessionRequest interceptRequest(
+            com.oracle.bmc.bastion.requests.UpdateSessionRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.bastion.requests.UpdateSessionRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getSessionId(), "sessionId must not be blank");
+        Validate.notNull(request.getUpdateSessionDetails(), "updateSessionDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210331")
+                        .path("sessions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getSessionId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.bastion.responses.UpdateSessionResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.bastion.responses.UpdateSessionResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.bastion.responses.UpdateSessionResponse>() {
+                            @Override
+                            public com.oracle.bmc.bastion.responses.UpdateSessionResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.bastion.responses.UpdateSessionResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Session>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(Session.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<Session> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.bastion.responses.UpdateSessionResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.bastion.responses
+                                                        .UpdateSessionResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.session(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.bastion.responses.UpdateSessionResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/ActionType.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/ActionType.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Possible types of actions.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public enum ActionType {
+    Created("CREATED"),
+    Updated("UPDATED"),
+    Deleted("DELETED"),
+    InProgress("IN_PROGRESS"),
+    Related("RELATED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, ActionType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (ActionType v : ActionType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    ActionType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static ActionType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'ActionType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/Bastion.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/Bastion.java
@@ -1,0 +1,391 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * A bastion resource. A bastion provides secured, public access to target resources in the cloud that you cannot otherwise reach from the internet. A bastion resides in a public subnet and establishes the network infrastructure needed to connect a user to a target resource in a private subnet.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Bastion.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Bastion {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionType")
+        private String bastionType;
+
+        public Builder bastionType(String bastionType) {
+            this.bastionType = bastionType;
+            this.__explicitlySet__.add("bastionType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetVcnId")
+        private String targetVcnId;
+
+        public Builder targetVcnId(String targetVcnId) {
+            this.targetVcnId = targetVcnId;
+            this.__explicitlySet__.add("targetVcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetSubnetId")
+        private String targetSubnetId;
+
+        public Builder targetSubnetId(String targetSubnetId) {
+            this.targetSubnetId = targetSubnetId;
+            this.__explicitlySet__.add("targetSubnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("phoneBookEntry")
+        private String phoneBookEntry;
+
+        public Builder phoneBookEntry(String phoneBookEntry) {
+            this.phoneBookEntry = phoneBookEntry;
+            this.__explicitlySet__.add("phoneBookEntry");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clientCidrBlockAllowList")
+        private java.util.List<String> clientCidrBlockAllowList;
+
+        public Builder clientCidrBlockAllowList(java.util.List<String> clientCidrBlockAllowList) {
+            this.clientCidrBlockAllowList = clientCidrBlockAllowList;
+            this.__explicitlySet__.add("clientCidrBlockAllowList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("staticJumpHostIpAddresses")
+        private java.util.List<String> staticJumpHostIpAddresses;
+
+        public Builder staticJumpHostIpAddresses(java.util.List<String> staticJumpHostIpAddresses) {
+            this.staticJumpHostIpAddresses = staticJumpHostIpAddresses;
+            this.__explicitlySet__.add("staticJumpHostIpAddresses");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointIpAddress")
+        private String privateEndpointIpAddress;
+
+        public Builder privateEndpointIpAddress(String privateEndpointIpAddress) {
+            this.privateEndpointIpAddress = privateEndpointIpAddress;
+            this.__explicitlySet__.add("privateEndpointIpAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxSessionTtlInSeconds")
+        private Integer maxSessionTtlInSeconds;
+
+        public Builder maxSessionTtlInSeconds(Integer maxSessionTtlInSeconds) {
+            this.maxSessionTtlInSeconds = maxSessionTtlInSeconds;
+            this.__explicitlySet__.add("maxSessionTtlInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxSessionsAllowed")
+        private Integer maxSessionsAllowed;
+
+        public Builder maxSessionsAllowed(Integer maxSessionsAllowed) {
+            this.maxSessionsAllowed = maxSessionsAllowed;
+            this.__explicitlySet__.add("maxSessionsAllowed");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private BastionLifecycleState lifecycleState;
+
+        public Builder lifecycleState(BastionLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Bastion build() {
+            Bastion __instance__ =
+                    new Bastion(
+                            bastionType,
+                            id,
+                            name,
+                            compartmentId,
+                            targetVcnId,
+                            targetSubnetId,
+                            phoneBookEntry,
+                            clientCidrBlockAllowList,
+                            staticJumpHostIpAddresses,
+                            privateEndpointIpAddress,
+                            maxSessionTtlInSeconds,
+                            maxSessionsAllowed,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Bastion o) {
+            Builder copiedBuilder =
+                    bastionType(o.getBastionType())
+                            .id(o.getId())
+                            .name(o.getName())
+                            .compartmentId(o.getCompartmentId())
+                            .targetVcnId(o.getTargetVcnId())
+                            .targetSubnetId(o.getTargetSubnetId())
+                            .phoneBookEntry(o.getPhoneBookEntry())
+                            .clientCidrBlockAllowList(o.getClientCidrBlockAllowList())
+                            .staticJumpHostIpAddresses(o.getStaticJumpHostIpAddresses())
+                            .privateEndpointIpAddress(o.getPrivateEndpointIpAddress())
+                            .maxSessionTtlInSeconds(o.getMaxSessionTtlInSeconds())
+                            .maxSessionsAllowed(o.getMaxSessionsAllowed())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The type of bastion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionType")
+    String bastionType;
+
+    /**
+     * The unique identifier (OCID) of the bastion, which can't be changed after creation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The name of the bastion, which can't be changed after creation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The unique identifier (OCID) of the compartment where the bastion is located.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The unique identifier (OCID) of the virtual cloud network (VCN) that the bastion connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetVcnId")
+    String targetVcnId;
+
+    /**
+     * The unique identifier (OCID) of the subnet that the bastion connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetSubnetId")
+    String targetSubnetId;
+
+    /**
+     * The phonebook entry of the customer's team, which can't be changed after creation. Not applicable to `standard` bastions.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("phoneBookEntry")
+    String phoneBookEntry;
+
+    /**
+     * A list of address ranges in CIDR notation that you want to allow to connect to sessions hosted by this bastion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clientCidrBlockAllowList")
+    java.util.List<String> clientCidrBlockAllowList;
+
+    /**
+     * A list of IP addresses of the hosts that the bastion has access to. Not applicable to `standard` bastions.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("staticJumpHostIpAddresses")
+    java.util.List<String> staticJumpHostIpAddresses;
+
+    /**
+     * The private IP address of the created private endpoint.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("privateEndpointIpAddress")
+    String privateEndpointIpAddress;
+
+    /**
+     * The maximum amount of time that any session on the bastion can remain active.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxSessionTtlInSeconds")
+    Integer maxSessionTtlInSeconds;
+
+    /**
+     * The maximum number of active sessions allowed on the bastion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxSessionsAllowed")
+    Integer maxSessionsAllowed;
+
+    /**
+     * The time the bastion was created. Format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2020-01-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the bastion was updated. Format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2020-01-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * The current state of the bastion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    BastionLifecycleState lifecycleState;
+
+    /**
+     * A message describing the current state in more detail.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Usage of system tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/BastionLifecycleState.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/BastionLifecycleState.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Possible bastion lifecycle states.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public enum BastionLifecycleState {
+    Creating("CREATING"),
+    Updating("UPDATING"),
+    Active("ACTIVE"),
+    Deleting("DELETING"),
+    Deleted("DELETED"),
+    Failed("FAILED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, BastionLifecycleState> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (BastionLifecycleState v : BastionLifecycleState.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    BastionLifecycleState(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static BastionLifecycleState create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'BastionLifecycleState', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/BastionSummary.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/BastionSummary.java
@@ -1,0 +1,287 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Summary information for a bastion resource. A bastion provides secured, public access to target resources in the cloud that you cannot otherwise reach from the internet. A bastion resides in a public subnet and establishes the network infrastructure needed to connect a user to a target resource in a private subnet.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = BastionSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class BastionSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionType")
+        private String bastionType;
+
+        public Builder bastionType(String bastionType) {
+            this.bastionType = bastionType;
+            this.__explicitlySet__.add("bastionType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetVcnId")
+        private String targetVcnId;
+
+        public Builder targetVcnId(String targetVcnId) {
+            this.targetVcnId = targetVcnId;
+            this.__explicitlySet__.add("targetVcnId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetSubnetId")
+        private String targetSubnetId;
+
+        public Builder targetSubnetId(String targetSubnetId) {
+            this.targetSubnetId = targetSubnetId;
+            this.__explicitlySet__.add("targetSubnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private BastionLifecycleState lifecycleState;
+
+        public Builder lifecycleState(BastionLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public BastionSummary build() {
+            BastionSummary __instance__ =
+                    new BastionSummary(
+                            bastionType,
+                            id,
+                            name,
+                            compartmentId,
+                            targetVcnId,
+                            targetSubnetId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(BastionSummary o) {
+            Builder copiedBuilder =
+                    bastionType(o.getBastionType())
+                            .id(o.getId())
+                            .name(o.getName())
+                            .compartmentId(o.getCompartmentId())
+                            .targetVcnId(o.getTargetVcnId())
+                            .targetSubnetId(o.getTargetSubnetId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The type of bastion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionType")
+    String bastionType;
+
+    /**
+     * The unique identifier (OCID) of the bastion, which can't be changed after creation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The name of the bastion, which can't be changed after creation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The unique identifier (OCID) of the compartment where the bastion is located.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The unique identifier (OCID) of the virtual cloud network (VCN) that the bastion connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetVcnId")
+    String targetVcnId;
+
+    /**
+     * The unique identifier (OCID) of the subnet that the bastion connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetSubnetId")
+    String targetSubnetId;
+
+    /**
+     * The time the bastion was created. Format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2020-01-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the bastion was updated. Format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2020-01-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * The current state of the bastion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    BastionLifecycleState lifecycleState;
+
+    /**
+     * A message describing the current state in more detail.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Usage of system tag keys. These predefined keys are scoped to namespaces.
+     * Example: `{\"orcl-cloud\": {\"free-tier-retained\": \"true\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/ChangeBastionCompartmentDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/ChangeBastionCompartmentDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Details about the compartment that the bastion should move to.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeBastionCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeBastionCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeBastionCompartmentDetails build() {
+            ChangeBastionCompartmentDetails __instance__ =
+                    new ChangeBastionCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeBastionCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique identifier (OCID) of the compartment that the bastion should move to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreateBastionDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreateBastionDetails.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * The configuration details for a new bastion. A bastion provides secured, public access to target resources in the cloud that you cannot otherwise reach from the internet. A bastion resides in a public subnet and establishes the network infrastructure needed to connect a user to a target resource in a private subnet.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateBastionDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateBastionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionType")
+        private String bastionType;
+
+        public Builder bastionType(String bastionType) {
+            this.bastionType = bastionType;
+            this.__explicitlySet__.add("bastionType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetSubnetId")
+        private String targetSubnetId;
+
+        public Builder targetSubnetId(String targetSubnetId) {
+            this.targetSubnetId = targetSubnetId;
+            this.__explicitlySet__.add("targetSubnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("phoneBookEntry")
+        private String phoneBookEntry;
+
+        public Builder phoneBookEntry(String phoneBookEntry) {
+            this.phoneBookEntry = phoneBookEntry;
+            this.__explicitlySet__.add("phoneBookEntry");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("staticJumpHostIpAddresses")
+        private java.util.List<String> staticJumpHostIpAddresses;
+
+        public Builder staticJumpHostIpAddresses(java.util.List<String> staticJumpHostIpAddresses) {
+            this.staticJumpHostIpAddresses = staticJumpHostIpAddresses;
+            this.__explicitlySet__.add("staticJumpHostIpAddresses");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clientCidrBlockAllowList")
+        private java.util.List<String> clientCidrBlockAllowList;
+
+        public Builder clientCidrBlockAllowList(java.util.List<String> clientCidrBlockAllowList) {
+            this.clientCidrBlockAllowList = clientCidrBlockAllowList;
+            this.__explicitlySet__.add("clientCidrBlockAllowList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxSessionTtlInSeconds")
+        private Integer maxSessionTtlInSeconds;
+
+        public Builder maxSessionTtlInSeconds(Integer maxSessionTtlInSeconds) {
+            this.maxSessionTtlInSeconds = maxSessionTtlInSeconds;
+            this.__explicitlySet__.add("maxSessionTtlInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateBastionDetails build() {
+            CreateBastionDetails __instance__ =
+                    new CreateBastionDetails(
+                            bastionType,
+                            name,
+                            compartmentId,
+                            targetSubnetId,
+                            phoneBookEntry,
+                            staticJumpHostIpAddresses,
+                            clientCidrBlockAllowList,
+                            maxSessionTtlInSeconds,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateBastionDetails o) {
+            Builder copiedBuilder =
+                    bastionType(o.getBastionType())
+                            .name(o.getName())
+                            .compartmentId(o.getCompartmentId())
+                            .targetSubnetId(o.getTargetSubnetId())
+                            .phoneBookEntry(o.getPhoneBookEntry())
+                            .staticJumpHostIpAddresses(o.getStaticJumpHostIpAddresses())
+                            .clientCidrBlockAllowList(o.getClientCidrBlockAllowList())
+                            .maxSessionTtlInSeconds(o.getMaxSessionTtlInSeconds())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The type of bastion. Use `standard`.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionType")
+    String bastionType;
+
+    /**
+     * The name of the bastion, which can't be changed after creation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The unique identifier (OCID) of the compartment where the bastion is located.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The unique identifier (OCID) of the subnet that the bastion connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetSubnetId")
+    String targetSubnetId;
+
+    /**
+     * The phonebook entry of the customer's team, which can't be changed after creation. Not applicable to `standard` bastions.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("phoneBookEntry")
+    String phoneBookEntry;
+
+    /**
+     * A list of IP addresses of the hosts that the bastion has access to. Not applicable to `standard` bastions.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("staticJumpHostIpAddresses")
+    java.util.List<String> staticJumpHostIpAddresses;
+
+    /**
+     * A list of address ranges in CIDR notation that you want to allow to connect to sessions hosted by this bastion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clientCidrBlockAllowList")
+    java.util.List<String> clientCidrBlockAllowList;
+
+    /**
+     * The maximum amount of time that any session on the bastion can remain active.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxSessionTtlInSeconds")
+    Integer maxSessionTtlInSeconds;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreateManagedSshSessionTargetResourceDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreateManagedSshSessionTargetResourceDetails.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Details about a managed SSH session for a target resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateManagedSshSessionTargetResourceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sessionType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateManagedSshSessionTargetResourceDetails
+        extends CreateSessionTargetResourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePort")
+        private Integer targetResourcePort;
+
+        public Builder targetResourcePort(Integer targetResourcePort) {
+            this.targetResourcePort = targetResourcePort;
+            this.__explicitlySet__.add("targetResourcePort");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceOperatingSystemUserName")
+        private String targetResourceOperatingSystemUserName;
+
+        public Builder targetResourceOperatingSystemUserName(
+                String targetResourceOperatingSystemUserName) {
+            this.targetResourceOperatingSystemUserName = targetResourceOperatingSystemUserName;
+            this.__explicitlySet__.add("targetResourceOperatingSystemUserName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceId")
+        private String targetResourceId;
+
+        public Builder targetResourceId(String targetResourceId) {
+            this.targetResourceId = targetResourceId;
+            this.__explicitlySet__.add("targetResourceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePrivateIpAddress")
+        private String targetResourcePrivateIpAddress;
+
+        public Builder targetResourcePrivateIpAddress(String targetResourcePrivateIpAddress) {
+            this.targetResourcePrivateIpAddress = targetResourcePrivateIpAddress;
+            this.__explicitlySet__.add("targetResourcePrivateIpAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateManagedSshSessionTargetResourceDetails build() {
+            CreateManagedSshSessionTargetResourceDetails __instance__ =
+                    new CreateManagedSshSessionTargetResourceDetails(
+                            targetResourcePort,
+                            targetResourceOperatingSystemUserName,
+                            targetResourceId,
+                            targetResourcePrivateIpAddress);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateManagedSshSessionTargetResourceDetails o) {
+            Builder copiedBuilder =
+                    targetResourcePort(o.getTargetResourcePort())
+                            .targetResourceOperatingSystemUserName(
+                                    o.getTargetResourceOperatingSystemUserName())
+                            .targetResourceId(o.getTargetResourceId())
+                            .targetResourcePrivateIpAddress(o.getTargetResourcePrivateIpAddress());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateManagedSshSessionTargetResourceDetails(
+            Integer targetResourcePort,
+            String targetResourceOperatingSystemUserName,
+            String targetResourceId,
+            String targetResourcePrivateIpAddress) {
+        super(targetResourcePort);
+        this.targetResourceOperatingSystemUserName = targetResourceOperatingSystemUserName;
+        this.targetResourceId = targetResourceId;
+        this.targetResourcePrivateIpAddress = targetResourcePrivateIpAddress;
+    }
+
+    /**
+     * The name of the user on the target resource operating system that the session uses for the connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceOperatingSystemUserName")
+    String targetResourceOperatingSystemUserName;
+
+    /**
+     * The unique identifier (OCID) of the target resource (a Compute instance, for example) that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceId")
+    String targetResourceId;
+
+    /**
+     * The private IP address of the target resource that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePrivateIpAddress")
+    String targetResourcePrivateIpAddress;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreatePortForwardingSessionTargetResourceDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreatePortForwardingSessionTargetResourceDetails.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Details about a port forwarding session for a target resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreatePortForwardingSessionTargetResourceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sessionType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreatePortForwardingSessionTargetResourceDetails
+        extends CreateSessionTargetResourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePort")
+        private Integer targetResourcePort;
+
+        public Builder targetResourcePort(Integer targetResourcePort) {
+            this.targetResourcePort = targetResourcePort;
+            this.__explicitlySet__.add("targetResourcePort");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceId")
+        private String targetResourceId;
+
+        public Builder targetResourceId(String targetResourceId) {
+            this.targetResourceId = targetResourceId;
+            this.__explicitlySet__.add("targetResourceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePrivateIpAddress")
+        private String targetResourcePrivateIpAddress;
+
+        public Builder targetResourcePrivateIpAddress(String targetResourcePrivateIpAddress) {
+            this.targetResourcePrivateIpAddress = targetResourcePrivateIpAddress;
+            this.__explicitlySet__.add("targetResourcePrivateIpAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreatePortForwardingSessionTargetResourceDetails build() {
+            CreatePortForwardingSessionTargetResourceDetails __instance__ =
+                    new CreatePortForwardingSessionTargetResourceDetails(
+                            targetResourcePort, targetResourceId, targetResourcePrivateIpAddress);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreatePortForwardingSessionTargetResourceDetails o) {
+            Builder copiedBuilder =
+                    targetResourcePort(o.getTargetResourcePort())
+                            .targetResourceId(o.getTargetResourceId())
+                            .targetResourcePrivateIpAddress(o.getTargetResourcePrivateIpAddress());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreatePortForwardingSessionTargetResourceDetails(
+            Integer targetResourcePort,
+            String targetResourceId,
+            String targetResourcePrivateIpAddress) {
+        super(targetResourcePort);
+        this.targetResourceId = targetResourceId;
+        this.targetResourcePrivateIpAddress = targetResourcePrivateIpAddress;
+    }
+
+    /**
+     * The unique identifier (OCID) of the target resource (a Compute instance, for example) that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceId")
+    String targetResourceId;
+
+    /**
+     * The private IP address of the target resource that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePrivateIpAddress")
+    String targetResourcePrivateIpAddress;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreateSessionDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreateSessionDetails.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * The configuration details for a new bastion session. A session lets authorized users connect to a target resource for a predetermined amount of time. The Bastion service recognizes two types of sessions, managed SSH sessions and SSH port forwarding sessions. Managed SSH sessions require that the target resource has an OpenSSH server and the Oracle Cloud Agent both running.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateSessionDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateSessionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionId")
+        private String bastionId;
+
+        public Builder bastionId(String bastionId) {
+            this.bastionId = bastionId;
+            this.__explicitlySet__.add("bastionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDetails")
+        private CreateSessionTargetResourceDetails targetResourceDetails;
+
+        public Builder targetResourceDetails(
+                CreateSessionTargetResourceDetails targetResourceDetails) {
+            this.targetResourceDetails = targetResourceDetails;
+            this.__explicitlySet__.add("targetResourceDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keyType")
+        private KeyType keyType;
+
+        public Builder keyType(KeyType keyType) {
+            this.keyType = keyType;
+            this.__explicitlySet__.add("keyType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keyDetails")
+        private PublicKeyDetails keyDetails;
+
+        public Builder keyDetails(PublicKeyDetails keyDetails) {
+            this.keyDetails = keyDetails;
+            this.__explicitlySet__.add("keyDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sessionTtlInSeconds")
+        private Integer sessionTtlInSeconds;
+
+        public Builder sessionTtlInSeconds(Integer sessionTtlInSeconds) {
+            this.sessionTtlInSeconds = sessionTtlInSeconds;
+            this.__explicitlySet__.add("sessionTtlInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateSessionDetails build() {
+            CreateSessionDetails __instance__ =
+                    new CreateSessionDetails(
+                            displayName,
+                            bastionId,
+                            targetResourceDetails,
+                            keyType,
+                            keyDetails,
+                            sessionTtlInSeconds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateSessionDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .bastionId(o.getBastionId())
+                            .targetResourceDetails(o.getTargetResourceDetails())
+                            .keyType(o.getKeyType())
+                            .keyDetails(o.getKeyDetails())
+                            .sessionTtlInSeconds(o.getSessionTtlInSeconds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The unique identifier (OCID) of the bastion on which to create this session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionId")
+    String bastionId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDetails")
+    CreateSessionTargetResourceDetails targetResourceDetails;
+    /**
+     * The type of the key used to connect to the session. PUB is a standard public key in OpenSSH format.
+     **/
+    public enum KeyType {
+        Pub("PUB"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, KeyType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (KeyType v : KeyType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        KeyType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static KeyType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid KeyType: " + key);
+        }
+    };
+    /**
+     * The type of the key used to connect to the session. PUB is a standard public key in OpenSSH format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("keyType")
+    KeyType keyType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("keyDetails")
+    PublicKeyDetails keyDetails;
+
+    /**
+     * The amount of time the session can remain active.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sessionTtlInSeconds")
+    Integer sessionTtlInSeconds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreateSessionTargetResourceDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/CreateSessionTargetResourceDetails.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Details about a bastion session's target resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sessionType",
+    defaultImpl = CreateSessionTargetResourceDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateManagedSshSessionTargetResourceDetails.class,
+        name = "MANAGED_SSH"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreatePortForwardingSessionTargetResourceDetails.class,
+        name = "PORT_FORWARDING"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateSessionTargetResourceDetails {
+
+    /**
+     * The port number to connect to on the target resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePort")
+    Integer targetResourcePort;
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/ManagedSshSessionTargetResourceDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/ManagedSshSessionTargetResourceDetails.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Details about a managed SSH session for a target resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ManagedSshSessionTargetResourceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sessionType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ManagedSshSessionTargetResourceDetails extends TargetResourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePort")
+        private Integer targetResourcePort;
+
+        public Builder targetResourcePort(Integer targetResourcePort) {
+            this.targetResourcePort = targetResourcePort;
+            this.__explicitlySet__.add("targetResourcePort");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceOperatingSystemUserName")
+        private String targetResourceOperatingSystemUserName;
+
+        public Builder targetResourceOperatingSystemUserName(
+                String targetResourceOperatingSystemUserName) {
+            this.targetResourceOperatingSystemUserName = targetResourceOperatingSystemUserName;
+            this.__explicitlySet__.add("targetResourceOperatingSystemUserName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceId")
+        private String targetResourceId;
+
+        public Builder targetResourceId(String targetResourceId) {
+            this.targetResourceId = targetResourceId;
+            this.__explicitlySet__.add("targetResourceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePrivateIpAddress")
+        private String targetResourcePrivateIpAddress;
+
+        public Builder targetResourcePrivateIpAddress(String targetResourcePrivateIpAddress) {
+            this.targetResourcePrivateIpAddress = targetResourcePrivateIpAddress;
+            this.__explicitlySet__.add("targetResourcePrivateIpAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDisplayName")
+        private String targetResourceDisplayName;
+
+        public Builder targetResourceDisplayName(String targetResourceDisplayName) {
+            this.targetResourceDisplayName = targetResourceDisplayName;
+            this.__explicitlySet__.add("targetResourceDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ManagedSshSessionTargetResourceDetails build() {
+            ManagedSshSessionTargetResourceDetails __instance__ =
+                    new ManagedSshSessionTargetResourceDetails(
+                            targetResourcePort,
+                            targetResourceOperatingSystemUserName,
+                            targetResourceId,
+                            targetResourcePrivateIpAddress,
+                            targetResourceDisplayName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ManagedSshSessionTargetResourceDetails o) {
+            Builder copiedBuilder =
+                    targetResourcePort(o.getTargetResourcePort())
+                            .targetResourceOperatingSystemUserName(
+                                    o.getTargetResourceOperatingSystemUserName())
+                            .targetResourceId(o.getTargetResourceId())
+                            .targetResourcePrivateIpAddress(o.getTargetResourcePrivateIpAddress())
+                            .targetResourceDisplayName(o.getTargetResourceDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ManagedSshSessionTargetResourceDetails(
+            Integer targetResourcePort,
+            String targetResourceOperatingSystemUserName,
+            String targetResourceId,
+            String targetResourcePrivateIpAddress,
+            String targetResourceDisplayName) {
+        super(targetResourcePort);
+        this.targetResourceOperatingSystemUserName = targetResourceOperatingSystemUserName;
+        this.targetResourceId = targetResourceId;
+        this.targetResourcePrivateIpAddress = targetResourcePrivateIpAddress;
+        this.targetResourceDisplayName = targetResourceDisplayName;
+    }
+
+    /**
+     * The name of the user on the target resource operating system that the session uses for the connection.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceOperatingSystemUserName")
+    String targetResourceOperatingSystemUserName;
+
+    /**
+     * The unique identifier (OCID) of the target resource (a Compute instance, for example) that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceId")
+    String targetResourceId;
+
+    /**
+     * The private IP address of the target resource that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePrivateIpAddress")
+    String targetResourcePrivateIpAddress;
+
+    /**
+     * The display name of the target Compute instance that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDisplayName")
+    String targetResourceDisplayName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/OperationStatus.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/OperationStatus.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Possible operation status.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public enum OperationStatus {
+    Accepted("ACCEPTED"),
+    InProgress("IN_PROGRESS"),
+    Failed("FAILED"),
+    Succeeded("SUCCEEDED"),
+    Canceling("CANCELING"),
+    Canceled("CANCELED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, OperationStatus> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (OperationStatus v : OperationStatus.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    OperationStatus(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static OperationStatus create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'OperationStatus', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/OperationType.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/OperationType.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Possible operation types.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public enum OperationType {
+    CreateBastion("CREATE_BASTION"),
+    UpdateBastion("UPDATE_BASTION"),
+    DeleteBastion("DELETE_BASTION"),
+    CreateSession("CREATE_SESSION"),
+    DeleteSession("DELETE_SESSION"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, OperationType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (OperationType v : OperationType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    OperationType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static OperationType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'OperationType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/PortForwardingSessionTargetResourceDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/PortForwardingSessionTargetResourceDetails.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Details about a port forwarding session for a target resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PortForwardingSessionTargetResourceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sessionType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PortForwardingSessionTargetResourceDetails extends TargetResourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePort")
+        private Integer targetResourcePort;
+
+        public Builder targetResourcePort(Integer targetResourcePort) {
+            this.targetResourcePort = targetResourcePort;
+            this.__explicitlySet__.add("targetResourcePort");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceId")
+        private String targetResourceId;
+
+        public Builder targetResourceId(String targetResourceId) {
+            this.targetResourceId = targetResourceId;
+            this.__explicitlySet__.add("targetResourceId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePrivateIpAddress")
+        private String targetResourcePrivateIpAddress;
+
+        public Builder targetResourcePrivateIpAddress(String targetResourcePrivateIpAddress) {
+            this.targetResourcePrivateIpAddress = targetResourcePrivateIpAddress;
+            this.__explicitlySet__.add("targetResourcePrivateIpAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDisplayName")
+        private String targetResourceDisplayName;
+
+        public Builder targetResourceDisplayName(String targetResourceDisplayName) {
+            this.targetResourceDisplayName = targetResourceDisplayName;
+            this.__explicitlySet__.add("targetResourceDisplayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PortForwardingSessionTargetResourceDetails build() {
+            PortForwardingSessionTargetResourceDetails __instance__ =
+                    new PortForwardingSessionTargetResourceDetails(
+                            targetResourcePort,
+                            targetResourceId,
+                            targetResourcePrivateIpAddress,
+                            targetResourceDisplayName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PortForwardingSessionTargetResourceDetails o) {
+            Builder copiedBuilder =
+                    targetResourcePort(o.getTargetResourcePort())
+                            .targetResourceId(o.getTargetResourceId())
+                            .targetResourcePrivateIpAddress(o.getTargetResourcePrivateIpAddress())
+                            .targetResourceDisplayName(o.getTargetResourceDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PortForwardingSessionTargetResourceDetails(
+            Integer targetResourcePort,
+            String targetResourceId,
+            String targetResourcePrivateIpAddress,
+            String targetResourceDisplayName) {
+        super(targetResourcePort);
+        this.targetResourceId = targetResourceId;
+        this.targetResourcePrivateIpAddress = targetResourcePrivateIpAddress;
+        this.targetResourceDisplayName = targetResourceDisplayName;
+    }
+
+    /**
+     * The unique identifier (OCID) of the target resource (a Compute instance, for example) that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceId")
+    String targetResourceId;
+
+    /**
+     * The private IP address of the target resource that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePrivateIpAddress")
+    String targetResourcePrivateIpAddress;
+
+    /**
+     * The display name of the target Compute instance that the session connects to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDisplayName")
+    String targetResourceDisplayName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/PublicKeyDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/PublicKeyDetails.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Public key details for a bastion session.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PublicKeyDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PublicKeyDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("publicKeyContent")
+        private String publicKeyContent;
+
+        public Builder publicKeyContent(String publicKeyContent) {
+            this.publicKeyContent = publicKeyContent;
+            this.__explicitlySet__.add("publicKeyContent");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PublicKeyDetails build() {
+            PublicKeyDetails __instance__ = new PublicKeyDetails(publicKeyContent);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PublicKeyDetails o) {
+            Builder copiedBuilder = publicKeyContent(o.getPublicKeyContent());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The public key in OpenSSH format of the SSH key pair for the session. When you connect to the session, you must provide the private key of the same SSH key pair.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("publicKeyContent")
+    String publicKeyContent;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/Session.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/Session.java
@@ -1,0 +1,352 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * A bastion session resource. A bastion session lets authorized users connect to a target resource using a Secure Shell (SSH) for a predetermined amount of time.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Session.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Session {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionId")
+        private String bastionId;
+
+        public Builder bastionId(String bastionId) {
+            this.bastionId = bastionId;
+            this.__explicitlySet__.add("bastionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionName")
+        private String bastionName;
+
+        public Builder bastionName(String bastionName) {
+            this.bastionName = bastionName;
+            this.__explicitlySet__.add("bastionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionUserName")
+        private String bastionUserName;
+
+        public Builder bastionUserName(String bastionUserName) {
+            this.bastionUserName = bastionUserName;
+            this.__explicitlySet__.add("bastionUserName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDetails")
+        private TargetResourceDetails targetResourceDetails;
+
+        public Builder targetResourceDetails(TargetResourceDetails targetResourceDetails) {
+            this.targetResourceDetails = targetResourceDetails;
+            this.__explicitlySet__.add("targetResourceDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sshMetadata")
+        private java.util.Map<String, String> sshMetadata;
+
+        public Builder sshMetadata(java.util.Map<String, String> sshMetadata) {
+            this.sshMetadata = sshMetadata;
+            this.__explicitlySet__.add("sshMetadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keyType")
+        private KeyType keyType;
+
+        public Builder keyType(KeyType keyType) {
+            this.keyType = keyType;
+            this.__explicitlySet__.add("keyType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("keyDetails")
+        private PublicKeyDetails keyDetails;
+
+        public Builder keyDetails(PublicKeyDetails keyDetails) {
+            this.keyDetails = keyDetails;
+            this.__explicitlySet__.add("keyDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionPublicHostKeyInfo")
+        private String bastionPublicHostKeyInfo;
+
+        public Builder bastionPublicHostKeyInfo(String bastionPublicHostKeyInfo) {
+            this.bastionPublicHostKeyInfo = bastionPublicHostKeyInfo;
+            this.__explicitlySet__.add("bastionPublicHostKeyInfo");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private SessionLifecycleState lifecycleState;
+
+        public Builder lifecycleState(SessionLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sessionTtlInSeconds")
+        private Integer sessionTtlInSeconds;
+
+        public Builder sessionTtlInSeconds(Integer sessionTtlInSeconds) {
+            this.sessionTtlInSeconds = sessionTtlInSeconds;
+            this.__explicitlySet__.add("sessionTtlInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Session build() {
+            Session __instance__ =
+                    new Session(
+                            id,
+                            displayName,
+                            bastionId,
+                            bastionName,
+                            bastionUserName,
+                            targetResourceDetails,
+                            sshMetadata,
+                            keyType,
+                            keyDetails,
+                            bastionPublicHostKeyInfo,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            sessionTtlInSeconds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Session o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .bastionId(o.getBastionId())
+                            .bastionName(o.getBastionName())
+                            .bastionUserName(o.getBastionUserName())
+                            .targetResourceDetails(o.getTargetResourceDetails())
+                            .sshMetadata(o.getSshMetadata())
+                            .keyType(o.getKeyType())
+                            .keyDetails(o.getKeyDetails())
+                            .bastionPublicHostKeyInfo(o.getBastionPublicHostKeyInfo())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .sessionTtlInSeconds(o.getSessionTtlInSeconds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique identifier (OCID) of the session, which can't be changed after creation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The name of the session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The unique identifier (OCID) of the bastion that is hosting this session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionId")
+    String bastionId;
+
+    /**
+     * The name of the bastion that is hosting this session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionName")
+    String bastionName;
+
+    /**
+     * The username that the session uses to connect to the target resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionUserName")
+    String bastionUserName;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDetails")
+    TargetResourceDetails targetResourceDetails;
+
+    /**
+     * The connection message for the session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sshMetadata")
+    java.util.Map<String, String> sshMetadata;
+    /**
+     * The type of the key used to connect to the session. PUB is a standard public key in OpenSSH format.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum KeyType {
+        Pub("PUB"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, KeyType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (KeyType v : KeyType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        KeyType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static KeyType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'KeyType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The type of the key used to connect to the session. PUB is a standard public key in OpenSSH format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("keyType")
+    KeyType keyType;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("keyDetails")
+    PublicKeyDetails keyDetails;
+
+    /**
+     * The public key of the bastion host. You can use this to verify that you're connecting to the correct bastion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionPublicHostKeyInfo")
+    String bastionPublicHostKeyInfo;
+
+    /**
+     * The time the session was created. Format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2020-01-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the session was updated. Format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2020-01-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * The current state of the session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    SessionLifecycleState lifecycleState;
+
+    /**
+     * A message describing the current session state in more detail.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The amount of time the session can remain active.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sessionTtlInSeconds")
+    Integer sessionTtlInSeconds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/SessionLifecycleState.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/SessionLifecycleState.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Possible session lifecycle states.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public enum SessionLifecycleState {
+    Creating("CREATING"),
+    Active("ACTIVE"),
+    Deleting("DELETING"),
+    Deleted("DELETED"),
+    Failed("FAILED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, SessionLifecycleState> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (SessionLifecycleState v : SessionLifecycleState.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    SessionLifecycleState(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static SessionLifecycleState create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'SessionLifecycleState', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/SessionSummary.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/SessionSummary.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Summary information for a bastion session resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = SessionSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SessionSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionName")
+        private String bastionName;
+
+        public Builder bastionName(String bastionName) {
+            this.bastionName = bastionName;
+            this.__explicitlySet__.add("bastionName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bastionId")
+        private String bastionId;
+
+        public Builder bastionId(String bastionId) {
+            this.bastionId = bastionId;
+            this.__explicitlySet__.add("bastionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDetails")
+        private TargetResourceDetails targetResourceDetails;
+
+        public Builder targetResourceDetails(TargetResourceDetails targetResourceDetails) {
+            this.targetResourceDetails = targetResourceDetails;
+            this.__explicitlySet__.add("targetResourceDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private SessionLifecycleState lifecycleState;
+
+        public Builder lifecycleState(SessionLifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sessionTtlInSeconds")
+        private Integer sessionTtlInSeconds;
+
+        public Builder sessionTtlInSeconds(Integer sessionTtlInSeconds) {
+            this.sessionTtlInSeconds = sessionTtlInSeconds;
+            this.__explicitlySet__.add("sessionTtlInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SessionSummary build() {
+            SessionSummary __instance__ =
+                    new SessionSummary(
+                            id,
+                            displayName,
+                            bastionName,
+                            bastionId,
+                            targetResourceDetails,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleDetails,
+                            sessionTtlInSeconds);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SessionSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .bastionName(o.getBastionName())
+                            .bastionId(o.getBastionId())
+                            .targetResourceDetails(o.getTargetResourceDetails())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .sessionTtlInSeconds(o.getSessionTtlInSeconds());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The unique identifier (OCID) of the session, which can't be changed after creation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The name of the session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The name of the bastion that is hosting this session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionName")
+    String bastionName;
+
+    /**
+     * The unique identifier (OCID) of the bastion that is hosting this session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bastionId")
+    String bastionId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourceDetails")
+    TargetResourceDetails targetResourceDetails;
+
+    /**
+     * The time the session was created. Format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2020-01-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the session was updated. Format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * Example: `2020-01-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * The current state of the session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    SessionLifecycleState lifecycleState;
+
+    /**
+     * A message describing the current session state in more detail.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The amount of time the session can remain active.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sessionTtlInSeconds")
+    Integer sessionTtlInSeconds;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/SessionType.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/SessionType.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Possible session types.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.extern.slf4j.Slf4j
+public enum SessionType {
+    ManagedSsh("MANAGED_SSH"),
+    PortForwarding("PORT_FORWARDING"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, SessionType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (SessionType v : SessionType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    SessionType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static SessionType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'SessionType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/SortOrder.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/SortOrder.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Sort orders.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+public enum SortOrder {
+    Asc("ASC"),
+    Desc("DESC"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, SortOrder> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (SortOrder v : SortOrder.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    SortOrder(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static SortOrder create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid SortOrder: " + key);
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/TargetResourceDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/TargetResourceDetails.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * Details about a bastion session's target resource.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "sessionType",
+    defaultImpl = TargetResourceDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ManagedSshSessionTargetResourceDetails.class,
+        name = "MANAGED_SSH"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PortForwardingSessionTargetResourceDetails.class,
+        name = "PORT_FORWARDING"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TargetResourceDetails {
+
+    /**
+     * The port number to connect to on the target resource.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetResourcePort")
+    Integer targetResourcePort;
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/UpdateBastionDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/UpdateBastionDetails.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * The configuration to update on an existing bastion.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateBastionDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateBastionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("maxSessionTtlInSeconds")
+        private Integer maxSessionTtlInSeconds;
+
+        public Builder maxSessionTtlInSeconds(Integer maxSessionTtlInSeconds) {
+            this.maxSessionTtlInSeconds = maxSessionTtlInSeconds;
+            this.__explicitlySet__.add("maxSessionTtlInSeconds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("staticJumpHostIpAddresses")
+        private java.util.List<String> staticJumpHostIpAddresses;
+
+        public Builder staticJumpHostIpAddresses(java.util.List<String> staticJumpHostIpAddresses) {
+            this.staticJumpHostIpAddresses = staticJumpHostIpAddresses;
+            this.__explicitlySet__.add("staticJumpHostIpAddresses");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clientCidrBlockAllowList")
+        private java.util.List<String> clientCidrBlockAllowList;
+
+        public Builder clientCidrBlockAllowList(java.util.List<String> clientCidrBlockAllowList) {
+            this.clientCidrBlockAllowList = clientCidrBlockAllowList;
+            this.__explicitlySet__.add("clientCidrBlockAllowList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateBastionDetails build() {
+            UpdateBastionDetails __instance__ =
+                    new UpdateBastionDetails(
+                            maxSessionTtlInSeconds,
+                            staticJumpHostIpAddresses,
+                            clientCidrBlockAllowList,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateBastionDetails o) {
+            Builder copiedBuilder =
+                    maxSessionTtlInSeconds(o.getMaxSessionTtlInSeconds())
+                            .staticJumpHostIpAddresses(o.getStaticJumpHostIpAddresses())
+                            .clientCidrBlockAllowList(o.getClientCidrBlockAllowList())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The maximum amount of time that any session on the bastion can remain active.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxSessionTtlInSeconds")
+    Integer maxSessionTtlInSeconds;
+
+    /**
+     * A list of IP addresses of the hosts that the bastion has access to. Not applicable to `standard` bastions.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("staticJumpHostIpAddresses")
+    java.util.List<String> staticJumpHostIpAddresses;
+
+    /**
+     * A list of address ranges in CIDR notation that you want to allow to connect to sessions hosted by this bastion.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clientCidrBlockAllowList")
+    java.util.List<String> clientCidrBlockAllowList;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: `{\"bar-key\": \"value\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: `{\"foo-namespace\": {\"bar-key\": \"value\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/UpdateSessionDetails.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/UpdateSessionDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * The session information to be updated.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateSessionDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateSessionDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateSessionDetails build() {
+            UpdateSessionDetails __instance__ = new UpdateSessionDetails(displayName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateSessionDetails o) {
+            Builder copiedBuilder = displayName(o.getDisplayName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the session.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * A description of workrequest status.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = WorkRequest.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequest {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("operationType")
+        private OperationType operationType;
+
+        public Builder operationType(OperationType operationType) {
+            this.operationType = operationType;
+            this.__explicitlySet__.add("operationType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private OperationStatus status;
+
+        public Builder status(OperationStatus status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resources")
+        private java.util.List<WorkRequestResource> resources;
+
+        public Builder resources(java.util.List<WorkRequestResource> resources) {
+            this.resources = resources;
+            this.__explicitlySet__.add("resources");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
+        private Float percentComplete;
+
+        public Builder percentComplete(Float percentComplete) {
+            this.percentComplete = percentComplete;
+            this.__explicitlySet__.add("percentComplete");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
+        private java.util.Date timeAccepted;
+
+        public Builder timeAccepted(java.util.Date timeAccepted) {
+            this.timeAccepted = timeAccepted;
+            this.__explicitlySet__.add("timeAccepted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequest build() {
+            WorkRequest __instance__ =
+                    new WorkRequest(
+                            operationType,
+                            status,
+                            id,
+                            compartmentId,
+                            resources,
+                            percentComplete,
+                            timeAccepted,
+                            timeStarted,
+                            timeFinished);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequest o) {
+            Builder copiedBuilder =
+                    operationType(o.getOperationType())
+                            .status(o.getStatus())
+                            .id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .resources(o.getResources())
+                            .percentComplete(o.getPercentComplete())
+                            .timeAccepted(o.getTimeAccepted())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Type of the work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("operationType")
+    OperationType operationType;
+
+    /**
+     * Status of current work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    OperationStatus status;
+
+    /**
+     * The unique identifier (OCID) of the work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The ocid of the compartment that contains the work request. Work requests should be scoped to
+     * the same compartment as the resource the work request affects. If the work request affects multiple resources,
+     * and those resources are not in the same compartment, it is up to the service team to pick the primary
+     * resource whose compartment should be used
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The resources affected by this work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    java.util.List<WorkRequestResource> resources;
+
+    /**
+     * Percentage of the request completed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
+    Float percentComplete;
+
+    /**
+     * The date and time the request was created, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
+    java.util.Date timeAccepted;
+
+    /**
+     * The date and time the request was started, as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339),
+     * section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+    java.util.Date timeStarted;
+
+    /**
+     * The date and time the object was finished, as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+    java.util.Date timeFinished;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequestError.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequestError.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * An error encountered while executing a work request.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = WorkRequestError.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestError {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("code")
+        private String code;
+
+        public Builder code(String code) {
+            this.code = code;
+            this.__explicitlySet__.add("code");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("message")
+        private String message;
+
+        public Builder message(String message) {
+            this.message = message;
+            this.__explicitlySet__.add("message");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+        private java.util.Date timestamp;
+
+        public Builder timestamp(java.util.Date timestamp) {
+            this.timestamp = timestamp;
+            this.__explicitlySet__.add("timestamp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestError build() {
+            WorkRequestError __instance__ = new WorkRequestError(code, message, timestamp);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestError o) {
+            Builder copiedBuilder =
+                    code(o.getCode()).message(o.getMessage()).timestamp(o.getTimestamp());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A machine-usable code for the error that occurred. Error codes are listed on
+     * (https://docs.cloud.oracle.com/Content/API/References/apierrors.htm)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("code")
+    String code;
+
+    /**
+     * A human readable description of the issue encountered.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    String message;
+
+    /**
+     * The time the error occurred. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+    java.util.Date timestamp;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequestLogEntry.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequestLogEntry.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * A log message from the execution of a work request.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestLogEntry.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestLogEntry {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("message")
+        private String message;
+
+        public Builder message(String message) {
+            this.message = message;
+            this.__explicitlySet__.add("message");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+        private java.util.Date timestamp;
+
+        public Builder timestamp(java.util.Date timestamp) {
+            this.timestamp = timestamp;
+            this.__explicitlySet__.add("timestamp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestLogEntry build() {
+            WorkRequestLogEntry __instance__ = new WorkRequestLogEntry(message, timestamp);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestLogEntry o) {
+            Builder copiedBuilder = message(o.getMessage()).timestamp(o.getTimestamp());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Human-readable log message.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    String message;
+
+    /**
+     * The time the log message was written. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+    java.util.Date timestamp;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequestResource.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequestResource.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * A resource created or operated on by a work request.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestResource.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestResource {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("entityType")
+        private String entityType;
+
+        public Builder entityType(String entityType) {
+            this.entityType = entityType;
+            this.__explicitlySet__.add("entityType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("actionType")
+        private ActionType actionType;
+
+        public Builder actionType(ActionType actionType) {
+            this.actionType = actionType;
+            this.__explicitlySet__.add("actionType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("entityUri")
+        private String entityUri;
+
+        public Builder entityUri(String entityUri) {
+            this.entityUri = entityUri;
+            this.__explicitlySet__.add("entityUri");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestResource build() {
+            WorkRequestResource __instance__ =
+                    new WorkRequestResource(entityType, actionType, identifier, entityUri);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestResource o) {
+            Builder copiedBuilder =
+                    entityType(o.getEntityType())
+                            .actionType(o.getActionType())
+                            .identifier(o.getIdentifier())
+                            .entityUri(o.getEntityUri());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The resource type the work request affects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("entityType")
+    String entityType;
+
+    /**
+     * The way in which this resource is affected by the work tracked in the work request.
+     * A resource being created, updated, or deleted will remain in the IN_PROGRESS state until
+     * work is complete for that resource at which point it will transition to CREATED, UPDATED,
+     * or DELETED, respectively.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("actionType")
+    ActionType actionType;
+
+    /**
+     * The unique identifier (OCID) of the resource that the work request affects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * The URI path that the user can do a GET on to access the resource metadata.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("entityUri")
+    String entityUri;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequestSummary.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/model/WorkRequestSummary.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.model;
+
+/**
+ * A description of workrequest status.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("operationType")
+        private OperationType operationType;
+
+        public Builder operationType(OperationType operationType) {
+            this.operationType = operationType;
+            this.__explicitlySet__.add("operationType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private OperationStatus status;
+
+        public Builder status(OperationStatus status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resources")
+        private java.util.List<WorkRequestResource> resources;
+
+        public Builder resources(java.util.List<WorkRequestResource> resources) {
+            this.resources = resources;
+            this.__explicitlySet__.add("resources");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
+        private Float percentComplete;
+
+        public Builder percentComplete(Float percentComplete) {
+            this.percentComplete = percentComplete;
+            this.__explicitlySet__.add("percentComplete");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
+        private java.util.Date timeAccepted;
+
+        public Builder timeAccepted(java.util.Date timeAccepted) {
+            this.timeAccepted = timeAccepted;
+            this.__explicitlySet__.add("timeAccepted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestSummary build() {
+            WorkRequestSummary __instance__ =
+                    new WorkRequestSummary(
+                            operationType,
+                            status,
+                            id,
+                            compartmentId,
+                            resources,
+                            percentComplete,
+                            timeAccepted,
+                            timeStarted,
+                            timeFinished);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestSummary o) {
+            Builder copiedBuilder =
+                    operationType(o.getOperationType())
+                            .status(o.getStatus())
+                            .id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .resources(o.getResources())
+                            .percentComplete(o.getPercentComplete())
+                            .timeAccepted(o.getTimeAccepted())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Type of the work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("operationType")
+    OperationType operationType;
+
+    /**
+     * Status of current work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    OperationStatus status;
+
+    /**
+     * The unique identifier (OCID) of the work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The ocid of the compartment that contains the work request. Work requests should be scoped to
+     * the same compartment as the resource the work request affects. If the work request affects multiple resources,
+     * and those resources are not in the same compartment, it is up to the service team to pick the primary
+     * resource whose compartment should be used
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The resources affected by this work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    java.util.List<WorkRequestResource> resources;
+
+    /**
+     * Percentage of the request completed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
+    Float percentComplete;
+
+    /**
+     * The date and time the request was created, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
+    java.util.Date timeAccepted;
+
+    /**
+     * The date and time the request was started, as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339),
+     * section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+    java.util.Date timeStarted;
+
+    /**
+     * The date and time the object was finished, as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+    java.util.Date timeFinished;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ChangeBastionCompartmentRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ChangeBastionCompartmentRequest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ChangeBastionCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeBastionCompartmentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ChangeBastionCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeBastionCompartmentDetails> {
+
+    /**
+     * The unique identifier (OCID) of the bastion.
+     */
+    private String bastionId;
+
+    /**
+     * The compartment information to be updated.
+     */
+    private ChangeBastionCompartmentDetails changeBastionCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeBastionCompartmentDetails getBody$() {
+        return changeBastionCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeBastionCompartmentRequest, ChangeBastionCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeBastionCompartmentRequest o) {
+            bastionId(o.getBastionId());
+            changeBastionCompartmentDetails(o.getChangeBastionCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeBastionCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeBastionCompartmentRequest
+         */
+        public ChangeBastionCompartmentRequest build() {
+            ChangeBastionCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeBastionCompartmentDetails body) {
+            changeBastionCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/CreateBastionRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/CreateBastionRequest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/CreateBastionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateBastionRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateBastionRequest extends com.oracle.bmc.requests.BmcRequest<CreateBastionDetails> {
+
+    /**
+     * Details for the new bastion.
+     */
+    private CreateBastionDetails createBastionDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateBastionDetails getBody$() {
+        return createBastionDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateBastionRequest, CreateBastionDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateBastionRequest o) {
+            createBastionDetails(o.getCreateBastionDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateBastionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateBastionRequest
+         */
+        public CreateBastionRequest build() {
+            CreateBastionRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateBastionDetails body) {
+            createBastionDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/CreateSessionRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/CreateSessionRequest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/CreateSessionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateSessionRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateSessionRequest extends com.oracle.bmc.requests.BmcRequest<CreateSessionDetails> {
+
+    /**
+     * Details for the new session.
+     */
+    private CreateSessionDetails createSessionDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CreateSessionDetails getBody$() {
+        return createSessionDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateSessionRequest, CreateSessionDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateSessionRequest o) {
+            createSessionDetails(o.getCreateSessionDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateSessionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateSessionRequest
+         */
+        public CreateSessionRequest build() {
+            CreateSessionRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CreateSessionDetails body) {
+            createSessionDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/DeleteBastionRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/DeleteBastionRequest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/DeleteBastionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteBastionRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteBastionRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the bastion.
+     */
+    private String bastionId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteBastionRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteBastionRequest o) {
+            bastionId(o.getBastionId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteBastionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteBastionRequest
+         */
+        public DeleteBastionRequest build() {
+            DeleteBastionRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/DeleteSessionRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/DeleteSessionRequest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/DeleteSessionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteSessionRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteSessionRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the session.
+     */
+    private String sessionId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteSessionRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteSessionRequest o) {
+            sessionId(o.getSessionId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteSessionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteSessionRequest
+         */
+        public DeleteSessionRequest build() {
+            DeleteSessionRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/GetBastionRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/GetBastionRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/GetBastionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetBastionRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetBastionRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the bastion.
+     */
+    private String bastionId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetBastionRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetBastionRequest o) {
+            bastionId(o.getBastionId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetBastionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetBastionRequest
+         */
+        public GetBastionRequest build() {
+            GetBastionRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/GetSessionRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/GetSessionRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/GetSessionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetSessionRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetSessionRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the session.
+     */
+    private String sessionId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetSessionRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetSessionRequest o) {
+            sessionId(o.getSessionId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetSessionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetSessionRequest
+         */
+        public GetSessionRequest build() {
+            GetSessionRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/GetWorkRequestRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/GetWorkRequestRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetWorkRequestRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the asynchronous request.
+     */
+    private String workRequestId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetWorkRequestRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetWorkRequestRequest o) {
+            workRequestId(o.getWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetWorkRequestRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetWorkRequestRequest
+         */
+        public GetWorkRequestRequest build() {
+            GetWorkRequestRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListBastionsRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListBastionsRequest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListBastionsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListBastionsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListBastionsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A filter to return only resources their lifecycleState matches the given lifecycleState.
+     */
+    private com.oracle.bmc.bastion.model.BastionLifecycleState bastionLifecycleState;
+
+    /**
+     * The unique identifier (OCID) of the bastion in which to list resources.
+     */
+    private String bastionId;
+
+    /**
+     * A filter to return only resources that match the entire name given.
+     */
+    private String name;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     */
+    private com.oracle.bmc.bastion.model.SortOrder sortOrder;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for name is ascending. If no value is specified timeCreated is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for name is ascending. If no value is specified timeCreated is default.
+     *
+     **/
+    public enum SortBy {
+        TimeCreated("timeCreated"),
+        Name("name"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListBastionsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBastionsRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            bastionLifecycleState(o.getBastionLifecycleState());
+            bastionId(o.getBastionId());
+            name(o.getName());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListBastionsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListBastionsRequest
+         */
+        public ListBastionsRequest build() {
+            ListBastionsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListSessionsRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListSessionsRequest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListSessionsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListSessionsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListSessionsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the bastion in which to list sessions.
+     */
+    private String bastionId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A filter to return only resources that match the entire display name given.
+     */
+    private String displayName;
+
+    /**
+     * A filter to return only resources their lifecycleState matches the given lifecycleState.
+     */
+    private com.oracle.bmc.bastion.model.SessionLifecycleState sessionLifecycleState;
+
+    /**
+     * The unique identifier (OCID) of the session in which to list resources.
+     */
+    private String sessionId;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     */
+    private com.oracle.bmc.bastion.model.SortOrder sortOrder;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for displayName is ascending. If no value is specified timeCreated is default.
+     *
+     **/
+    public enum SortBy {
+        TimeCreated("timeCreated"),
+        DisplayName("displayName"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListSessionsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListSessionsRequest o) {
+            bastionId(o.getBastionId());
+            opcRequestId(o.getOpcRequestId());
+            displayName(o.getDisplayName());
+            sessionLifecycleState(o.getSessionLifecycleState());
+            sessionId(o.getSessionId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListSessionsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListSessionsRequest
+         */
+        public ListSessionsRequest build() {
+            ListSessionsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListWorkRequestErrorsRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListWorkRequestErrorsRequest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkRequestErrorsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkRequestErrorsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the asynchronous request.
+     */
+    private String workRequestId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListWorkRequestErrorsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestErrorsRequest o) {
+            workRequestId(o.getWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            page(o.getPage());
+            limit(o.getLimit());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListWorkRequestErrorsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListWorkRequestErrorsRequest
+         */
+        public ListWorkRequestErrorsRequest build() {
+            ListWorkRequestErrorsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListWorkRequestLogsRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListWorkRequestLogsRequest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkRequestLogsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the asynchronous request.
+     */
+    private String workRequestId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListWorkRequestLogsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestLogsRequest o) {
+            workRequestId(o.getWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            page(o.getPage());
+            limit(o.getLimit());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListWorkRequestLogsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListWorkRequestLogsRequest
+         */
+        public ListWorkRequestLogsRequest build() {
+            ListWorkRequestLogsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListWorkRequestsRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/ListWorkRequestsRequest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkRequestsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The unique identifier (OCID) of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListWorkRequestsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestsRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            page(o.getPage());
+            limit(o.getLimit());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListWorkRequestsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListWorkRequestsRequest
+         */
+        public ListWorkRequestsRequest build() {
+            ListWorkRequestsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/UpdateBastionRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/UpdateBastionRequest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/UpdateBastionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateBastionRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateBastionRequest extends com.oracle.bmc.requests.BmcRequest<UpdateBastionDetails> {
+
+    /**
+     * The unique identifier (OCID) of the bastion.
+     */
+    private String bastionId;
+
+    /**
+     * The bastion information to be updated.
+     */
+    private UpdateBastionDetails updateBastionDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateBastionDetails getBody$() {
+        return updateBastionDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateBastionRequest, UpdateBastionDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateBastionRequest o) {
+            bastionId(o.getBastionId());
+            updateBastionDetails(o.getUpdateBastionDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateBastionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateBastionRequest
+         */
+        public UpdateBastionRequest build() {
+            UpdateBastionRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateBastionDetails body) {
+            updateBastionDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/UpdateSessionRequest.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/requests/UpdateSessionRequest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.requests;
+
+import com.oracle.bmc.bastion.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/bastion/UpdateSessionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateSessionRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateSessionRequest extends com.oracle.bmc.requests.BmcRequest<UpdateSessionDetails> {
+
+    /**
+     * The unique identifier (OCID) of the session.
+     */
+    private String sessionId;
+
+    /**
+     * The session information to be updated.
+     */
+    private UpdateSessionDetails updateSessionDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public UpdateSessionDetails getBody$() {
+        return updateSessionDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateSessionRequest, UpdateSessionDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateSessionRequest o) {
+            sessionId(o.getSessionId());
+            updateSessionDetails(o.getUpdateSessionDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateSessionRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateSessionRequest
+         */
+        public UpdateSessionRequest build() {
+            UpdateSessionRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(UpdateSessionDetails body) {
+            updateSessionDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ChangeBastionCompartmentResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ChangeBastionCompartmentResponse.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ChangeBastionCompartmentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeBastionCompartmentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/CreateBastionResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/CreateBastionResponse.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class CreateBastionResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * this contains the full URI for the get request, e.g. \"https://iaas.us-phoenix-1.oraclecloud.com/20210331/bastions/<some-ocid>\"
+     *
+     */
+    private String location;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned Bastion instance.
+     */
+    private Bastion bastion;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateBastionResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            location(o.getLocation());
+            etag(o.getEtag());
+            bastion(o.getBastion());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/CreateSessionResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/CreateSessionResponse.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class CreateSessionResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * this contains the full URI for the get request, e.g. \"https://iaas.us-phoenix-1.oraclecloud.com/20210331/bastions/<some-ocid>\"
+     *
+     */
+    private String location;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned Session instance.
+     */
+    private Session session;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateSessionResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            location(o.getLocation());
+            etag(o.getEtag());
+            session(o.getSession());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/DeleteBastionResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/DeleteBastionResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class DeleteBastionResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteBastionResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/DeleteSessionResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/DeleteSessionResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class DeleteSessionResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteSessionResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/GetBastionResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/GetBastionResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetBastionResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Bastion instance.
+     */
+    private Bastion bastion;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetBastionResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            bastion(o.getBastion());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/GetSessionResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/GetSessionResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetSessionResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Session instance.
+     */
+    private Session session;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetSessionResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            session(o.getSession());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/GetWorkRequestResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/GetWorkRequestResponse.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetWorkRequestResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A decimal number representing the number of seconds the client should wait before polling this endpoint again.
+     */
+    private Float retryAfter;
+
+    /**
+     * The returned WorkRequest instance.
+     */
+    private WorkRequest workRequest;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetWorkRequestResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            retryAfter(o.getRetryAfter());
+            workRequest(o.getWorkRequest());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListBastionsResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListBastionsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListBastionsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of BastionSummary instances.
+     */
+    private java.util.List<BastionSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListBastionsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListSessionsResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListSessionsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListSessionsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of SessionSummary instances.
+     */
+    private java.util.List<SessionSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListSessionsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListWorkRequestErrorsResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListWorkRequestErrorsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListWorkRequestErrorsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of WorkRequestError instances.
+     */
+    private java.util.List<WorkRequestError> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestErrorsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListWorkRequestLogsResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListWorkRequestLogsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListWorkRequestLogsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of WorkRequestLogEntry instances.
+     */
+    private java.util.List<WorkRequestLogEntry> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestLogsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListWorkRequestsResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/ListWorkRequestsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListWorkRequestsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of WorkRequestSummary instances.
+     */
+    private java.util.List<WorkRequestSummary> items;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/UpdateBastionResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/UpdateBastionResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class UpdateBastionResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateBastionResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/UpdateSessionResponse.java
+++ b/bmc-bastion/src/main/java/com/oracle/bmc/bastion/responses/UpdateSessionResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.bastion.responses;
+
+import com.oracle.bmc.bastion.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210331")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class UpdateSessionResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Session instance.
+     */
+    private Session session;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateSessionResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            session(o.getSession());
+
+            return this;
+        }
+    }
+}

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,474 +19,486 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
+        <optional>false</optional>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle.oci.sdk</groupId>
+        <artifactId>oci-java-sdk-bastion</artifactId>
+        <version>1.37.0</version>
+        <optional>false</optional>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle.oci.sdk</groupId>
+        <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
+        <version>1.37.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-common/src/main/java/com/oracle/bmc/auth/AbstractFederationClientAuthenticationDetailsProviderBuilder.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/auth/AbstractFederationClientAuthenticationDetailsProviderBuilder.java
@@ -421,13 +421,14 @@ public abstract class AbstractFederationClientAuthenticationDetailsProviderBuild
             Function<WebTarget, T> retryOperation,
             final String metadataServiceUrl,
             final String endpoint) {
-        Client client = ClientBuilder.newClient();
-        WebTarget base = client.target(metadataServiceUrl + "instance/");
 
         final int MAX_RETRIES = 3;
         RuntimeException lastException = null;
+        Client client = null;
         for (int retry = 0; retry < MAX_RETRIES; retry++) {
             try {
+                client = ClientBuilder.newClient();
+                WebTarget base = client.target(metadataServiceUrl + "instance/");
                 return retryOperation.apply(base);
             } catch (RuntimeException e) {
                 LOG.warn(

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -22,11 +22,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -22,16 +22,17 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/Image.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/Image.java
@@ -169,6 +169,15 @@ public class Image {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("billableSizeInGBs")
+        private Long billableSizeInGBs;
+
+        public Builder billableSizeInGBs(Long billableSizeInGBs) {
+            this.billableSizeInGBs = billableSizeInGBs;
+            this.__explicitlySet__.add("billableSizeInGBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -199,6 +208,7 @@ public class Image {
                             agentFeatures,
                             listingType,
                             sizeInMBs,
+                            billableSizeInGBs,
                             timeCreated);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -222,6 +232,7 @@ public class Image {
                             .agentFeatures(o.getAgentFeatures())
                             .listingType(o.getListingType())
                             .sizeInMBs(o.getSizeInMBs())
+                            .billableSizeInGBs(o.getBillableSizeInGBs())
                             .timeCreated(o.getTimeCreated());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -496,6 +507,15 @@ public class Image {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sizeInMBs")
     Long sizeInMBs;
+
+    /**
+     * The size of the internal storage for this image that is subject to billing (1 GB = 1,073,741,824 bytes).
+     * <p>
+     * Example: `100`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("billableSizeInGBs")
+    Long billableSizeInGBs;
 
     /**
      * The date and time the image was created, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -22,16 +22,17 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/DbManagement.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/DbManagement.java
@@ -161,6 +161,28 @@ public interface DbManagement extends AutoCloseable {
             DeleteManagedDatabaseGroupRequest request);
 
     /**
+     * Gets the AWR report for the specified Managed Database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/GetAwrDbReportExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAwrDbReport API.
+     */
+    GetAwrDbReportResponse getAwrDbReport(GetAwrDbReportRequest request);
+
+    /**
+     * Get a AWR SQL report for one SQL.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/GetAwrDbSqlReportExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAwrDbSqlReport API.
+     */
+    GetAwrDbSqlReportResponse getAwrDbSqlReport(GetAwrDbSqlReportRequest request);
+
+    /**
      * Gets the metrics related to cluster cache for the Oracle
      * Real Application Clusters (Oracle RAC) database specified
      * by managedDatabaseId.
@@ -250,6 +272,28 @@ public interface DbManagement extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/GetManagedDatabaseGroupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetManagedDatabaseGroup API.
      */
     GetManagedDatabaseGroupResponse getManagedDatabaseGroup(GetManagedDatabaseGroupRequest request);
+
+    /**
+     * Lists AWR snapshots for the specified database in the AWR.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/ListAwrDbSnapshotsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAwrDbSnapshots API.
+     */
+    ListAwrDbSnapshotsResponse listAwrDbSnapshots(ListAwrDbSnapshotsRequest request);
+
+    /**
+     * Gets the list of databases and their snapshot summary details available in the AWR of the specified Managed Database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/ListAwrDbsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListAwrDbs API.
+     */
+    ListAwrDbsResponse listAwrDbs(ListAwrDbsRequest request);
 
     /**
      * Gets the list of database parameters for the specified Managed Database. The parameters are listed in alphabetical order, along with their current values.
@@ -368,6 +412,123 @@ public interface DbManagement extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/ResetDatabaseParametersExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ResetDatabaseParameters API.
      */
     ResetDatabaseParametersResponse resetDatabaseParameters(ResetDatabaseParametersRequest request);
+
+    /**
+     * Summarizes the AWR CPU resource limits and metrics for the specified database in AWR.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbCpuUsagesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAwrDbCpuUsages API.
+     */
+    SummarizeAwrDbCpuUsagesResponse summarizeAwrDbCpuUsages(SummarizeAwrDbCpuUsagesRequest request);
+
+    /**
+     * Summarizes the metric samples for the specified database in the AWR. The metric samples are summarized based on the Time dimension for each metric.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbMetricsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAwrDbMetrics API.
+     */
+    SummarizeAwrDbMetricsResponse summarizeAwrDbMetrics(SummarizeAwrDbMetricsRequest request);
+
+    /**
+     * Summarizes the AWR database parameter change history for one database parameter of the specified Managed Database. One change history record contains
+     * the previous value, the changed value, and the corresponding time range. If the database parameter value was changed multiple times within the time range, then multiple change history records are created for the same parameter.
+     * Note that this API only returns information on change history details for one database parameter.
+     * To get a list of all the database parameters whose values were changed during a specified time range, use the following API endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbParameters
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbParameterChangesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAwrDbParameterChanges API.
+     */
+    SummarizeAwrDbParameterChangesResponse summarizeAwrDbParameterChanges(
+            SummarizeAwrDbParameterChangesRequest request);
+
+    /**
+     * Summarizes the AWR database parameter history for the specified Managed Database. This includes the list of database
+     * parameters, with information on whether the parameter values were modified within the query time range. Note that
+     * each database parameter is only listed once. The returned summary gets all the database parameters, which include:
+     *  -Each parameter whose value was changed during the time range: AwrDbParameterValueOptionalQueryParam (valueChanged =\"Y\")
+     *  -Each parameter whose value was unchanged during the time range: AwrDbParameterValueOptionalQueryParam (valueChanged =\"N\")
+     *  -Each parameter whose value was changed at the system level during the time range: (valueChanged =\"Y\"  and valueModified = \"SYSTEM_MOD\").
+     *  -Each parameter whose value was unchanged during the time range, however, the value is not the default value: (valueChanged =\"N\" and  valueDefault = \"FALSE\")
+     * Note that this API does not return information on the number of times each database parameter has been changed within the time range. To get the database parameter value change history for a specific parameter, use the following API endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbParameterChanges
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbParametersExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAwrDbParameters API.
+     */
+    SummarizeAwrDbParametersResponse summarizeAwrDbParameters(
+            SummarizeAwrDbParametersRequest request);
+
+    /**
+     * Summarizes the AWR snapshot ranges that contain continuous snapshots, for the specified Managed Database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbSnapshotRangesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAwrDbSnapshotRanges API.
+     */
+    SummarizeAwrDbSnapshotRangesResponse summarizeAwrDbSnapshotRanges(
+            SummarizeAwrDbSnapshotRangesRequest request);
+
+    /**
+     * Summarizes the AWR SYSSTAT sample data for the specified database in AWR. The statistical data is summarized based on the Time dimension for each statistic.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbSysstatsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAwrDbSysstats API.
+     */
+    SummarizeAwrDbSysstatsResponse summarizeAwrDbSysstats(SummarizeAwrDbSysstatsRequest request);
+
+    /**
+     * Summarizes the AWR top wait events.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbTopWaitEventsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAwrDbTopWaitEvents API.
+     */
+    SummarizeAwrDbTopWaitEventsResponse summarizeAwrDbTopWaitEvents(
+            SummarizeAwrDbTopWaitEventsRequest request);
+
+    /**
+     * Summarizes AWR wait event data into value buckets and frequency, for the specified database in the AWR.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbWaitEventBucketsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAwrDbWaitEventBuckets API.
+     */
+    SummarizeAwrDbWaitEventBucketsResponse summarizeAwrDbWaitEventBuckets(
+            SummarizeAwrDbWaitEventBucketsRequest request);
+
+    /**
+     * Summarizes the AWR wait event sample data for the specified database in the AWR. The event data is summarized based on the Time dimension for each event.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbWaitEventsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SummarizeAwrDbWaitEvents API.
+     */
+    SummarizeAwrDbWaitEventsResponse summarizeAwrDbWaitEvents(
+            SummarizeAwrDbWaitEventsRequest request);
 
     /**
      * Updates the Managed Database Group specified by managedDatabaseGroupId.

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/DbManagementAsync.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/DbManagementAsync.java
@@ -204,6 +204,39 @@ public interface DbManagementAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets the AWR report for the specified Managed Database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetAwrDbReportResponse> getAwrDbReport(
+            GetAwrDbReportRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetAwrDbReportRequest, GetAwrDbReportResponse>
+                    handler);
+
+    /**
+     * Get a AWR SQL report for one SQL.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetAwrDbSqlReportResponse> getAwrDbSqlReport(
+            GetAwrDbSqlReportRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetAwrDbSqlReportRequest, GetAwrDbSqlReportResponse>
+                    handler);
+
+    /**
      * Gets the metrics related to cluster cache for the Oracle
      * Real Application Clusters (Oracle RAC) database specified
      * by managedDatabaseId.
@@ -337,6 +370,38 @@ public interface DbManagementAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             GetManagedDatabaseGroupRequest, GetManagedDatabaseGroupResponse>
                     handler);
+
+    /**
+     * Lists AWR snapshots for the specified database in the AWR.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListAwrDbSnapshotsResponse> listAwrDbSnapshots(
+            ListAwrDbSnapshotsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListAwrDbSnapshotsRequest, ListAwrDbSnapshotsResponse>
+                    handler);
+
+    /**
+     * Gets the list of databases and their snapshot summary details available in the AWR of the specified Managed Database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListAwrDbsResponse> listAwrDbs(
+            ListAwrDbsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListAwrDbsRequest, ListAwrDbsResponse> handler);
 
     /**
      * Gets the list of database parameters for the specified Managed Database. The parameters are listed in alphabetical order, along with their current values.
@@ -502,6 +567,176 @@ public interface DbManagementAsync extends AutoCloseable {
             ResetDatabaseParametersRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ResetDatabaseParametersRequest, ResetDatabaseParametersResponse>
+                    handler);
+
+    /**
+     * Summarizes the AWR CPU resource limits and metrics for the specified database in AWR.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeAwrDbCpuUsagesResponse> summarizeAwrDbCpuUsages(
+            SummarizeAwrDbCpuUsagesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbCpuUsagesRequest, SummarizeAwrDbCpuUsagesResponse>
+                    handler);
+
+    /**
+     * Summarizes the metric samples for the specified database in the AWR. The metric samples are summarized based on the Time dimension for each metric.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeAwrDbMetricsResponse> summarizeAwrDbMetrics(
+            SummarizeAwrDbMetricsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbMetricsRequest, SummarizeAwrDbMetricsResponse>
+                    handler);
+
+    /**
+     * Summarizes the AWR database parameter change history for one database parameter of the specified Managed Database. One change history record contains
+     * the previous value, the changed value, and the corresponding time range. If the database parameter value was changed multiple times within the time range, then multiple change history records are created for the same parameter.
+     * Note that this API only returns information on change history details for one database parameter.
+     * To get a list of all the database parameters whose values were changed during a specified time range, use the following API endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbParameters
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeAwrDbParameterChangesResponse>
+            summarizeAwrDbParameterChanges(
+                    SummarizeAwrDbParameterChangesRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    SummarizeAwrDbParameterChangesRequest,
+                                    SummarizeAwrDbParameterChangesResponse>
+                            handler);
+
+    /**
+     * Summarizes the AWR database parameter history for the specified Managed Database. This includes the list of database
+     * parameters, with information on whether the parameter values were modified within the query time range. Note that
+     * each database parameter is only listed once. The returned summary gets all the database parameters, which include:
+     *  -Each parameter whose value was changed during the time range: AwrDbParameterValueOptionalQueryParam (valueChanged =\"Y\")
+     *  -Each parameter whose value was unchanged during the time range: AwrDbParameterValueOptionalQueryParam (valueChanged =\"N\")
+     *  -Each parameter whose value was changed at the system level during the time range: (valueChanged =\"Y\"  and valueModified = \"SYSTEM_MOD\").
+     *  -Each parameter whose value was unchanged during the time range, however, the value is not the default value: (valueChanged =\"N\" and  valueDefault = \"FALSE\")
+     * Note that this API does not return information on the number of times each database parameter has been changed within the time range. To get the database parameter value change history for a specific parameter, use the following API endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbParameterChanges
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeAwrDbParametersResponse> summarizeAwrDbParameters(
+            SummarizeAwrDbParametersRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbParametersRequest, SummarizeAwrDbParametersResponse>
+                    handler);
+
+    /**
+     * Summarizes the AWR snapshot ranges that contain continuous snapshots, for the specified Managed Database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeAwrDbSnapshotRangesResponse> summarizeAwrDbSnapshotRanges(
+            SummarizeAwrDbSnapshotRangesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbSnapshotRangesRequest,
+                            SummarizeAwrDbSnapshotRangesResponse>
+                    handler);
+
+    /**
+     * Summarizes the AWR SYSSTAT sample data for the specified database in AWR. The statistical data is summarized based on the Time dimension for each statistic.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeAwrDbSysstatsResponse> summarizeAwrDbSysstats(
+            SummarizeAwrDbSysstatsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbSysstatsRequest, SummarizeAwrDbSysstatsResponse>
+                    handler);
+
+    /**
+     * Summarizes the AWR top wait events.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeAwrDbTopWaitEventsResponse> summarizeAwrDbTopWaitEvents(
+            SummarizeAwrDbTopWaitEventsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbTopWaitEventsRequest, SummarizeAwrDbTopWaitEventsResponse>
+                    handler);
+
+    /**
+     * Summarizes AWR wait event data into value buckets and frequency, for the specified database in the AWR.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeAwrDbWaitEventBucketsResponse>
+            summarizeAwrDbWaitEventBuckets(
+                    SummarizeAwrDbWaitEventBucketsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    SummarizeAwrDbWaitEventBucketsRequest,
+                                    SummarizeAwrDbWaitEventBucketsResponse>
+                            handler);
+
+    /**
+     * Summarizes the AWR wait event sample data for the specified database in the AWR. The event data is summarized based on the Time dimension for each event.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SummarizeAwrDbWaitEventsResponse> summarizeAwrDbWaitEvents(
+            SummarizeAwrDbWaitEventsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbWaitEventsRequest, SummarizeAwrDbWaitEventsResponse>
                     handler);
 
     /**

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/DbManagementAsyncClient.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/DbManagementAsyncClient.java
@@ -706,6 +706,86 @@ public class DbManagementAsyncClient implements DbManagementAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetAwrDbReportResponse> getAwrDbReport(
+            GetAwrDbReportRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetAwrDbReportRequest, GetAwrDbReportResponse>
+                    handler) {
+        LOG.trace("Called async getAwrDbReport");
+        final GetAwrDbReportRequest interceptedRequest =
+                GetAwrDbReportConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAwrDbReportConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetAwrDbReportResponse>
+                transformer = GetAwrDbReportConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<GetAwrDbReportRequest, GetAwrDbReportResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetAwrDbReportRequest, GetAwrDbReportResponse>,
+                        java.util.concurrent.Future<GetAwrDbReportResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetAwrDbReportRequest, GetAwrDbReportResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetAwrDbSqlReportResponse> getAwrDbSqlReport(
+            GetAwrDbSqlReportRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetAwrDbSqlReportRequest, GetAwrDbSqlReportResponse>
+                    handler) {
+        LOG.trace("Called async getAwrDbSqlReport");
+        final GetAwrDbSqlReportRequest interceptedRequest =
+                GetAwrDbSqlReportConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAwrDbSqlReportConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetAwrDbSqlReportResponse>
+                transformer = GetAwrDbSqlReportConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<GetAwrDbSqlReportRequest, GetAwrDbSqlReportResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetAwrDbSqlReportRequest, GetAwrDbSqlReportResponse>,
+                        java.util.concurrent.Future<GetAwrDbSqlReportResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetAwrDbSqlReportRequest, GetAwrDbSqlReportResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetClusterCacheMetricResponse> getClusterCacheMetric(
             GetClusterCacheMetricRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -1008,6 +1088,84 @@ public class DbManagementAsyncClient implements DbManagementAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetManagedDatabaseGroupRequest, GetManagedDatabaseGroupResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListAwrDbSnapshotsResponse> listAwrDbSnapshots(
+            ListAwrDbSnapshotsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListAwrDbSnapshotsRequest, ListAwrDbSnapshotsResponse>
+                    handler) {
+        LOG.trace("Called async listAwrDbSnapshots");
+        final ListAwrDbSnapshotsRequest interceptedRequest =
+                ListAwrDbSnapshotsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAwrDbSnapshotsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListAwrDbSnapshotsResponse>
+                transformer = ListAwrDbSnapshotsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<ListAwrDbSnapshotsRequest, ListAwrDbSnapshotsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListAwrDbSnapshotsRequest, ListAwrDbSnapshotsResponse>,
+                        java.util.concurrent.Future<ListAwrDbSnapshotsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListAwrDbSnapshotsRequest, ListAwrDbSnapshotsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListAwrDbsResponse> listAwrDbs(
+            ListAwrDbsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListAwrDbsRequest, ListAwrDbsResponse>
+                    handler) {
+        LOG.trace("Called async listAwrDbs");
+        final ListAwrDbsRequest interceptedRequest = ListAwrDbsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAwrDbsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListAwrDbsResponse>
+                transformer = ListAwrDbsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<ListAwrDbsRequest, ListAwrDbsResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListAwrDbsRequest, ListAwrDbsResponse>,
+                        java.util.concurrent.Future<ListAwrDbsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListAwrDbsRequest, ListAwrDbsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1376,6 +1534,398 @@ public class DbManagementAsyncClient implements DbManagementAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ResetDatabaseParametersRequest, ResetDatabaseParametersResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SummarizeAwrDbCpuUsagesResponse> summarizeAwrDbCpuUsages(
+            SummarizeAwrDbCpuUsagesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbCpuUsagesRequest, SummarizeAwrDbCpuUsagesResponse>
+                    handler) {
+        LOG.trace("Called async summarizeAwrDbCpuUsages");
+        final SummarizeAwrDbCpuUsagesRequest interceptedRequest =
+                SummarizeAwrDbCpuUsagesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbCpuUsagesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbCpuUsagesResponse>
+                transformer = SummarizeAwrDbCpuUsagesConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeAwrDbCpuUsagesRequest, SummarizeAwrDbCpuUsagesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeAwrDbCpuUsagesRequest, SummarizeAwrDbCpuUsagesResponse>,
+                        java.util.concurrent.Future<SummarizeAwrDbCpuUsagesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeAwrDbCpuUsagesRequest, SummarizeAwrDbCpuUsagesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SummarizeAwrDbMetricsResponse> summarizeAwrDbMetrics(
+            SummarizeAwrDbMetricsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbMetricsRequest, SummarizeAwrDbMetricsResponse>
+                    handler) {
+        LOG.trace("Called async summarizeAwrDbMetrics");
+        final SummarizeAwrDbMetricsRequest interceptedRequest =
+                SummarizeAwrDbMetricsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbMetricsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbMetricsResponse>
+                transformer = SummarizeAwrDbMetricsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeAwrDbMetricsRequest, SummarizeAwrDbMetricsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeAwrDbMetricsRequest, SummarizeAwrDbMetricsResponse>,
+                        java.util.concurrent.Future<SummarizeAwrDbMetricsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeAwrDbMetricsRequest, SummarizeAwrDbMetricsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SummarizeAwrDbParameterChangesResponse>
+            summarizeAwrDbParameterChanges(
+                    SummarizeAwrDbParameterChangesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    SummarizeAwrDbParameterChangesRequest,
+                                    SummarizeAwrDbParameterChangesResponse>
+                            handler) {
+        LOG.trace("Called async summarizeAwrDbParameterChanges");
+        final SummarizeAwrDbParameterChangesRequest interceptedRequest =
+                SummarizeAwrDbParameterChangesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbParameterChangesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbParameterChangesResponse>
+                transformer = SummarizeAwrDbParameterChangesConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeAwrDbParameterChangesRequest,
+                        SummarizeAwrDbParameterChangesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeAwrDbParameterChangesRequest,
+                                SummarizeAwrDbParameterChangesResponse>,
+                        java.util.concurrent.Future<SummarizeAwrDbParameterChangesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeAwrDbParameterChangesRequest, SummarizeAwrDbParameterChangesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SummarizeAwrDbParametersResponse> summarizeAwrDbParameters(
+            SummarizeAwrDbParametersRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbParametersRequest, SummarizeAwrDbParametersResponse>
+                    handler) {
+        LOG.trace("Called async summarizeAwrDbParameters");
+        final SummarizeAwrDbParametersRequest interceptedRequest =
+                SummarizeAwrDbParametersConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbParametersConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbParametersResponse>
+                transformer = SummarizeAwrDbParametersConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeAwrDbParametersRequest, SummarizeAwrDbParametersResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeAwrDbParametersRequest, SummarizeAwrDbParametersResponse>,
+                        java.util.concurrent.Future<SummarizeAwrDbParametersResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeAwrDbParametersRequest, SummarizeAwrDbParametersResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SummarizeAwrDbSnapshotRangesResponse>
+            summarizeAwrDbSnapshotRanges(
+                    SummarizeAwrDbSnapshotRangesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    SummarizeAwrDbSnapshotRangesRequest,
+                                    SummarizeAwrDbSnapshotRangesResponse>
+                            handler) {
+        LOG.trace("Called async summarizeAwrDbSnapshotRanges");
+        final SummarizeAwrDbSnapshotRangesRequest interceptedRequest =
+                SummarizeAwrDbSnapshotRangesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbSnapshotRangesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbSnapshotRangesResponse>
+                transformer = SummarizeAwrDbSnapshotRangesConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeAwrDbSnapshotRangesRequest, SummarizeAwrDbSnapshotRangesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeAwrDbSnapshotRangesRequest,
+                                SummarizeAwrDbSnapshotRangesResponse>,
+                        java.util.concurrent.Future<SummarizeAwrDbSnapshotRangesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeAwrDbSnapshotRangesRequest, SummarizeAwrDbSnapshotRangesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SummarizeAwrDbSysstatsResponse> summarizeAwrDbSysstats(
+            SummarizeAwrDbSysstatsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbSysstatsRequest, SummarizeAwrDbSysstatsResponse>
+                    handler) {
+        LOG.trace("Called async summarizeAwrDbSysstats");
+        final SummarizeAwrDbSysstatsRequest interceptedRequest =
+                SummarizeAwrDbSysstatsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbSysstatsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbSysstatsResponse>
+                transformer = SummarizeAwrDbSysstatsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeAwrDbSysstatsRequest, SummarizeAwrDbSysstatsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeAwrDbSysstatsRequest, SummarizeAwrDbSysstatsResponse>,
+                        java.util.concurrent.Future<SummarizeAwrDbSysstatsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeAwrDbSysstatsRequest, SummarizeAwrDbSysstatsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SummarizeAwrDbTopWaitEventsResponse>
+            summarizeAwrDbTopWaitEvents(
+                    SummarizeAwrDbTopWaitEventsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    SummarizeAwrDbTopWaitEventsRequest,
+                                    SummarizeAwrDbTopWaitEventsResponse>
+                            handler) {
+        LOG.trace("Called async summarizeAwrDbTopWaitEvents");
+        final SummarizeAwrDbTopWaitEventsRequest interceptedRequest =
+                SummarizeAwrDbTopWaitEventsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbTopWaitEventsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbTopWaitEventsResponse>
+                transformer = SummarizeAwrDbTopWaitEventsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeAwrDbTopWaitEventsRequest, SummarizeAwrDbTopWaitEventsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeAwrDbTopWaitEventsRequest,
+                                SummarizeAwrDbTopWaitEventsResponse>,
+                        java.util.concurrent.Future<SummarizeAwrDbTopWaitEventsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeAwrDbTopWaitEventsRequest, SummarizeAwrDbTopWaitEventsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SummarizeAwrDbWaitEventBucketsResponse>
+            summarizeAwrDbWaitEventBuckets(
+                    SummarizeAwrDbWaitEventBucketsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    SummarizeAwrDbWaitEventBucketsRequest,
+                                    SummarizeAwrDbWaitEventBucketsResponse>
+                            handler) {
+        LOG.trace("Called async summarizeAwrDbWaitEventBuckets");
+        final SummarizeAwrDbWaitEventBucketsRequest interceptedRequest =
+                SummarizeAwrDbWaitEventBucketsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbWaitEventBucketsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbWaitEventBucketsResponse>
+                transformer = SummarizeAwrDbWaitEventBucketsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeAwrDbWaitEventBucketsRequest,
+                        SummarizeAwrDbWaitEventBucketsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeAwrDbWaitEventBucketsRequest,
+                                SummarizeAwrDbWaitEventBucketsResponse>,
+                        java.util.concurrent.Future<SummarizeAwrDbWaitEventBucketsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeAwrDbWaitEventBucketsRequest, SummarizeAwrDbWaitEventBucketsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SummarizeAwrDbWaitEventsResponse> summarizeAwrDbWaitEvents(
+            SummarizeAwrDbWaitEventsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            SummarizeAwrDbWaitEventsRequest, SummarizeAwrDbWaitEventsResponse>
+                    handler) {
+        LOG.trace("Called async summarizeAwrDbWaitEvents");
+        final SummarizeAwrDbWaitEventsRequest interceptedRequest =
+                SummarizeAwrDbWaitEventsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbWaitEventsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbWaitEventsResponse>
+                transformer = SummarizeAwrDbWaitEventsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SummarizeAwrDbWaitEventsRequest, SummarizeAwrDbWaitEventsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SummarizeAwrDbWaitEventsRequest, SummarizeAwrDbWaitEventsResponse>,
+                        java.util.concurrent.Future<SummarizeAwrDbWaitEventsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SummarizeAwrDbWaitEventsRequest, SummarizeAwrDbWaitEventsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/DbManagementClient.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/DbManagementClient.java
@@ -710,6 +710,64 @@ public class DbManagementClient implements DbManagement {
     }
 
     @Override
+    public GetAwrDbReportResponse getAwrDbReport(GetAwrDbReportRequest request) {
+        LOG.trace("Called getAwrDbReport");
+        final GetAwrDbReportRequest interceptedRequest =
+                GetAwrDbReportConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAwrDbReportConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetAwrDbReportResponse>
+                transformer = GetAwrDbReportConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetAwrDbSqlReportResponse getAwrDbSqlReport(GetAwrDbSqlReportRequest request) {
+        LOG.trace("Called getAwrDbSqlReport");
+        final GetAwrDbSqlReportRequest interceptedRequest =
+                GetAwrDbSqlReportConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAwrDbSqlReportConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetAwrDbSqlReportResponse>
+                transformer = GetAwrDbSqlReportConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetClusterCacheMetricResponse getClusterCacheMetric(
             GetClusterCacheMetricRequest request) {
         LOG.trace("Called getClusterCacheMetric");
@@ -921,6 +979,63 @@ public class DbManagementClient implements DbManagement {
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
                         interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListAwrDbSnapshotsResponse listAwrDbSnapshots(ListAwrDbSnapshotsRequest request) {
+        LOG.trace("Called listAwrDbSnapshots");
+        final ListAwrDbSnapshotsRequest interceptedRequest =
+                ListAwrDbSnapshotsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAwrDbSnapshotsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListAwrDbSnapshotsResponse>
+                transformer = ListAwrDbSnapshotsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListAwrDbsResponse listAwrDbs(ListAwrDbsRequest request) {
+        LOG.trace("Called listAwrDbs");
+        final ListAwrDbsRequest interceptedRequest = ListAwrDbsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListAwrDbsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListAwrDbsResponse> transformer =
+                ListAwrDbsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         return retrier.execute(
                 interceptedRequest,
                 retryRequest -> {
@@ -1202,6 +1317,280 @@ public class DbManagementClient implements DbManagement {
                                                 ib,
                                                 retriedRequest.getResetDatabaseParametersDetails(),
                                                 retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SummarizeAwrDbCpuUsagesResponse summarizeAwrDbCpuUsages(
+            SummarizeAwrDbCpuUsagesRequest request) {
+        LOG.trace("Called summarizeAwrDbCpuUsages");
+        final SummarizeAwrDbCpuUsagesRequest interceptedRequest =
+                SummarizeAwrDbCpuUsagesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbCpuUsagesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, SummarizeAwrDbCpuUsagesResponse>
+                transformer = SummarizeAwrDbCpuUsagesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SummarizeAwrDbMetricsResponse summarizeAwrDbMetrics(
+            SummarizeAwrDbMetricsRequest request) {
+        LOG.trace("Called summarizeAwrDbMetrics");
+        final SummarizeAwrDbMetricsRequest interceptedRequest =
+                SummarizeAwrDbMetricsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbMetricsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, SummarizeAwrDbMetricsResponse>
+                transformer = SummarizeAwrDbMetricsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SummarizeAwrDbParameterChangesResponse summarizeAwrDbParameterChanges(
+            SummarizeAwrDbParameterChangesRequest request) {
+        LOG.trace("Called summarizeAwrDbParameterChanges");
+        final SummarizeAwrDbParameterChangesRequest interceptedRequest =
+                SummarizeAwrDbParameterChangesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbParameterChangesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbParameterChangesResponse>
+                transformer = SummarizeAwrDbParameterChangesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SummarizeAwrDbParametersResponse summarizeAwrDbParameters(
+            SummarizeAwrDbParametersRequest request) {
+        LOG.trace("Called summarizeAwrDbParameters");
+        final SummarizeAwrDbParametersRequest interceptedRequest =
+                SummarizeAwrDbParametersConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbParametersConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, SummarizeAwrDbParametersResponse>
+                transformer = SummarizeAwrDbParametersConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SummarizeAwrDbSnapshotRangesResponse summarizeAwrDbSnapshotRanges(
+            SummarizeAwrDbSnapshotRangesRequest request) {
+        LOG.trace("Called summarizeAwrDbSnapshotRanges");
+        final SummarizeAwrDbSnapshotRangesRequest interceptedRequest =
+                SummarizeAwrDbSnapshotRangesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbSnapshotRangesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbSnapshotRangesResponse>
+                transformer = SummarizeAwrDbSnapshotRangesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SummarizeAwrDbSysstatsResponse summarizeAwrDbSysstats(
+            SummarizeAwrDbSysstatsRequest request) {
+        LOG.trace("Called summarizeAwrDbSysstats");
+        final SummarizeAwrDbSysstatsRequest interceptedRequest =
+                SummarizeAwrDbSysstatsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbSysstatsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, SummarizeAwrDbSysstatsResponse>
+                transformer = SummarizeAwrDbSysstatsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SummarizeAwrDbTopWaitEventsResponse summarizeAwrDbTopWaitEvents(
+            SummarizeAwrDbTopWaitEventsRequest request) {
+        LOG.trace("Called summarizeAwrDbTopWaitEvents");
+        final SummarizeAwrDbTopWaitEventsRequest interceptedRequest =
+                SummarizeAwrDbTopWaitEventsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbTopWaitEventsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbTopWaitEventsResponse>
+                transformer = SummarizeAwrDbTopWaitEventsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SummarizeAwrDbWaitEventBucketsResponse summarizeAwrDbWaitEventBuckets(
+            SummarizeAwrDbWaitEventBucketsRequest request) {
+        LOG.trace("Called summarizeAwrDbWaitEventBuckets");
+        final SummarizeAwrDbWaitEventBucketsRequest interceptedRequest =
+                SummarizeAwrDbWaitEventBucketsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbWaitEventBucketsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SummarizeAwrDbWaitEventBucketsResponse>
+                transformer = SummarizeAwrDbWaitEventBucketsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SummarizeAwrDbWaitEventsResponse summarizeAwrDbWaitEvents(
+            SummarizeAwrDbWaitEventsRequest request) {
+        LOG.trace("Called summarizeAwrDbWaitEvents");
+        final SummarizeAwrDbWaitEventsRequest interceptedRequest =
+                SummarizeAwrDbWaitEventsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SummarizeAwrDbWaitEventsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, SummarizeAwrDbWaitEventsResponse>
+                transformer = SummarizeAwrDbWaitEventsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/GetAwrDbReportConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/GetAwrDbReportConverter.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class GetAwrDbReportConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.GetAwrDbReportRequest interceptRequest(
+            com.oracle.bmc.databasemanagement.requests.GetAwrDbReportRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.GetAwrDbReportRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbReport");
+
+        if (request.getInstNums() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "instNums",
+                            request.getInstNums(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.CommaSeparated);
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        if (request.getReportType() != null) {
+            target =
+                    target.queryParam(
+                            "reportType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getReportType().getValue()));
+        }
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        if (request.getReportFormat() != null) {
+            target =
+                    target.queryParam(
+                            "reportFormat",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getReportFormat().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.GetAwrDbReportResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses.GetAwrDbReportResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .GetAwrDbReportResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .GetAwrDbReportResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.GetAwrDbReportResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbReport>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbReport.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AwrDbReport> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses.GetAwrDbReportResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .GetAwrDbReportResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbReport(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses.GetAwrDbReportResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/GetAwrDbSqlReportConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/GetAwrDbSqlReportConverter.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class GetAwrDbSqlReportConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.GetAwrDbSqlReportRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.GetAwrDbSqlReportRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.GetAwrDbSqlReportRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+        Validate.notNull(request.getSqlId(), "sqlId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbSqlReport");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        target =
+                target.queryParam(
+                        "sqlId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getSqlId()));
+
+        if (request.getReportFormat() != null) {
+            target =
+                    target.queryParam(
+                            "reportFormat",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getReportFormat().getValue()));
+        }
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.GetAwrDbSqlReportResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses.GetAwrDbSqlReportResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .GetAwrDbSqlReportResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .GetAwrDbSqlReportResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.GetAwrDbSqlReportResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbSqlReport>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbSqlReport.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AwrDbSqlReport> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .GetAwrDbSqlReportResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .GetAwrDbSqlReportResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbSqlReport(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .GetAwrDbSqlReportResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/ListAwrDbSnapshotsConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/ListAwrDbSnapshotsConverter.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class ListAwrDbSnapshotsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.ListAwrDbSnapshotsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.ListAwrDbSnapshotsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.ListAwrDbSnapshotsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbSnapshots");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.ListAwrDbSnapshotsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses.ListAwrDbSnapshotsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .ListAwrDbSnapshotsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .ListAwrDbSnapshotsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.ListAwrDbSnapshotsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbSnapshotCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbSnapshotCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AwrDbSnapshotCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .ListAwrDbSnapshotsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .ListAwrDbSnapshotsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbSnapshotCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .ListAwrDbSnapshotsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/ListAwrDbsConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/ListAwrDbsConverter.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class ListAwrDbsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.ListAwrDbsRequest interceptRequest(
+            com.oracle.bmc.databasemanagement.requests.ListAwrDbsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.ListAwrDbsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs");
+
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.ListAwrDbsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses.ListAwrDbsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses.ListAwrDbsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses.ListAwrDbsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.ListAwrDbsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AwrDbCollection> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses.ListAwrDbsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .ListAwrDbsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses.ListAwrDbsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbCpuUsagesConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbCpuUsagesConverter.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeAwrDbCpuUsagesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbCpuUsagesRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbCpuUsagesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbCpuUsagesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbCpuUsages");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        if (request.getSessionType() != null) {
+            target =
+                    target.queryParam(
+                            "sessionType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSessionType().getValue()));
+        }
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbCpuUsagesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbCpuUsagesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .SummarizeAwrDbCpuUsagesResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .SummarizeAwrDbCpuUsagesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbCpuUsagesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbCpuUsageCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbCpuUsageCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AwrDbCpuUsageCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbCpuUsagesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .SummarizeAwrDbCpuUsagesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbCpuUsageCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbCpuUsagesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbMetricsConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbMetricsConverter.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeAwrDbMetricsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbMetricsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbMetricsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbMetricsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+        Validate.notNull(request.getName(), "name is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbMetrics");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        target =
+                com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                        target,
+                        "name",
+                        request.getName(),
+                        com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbMetricsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbMetricsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .SummarizeAwrDbMetricsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .SummarizeAwrDbMetricsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbMetricsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbMetricCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbMetricCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AwrDbMetricCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbMetricsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .SummarizeAwrDbMetricsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbMetricCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbMetricsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbParameterChangesConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbParameterChangesConverter.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeAwrDbParameterChangesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbParameterChangesRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbParameterChangesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbParameterChangesRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+        Validate.notNull(request.getName(), "name is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbParameterChanges");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        target =
+                target.queryParam(
+                        "name",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getName()));
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses
+                            .SummarizeAwrDbParameterChangesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses
+                                .SummarizeAwrDbParameterChangesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .SummarizeAwrDbParameterChangesResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .SummarizeAwrDbParameterChangesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbParameterChangesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbParameterChangeCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbParameterChangeCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AwrDbParameterChangeCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbParameterChangesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .SummarizeAwrDbParameterChangesResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbParameterChangeCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbParameterChangesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbParametersConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbParametersConverter.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeAwrDbParametersConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbParametersRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbParametersRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbParametersRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbParameters");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        if (request.getName() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "name",
+                            request.getName(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getNameContains() != null) {
+            target =
+                    target.queryParam(
+                            "nameContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getNameContains()));
+        }
+
+        if (request.getValueChanged() != null) {
+            target =
+                    target.queryParam(
+                            "valueChanged",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getValueChanged().getValue()));
+        }
+
+        if (request.getValueDefault() != null) {
+            target =
+                    target.queryParam(
+                            "valueDefault",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getValueDefault().getValue()));
+        }
+
+        if (request.getValueModified() != null) {
+            target =
+                    target.queryParam(
+                            "valueModified",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getValueModified().getValue()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbParametersResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses
+                                .SummarizeAwrDbParametersResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .SummarizeAwrDbParametersResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .SummarizeAwrDbParametersResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbParametersResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbParameterCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbParameterCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AwrDbParameterCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbParametersResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .SummarizeAwrDbParametersResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbParameterCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbParametersResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbSnapshotRangesConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbSnapshotRangesConverter.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeAwrDbSnapshotRangesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbSnapshotRangesRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbSnapshotRangesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbSnapshotRangesRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbSnapshotRanges");
+
+        if (request.getName() != null) {
+            target =
+                    target.queryParam(
+                            "name",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getName()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses
+                            .SummarizeAwrDbSnapshotRangesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses
+                                .SummarizeAwrDbSnapshotRangesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .SummarizeAwrDbSnapshotRangesResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .SummarizeAwrDbSnapshotRangesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbSnapshotRangesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbSnapshotRangeCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbSnapshotRangeCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AwrDbSnapshotRangeCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbSnapshotRangesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .SummarizeAwrDbSnapshotRangesResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbSnapshotRangeCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbSnapshotRangesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbSysstatsConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbSysstatsConverter.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeAwrDbSysstatsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbSysstatsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbSysstatsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbSysstatsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+        Validate.notNull(request.getName(), "name is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbSysstats");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        target =
+                com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                        target,
+                        "name",
+                        request.getName(),
+                        com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbSysstatsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbSysstatsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .SummarizeAwrDbSysstatsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .SummarizeAwrDbSysstatsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbSysstatsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbSysstatCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbSysstatCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AwrDbSysstatCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbSysstatsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .SummarizeAwrDbSysstatsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbSysstatCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbSysstatsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbTopWaitEventsConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbTopWaitEventsConverter.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeAwrDbTopWaitEventsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbTopWaitEventsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbTopWaitEventsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbTopWaitEventsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbTopWaitEvents");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        if (request.getSessionType() != null) {
+            target =
+                    target.queryParam(
+                            "sessionType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSessionType().getValue()));
+        }
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        if (request.getTopN() != null) {
+            target =
+                    target.queryParam(
+                            "topN",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTopN()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbTopWaitEventsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses
+                                .SummarizeAwrDbTopWaitEventsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .SummarizeAwrDbTopWaitEventsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .SummarizeAwrDbTopWaitEventsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbTopWaitEventsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbTopWaitEventCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbTopWaitEventCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AwrDbTopWaitEventCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbTopWaitEventsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .SummarizeAwrDbTopWaitEventsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbTopWaitEventCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbTopWaitEventsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbWaitEventBucketsConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbWaitEventBucketsConverter.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeAwrDbWaitEventBucketsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbWaitEventBucketsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbWaitEventBucketsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbWaitEventBucketsRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+        Validate.notNull(request.getName(), "name is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbWaitEventBuckets");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        target =
+                target.queryParam(
+                        "name",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getName()));
+
+        if (request.getNumBucket() != null) {
+            target =
+                    target.queryParam(
+                            "numBucket",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getNumBucket()));
+        }
+
+        if (request.getMinValue() != null) {
+            target =
+                    target.queryParam(
+                            "minValue",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getMinValue()));
+        }
+
+        if (request.getMaxValue() != null) {
+            target =
+                    target.queryParam(
+                            "maxValue",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getMaxValue()));
+        }
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses
+                            .SummarizeAwrDbWaitEventBucketsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses
+                                .SummarizeAwrDbWaitEventBucketsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .SummarizeAwrDbWaitEventBucketsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .SummarizeAwrDbWaitEventBucketsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbWaitEventBucketsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbWaitEventBucketCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbWaitEventBucketCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                AwrDbWaitEventBucketCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbWaitEventBucketsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .SummarizeAwrDbWaitEventBucketsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbWaitEventBucketCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbWaitEventBucketsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbWaitEventsConverter.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/internal/http/SummarizeAwrDbWaitEventsConverter.java
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemanagement.model.*;
+import com.oracle.bmc.databasemanagement.requests.*;
+import com.oracle.bmc.databasemanagement.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.extern.slf4j.Slf4j
+public class SummarizeAwrDbWaitEventsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbWaitEventsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbWaitEventsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemanagement.requests.SummarizeAwrDbWaitEventsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getManagedDatabaseId(), "managedDatabaseId must not be blank");
+        Validate.notBlank(request.getAwrDbId(), "awrDbId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20201101")
+                        .path("managedDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getManagedDatabaseId()))
+                        .path("awrDbs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAwrDbId()))
+                        .path("awrDbWaitEvents");
+
+        if (request.getInstNum() != null) {
+            target =
+                    target.queryParam(
+                            "instNum",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstNum()));
+        }
+
+        if (request.getBeginSnIdGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "beginSnIdGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getBeginSnIdGreaterThanOrEqualTo()));
+        }
+
+        if (request.getEndSnIdLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "endSnIdLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getEndSnIdLessThanOrEqualTo()));
+        }
+
+        if (request.getTimeGreaterThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeGreaterThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeGreaterThanOrEqualTo()));
+        }
+
+        if (request.getTimeLessThanOrEqualTo() != null) {
+            target =
+                    target.queryParam(
+                            "timeLessThanOrEqualTo",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeLessThanOrEqualTo()));
+        }
+
+        if (request.getName() != null) {
+            target =
+                    com.oracle.bmc.util.internal.HttpUtils.encodeCollectionFormatQueryParam(
+                            target,
+                            "name",
+                            request.getName(),
+                            com.oracle.bmc.util.internal.CollectionFormatType.Multi);
+        }
+
+        if (request.getSessionType() != null) {
+            target =
+                    target.queryParam(
+                            "sessionType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSessionType().getValue()));
+        }
+
+        if (request.getContainerId() != null) {
+            target =
+                    target.queryParam(
+                            "containerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getContainerId()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbWaitEventsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemanagement.responses
+                                .SummarizeAwrDbWaitEventsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemanagement.responses
+                                        .SummarizeAwrDbWaitEventsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemanagement.responses
+                                            .SummarizeAwrDbWaitEventsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemanagement.responses.SummarizeAwrDbWaitEventsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        AwrDbWaitEventCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        AwrDbWaitEventCollection.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<AwrDbWaitEventCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbWaitEventsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemanagement.responses
+                                                        .SummarizeAwrDbWaitEventsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.awrDbWaitEventCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemanagement.responses
+                                                .SummarizeAwrDbWaitEventsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbCollection.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The result of AWR query.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AwrDbCollection.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbSummary> items;
+
+        public Builder items(java.util.List<AwrDbSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbCollection build() {
+            AwrDbCollection __instance__ =
+                    new AwrDbCollection(name, version, queryKey, dbQueryTimeInSecs, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            java.util.List<AwrDbSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.items = items;
+    }
+
+    /**
+     * A list of AWR summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbCpuUsageCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbCpuUsageCollection.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR CPU usage data.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbCpuUsageCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbCpuUsageCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("numCpuCores")
+        private Integer numCpuCores;
+
+        public Builder numCpuCores(Integer numCpuCores) {
+            this.numCpuCores = numCpuCores;
+            this.__explicitlySet__.add("numCpuCores");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCount")
+        private Integer cpuCount;
+
+        public Builder cpuCount(Integer cpuCount) {
+            this.cpuCount = cpuCount;
+            this.__explicitlySet__.add("cpuCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("numCpus")
+        private Double numCpus;
+
+        public Builder numCpus(Double numCpus) {
+            this.numCpus = numCpus;
+            this.__explicitlySet__.add("numCpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbCpuUsageSummary> items;
+
+        public Builder items(java.util.List<AwrDbCpuUsageSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbCpuUsageCollection build() {
+            AwrDbCpuUsageCollection __instance__ =
+                    new AwrDbCpuUsageCollection(
+                            name,
+                            version,
+                            queryKey,
+                            dbQueryTimeInSecs,
+                            numCpuCores,
+                            cpuCount,
+                            numCpus,
+                            items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbCpuUsageCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .numCpuCores(o.getNumCpuCores())
+                            .cpuCount(o.getCpuCount())
+                            .numCpus(o.getNumCpus())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbCpuUsageCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            Integer numCpuCores,
+            Integer cpuCount,
+            Double numCpus,
+            java.util.List<AwrDbCpuUsageSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.numCpuCores = numCpuCores;
+        this.cpuCount = cpuCount;
+        this.numCpus = numCpus;
+        this.items = items;
+    }
+
+    /**
+     * The number of available CPU cores, which include subcores of multicore and single-core CPUs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("numCpuCores")
+    Integer numCpuCores;
+
+    /**
+     * The number of CPUs available for the database to use.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCount")
+    Integer cpuCount;
+
+    /**
+     * The number of available CPUs or processors.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("numCpus")
+    Double numCpus;
+
+    /**
+     * A list of AWR CPU usage summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbCpuUsageSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbCpuUsageSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbCpuUsageSummary.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * A summary of the AWR CPU resource limits and metrics.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbCpuUsageSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbCpuUsageSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+        private java.util.Date timestamp;
+
+        public Builder timestamp(java.util.Date timestamp) {
+            this.timestamp = timestamp;
+            this.__explicitlySet__.add("timestamp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("avgValue")
+        private Double avgValue;
+
+        public Builder avgValue(Double avgValue) {
+            this.avgValue = avgValue;
+            this.__explicitlySet__.add("avgValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbCpuUsageSummary build() {
+            AwrDbCpuUsageSummary __instance__ = new AwrDbCpuUsageSummary(timestamp, avgValue);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbCpuUsageSummary o) {
+            Builder copiedBuilder = timestamp(o.getTimestamp()).avgValue(o.getAvgValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The timestamp for the CPU summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+    java.util.Date timestamp;
+
+    /**
+     * The average CPU usage per second.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("avgValue")
+    Double avgValue;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbMetricCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbMetricCollection.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR metrics time series summary data.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbMetricCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbMetricCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbMetricSummary> items;
+
+        public Builder items(java.util.List<AwrDbMetricSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbMetricCollection build() {
+            AwrDbMetricCollection __instance__ =
+                    new AwrDbMetricCollection(name, version, queryKey, dbQueryTimeInSecs, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbMetricCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbMetricCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            java.util.List<AwrDbMetricSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.items = items;
+    }
+
+    /**
+     * A list of AWR metric summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbMetricSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbMetricSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbMetricSummary.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The summary of the AWR metric data for a particular metric at a specific time.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbMetricSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbMetricSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+        private java.util.Date timestamp;
+
+        public Builder timestamp(java.util.Date timestamp) {
+            this.timestamp = timestamp;
+            this.__explicitlySet__.add("timestamp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("avgValue")
+        private Double avgValue;
+
+        public Builder avgValue(Double avgValue) {
+            this.avgValue = avgValue;
+            this.__explicitlySet__.add("avgValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("minValue")
+        private Double minValue;
+
+        public Builder minValue(Double minValue) {
+            this.minValue = minValue;
+            this.__explicitlySet__.add("minValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxValue")
+        private Double maxValue;
+
+        public Builder maxValue(Double maxValue) {
+            this.maxValue = maxValue;
+            this.__explicitlySet__.add("maxValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbMetricSummary build() {
+            AwrDbMetricSummary __instance__ =
+                    new AwrDbMetricSummary(name, timestamp, avgValue, minValue, maxValue);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbMetricSummary o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .timestamp(o.getTimestamp())
+                            .avgValue(o.getAvgValue())
+                            .minValue(o.getMinValue())
+                            .maxValue(o.getMaxValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the metric.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The time of the sampling.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+    java.util.Date timestamp;
+
+    /**
+     * The average value of the sampling period.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("avgValue")
+    Double avgValue;
+
+    /**
+     * The minimum value of the sampling period.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("minValue")
+    Double minValue;
+
+    /**
+     * The maximum value of the sampling period.v
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxValue")
+    Double maxValue;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbParameterChangeCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbParameterChangeCollection.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR database parameter change history.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbParameterChangeCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbParameterChangeCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbParameterChangeSummary> items;
+
+        public Builder items(java.util.List<AwrDbParameterChangeSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbParameterChangeCollection build() {
+            AwrDbParameterChangeCollection __instance__ =
+                    new AwrDbParameterChangeCollection(
+                            name, version, queryKey, dbQueryTimeInSecs, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbParameterChangeCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbParameterChangeCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            java.util.List<AwrDbParameterChangeSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.items = items;
+    }
+
+    /**
+     * A list of AWR database parameter change summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbParameterChangeSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbParameterChangeSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbParameterChangeSummary.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * A summary of the changes made to a single AWR database parameter.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbParameterChangeSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbParameterChangeSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("timeBegin")
+        private java.util.Date timeBegin;
+
+        public Builder timeBegin(java.util.Date timeBegin) {
+            this.timeBegin = timeBegin;
+            this.__explicitlySet__.add("timeBegin");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeEnd")
+        private java.util.Date timeEnd;
+
+        public Builder timeEnd(java.util.Date timeEnd) {
+            this.timeEnd = timeEnd;
+            this.__explicitlySet__.add("timeEnd");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceNumber")
+        private Integer instanceNumber;
+
+        public Builder instanceNumber(Integer instanceNumber) {
+            this.instanceNumber = instanceNumber;
+            this.__explicitlySet__.add("instanceNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("previousValue")
+        private String previousValue;
+
+        public Builder previousValue(String previousValue) {
+            this.previousValue = previousValue;
+            this.__explicitlySet__.add("previousValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            this.__explicitlySet__.add("value");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("snapshotId")
+        private Integer snapshotId;
+
+        public Builder snapshotId(Integer snapshotId) {
+            this.snapshotId = snapshotId;
+            this.__explicitlySet__.add("snapshotId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("valueModified")
+        private String valueModified;
+
+        public Builder valueModified(String valueModified) {
+            this.valueModified = valueModified;
+            this.__explicitlySet__.add("valueModified");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
+        private Boolean isDefault;
+
+        public Builder isDefault(Boolean isDefault) {
+            this.isDefault = isDefault;
+            this.__explicitlySet__.add("isDefault");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbParameterChangeSummary build() {
+            AwrDbParameterChangeSummary __instance__ =
+                    new AwrDbParameterChangeSummary(
+                            timeBegin,
+                            timeEnd,
+                            instanceNumber,
+                            previousValue,
+                            value,
+                            snapshotId,
+                            valueModified,
+                            isDefault);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbParameterChangeSummary o) {
+            Builder copiedBuilder =
+                    timeBegin(o.getTimeBegin())
+                            .timeEnd(o.getTimeEnd())
+                            .instanceNumber(o.getInstanceNumber())
+                            .previousValue(o.getPreviousValue())
+                            .value(o.getValue())
+                            .snapshotId(o.getSnapshotId())
+                            .valueModified(o.getValueModified())
+                            .isDefault(o.getIsDefault());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The start time of the interval.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeBegin")
+    java.util.Date timeBegin;
+
+    /**
+     * The end time of the interval.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeEnd")
+    java.util.Date timeEnd;
+
+    /**
+     * The database instance number.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceNumber")
+    Integer instanceNumber;
+
+    /**
+     * The previous value of the database parameter.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("previousValue")
+    String previousValue;
+
+    /**
+     * The current value of the database parameter.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    String value;
+
+    /**
+     * The ID of the snapshot with the parameter value changed. The snapshot ID is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbSnapshots
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("snapshotId")
+    Integer snapshotId;
+
+    /**
+     * Indicates whether the parameter has been modified after instance startup:
+     *  - MODIFIED - Parameter has been modified with ALTER SESSION
+     *  - SYSTEM_MOD - Parameter has been modified with ALTER SYSTEM (which causes all the currently logged in sessions\u2019 values to be modified)
+     *  - FALSE - Parameter has not been modified after instance startup
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("valueModified")
+    String valueModified;
+
+    /**
+     * Indicates whether the parameter value in the end snapshot is the default.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
+    Boolean isDefault;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbParameterCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbParameterCollection.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR database parameter data.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbParameterCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbParameterCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbParameterSummary> items;
+
+        public Builder items(java.util.List<AwrDbParameterSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbParameterCollection build() {
+            AwrDbParameterCollection __instance__ =
+                    new AwrDbParameterCollection(name, version, queryKey, dbQueryTimeInSecs, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbParameterCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbParameterCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            java.util.List<AwrDbParameterSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.items = items;
+    }
+
+    /**
+     * A list of AWR database parameter summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbParameterSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbParameterSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbParameterSummary.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The summary of the AWR change history data for a single database parameter.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbParameterSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbParameterSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceNumber")
+        private Integer instanceNumber;
+
+        public Builder instanceNumber(Integer instanceNumber) {
+            this.instanceNumber = instanceNumber;
+            this.__explicitlySet__.add("instanceNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("beginValue")
+        private String beginValue;
+
+        public Builder beginValue(String beginValue) {
+            this.beginValue = beginValue;
+            this.__explicitlySet__.add("beginValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("endValue")
+        private String endValue;
+
+        public Builder endValue(String endValue) {
+            this.endValue = endValue;
+            this.__explicitlySet__.add("endValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isChanged")
+        private Boolean isChanged;
+
+        public Builder isChanged(Boolean isChanged) {
+            this.isChanged = isChanged;
+            this.__explicitlySet__.add("isChanged");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("valueModified")
+        private String valueModified;
+
+        public Builder valueModified(String valueModified) {
+            this.valueModified = valueModified;
+            this.__explicitlySet__.add("valueModified");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
+        private Boolean isDefault;
+
+        public Builder isDefault(Boolean isDefault) {
+            this.isDefault = isDefault;
+            this.__explicitlySet__.add("isDefault");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbParameterSummary build() {
+            AwrDbParameterSummary __instance__ =
+                    new AwrDbParameterSummary(
+                            name,
+                            instanceNumber,
+                            beginValue,
+                            endValue,
+                            isChanged,
+                            valueModified,
+                            isDefault);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbParameterSummary o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .instanceNumber(o.getInstanceNumber())
+                            .beginValue(o.getBeginValue())
+                            .endValue(o.getEndValue())
+                            .isChanged(o.getIsChanged())
+                            .valueModified(o.getValueModified())
+                            .isDefault(o.getIsDefault());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the parameter.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The database instance number.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceNumber")
+    Integer instanceNumber;
+
+    /**
+     * The parameter value when the period began.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("beginValue")
+    String beginValue;
+
+    /**
+     * The parameter value when the period ended.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("endValue")
+    String endValue;
+
+    /**
+     * Indicates whether the parameter value changed within the period.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isChanged")
+    Boolean isChanged;
+
+    /**
+     * Indicates whether the parameter has been modified after instance startup:
+     *  - MODIFIED - Parameter has been modified with ALTER SESSION
+     *  - SYSTEM_MOD - Parameter has been modified with ALTER SYSTEM (which causes all the currently logged in sessions\u2019 values to be modified)
+     *  - FALSE - Parameter has not been modified after instance startup
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("valueModified")
+    String valueModified;
+
+    /**
+     * Indicates whether the parameter value in the end snapshot is the default.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
+    Boolean isDefault;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbReport.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbReport.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The result of the AWR report.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AwrDbReport.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbReport extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("content")
+        private String content;
+
+        public Builder content(String content) {
+            this.content = content;
+            this.__explicitlySet__.add("content");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("format")
+        private Format format;
+
+        public Builder format(Format format) {
+            this.format = format;
+            this.__explicitlySet__.add("format");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbReport build() {
+            AwrDbReport __instance__ =
+                    new AwrDbReport(name, version, queryKey, dbQueryTimeInSecs, content, format);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbReport o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .content(o.getContent())
+                            .format(o.getFormat());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbReport(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            String content,
+            Format format) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.content = content;
+        this.format = format;
+    }
+
+    /**
+     * The content of the report.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("content")
+    String content;
+    /**
+     * The format of the report.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Format {
+        Html("HTML"),
+        Text("TEXT"),
+        Xml("XML"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Format> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Format v : Format.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Format(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Format create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Format', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The format of the report.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("format")
+    Format format;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSnapshotCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSnapshotCollection.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The list of AWR snapshots for one database.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbSnapshotCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbSnapshotCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbSnapshotSummary> items;
+
+        public Builder items(java.util.List<AwrDbSnapshotSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbSnapshotCollection build() {
+            AwrDbSnapshotCollection __instance__ =
+                    new AwrDbSnapshotCollection(name, version, queryKey, dbQueryTimeInSecs, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbSnapshotCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbSnapshotCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            java.util.List<AwrDbSnapshotSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.items = items;
+    }
+
+    /**
+     * A list of AWR snapshot summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbSnapshotSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSnapshotRangeCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSnapshotRangeCollection.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR snapshot range list.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbSnapshotRangeCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbSnapshotRangeCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbSnapshotRangeSummary> items;
+
+        public Builder items(java.util.List<AwrDbSnapshotRangeSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbSnapshotRangeCollection build() {
+            AwrDbSnapshotRangeCollection __instance__ =
+                    new AwrDbSnapshotRangeCollection(
+                            name, version, queryKey, dbQueryTimeInSecs, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbSnapshotRangeCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbSnapshotRangeCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            java.util.List<AwrDbSnapshotRangeSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.items = items;
+    }
+
+    /**
+     * A list of AWR snapshot range summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbSnapshotRangeSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSnapshotRangeSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSnapshotRangeSummary.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The summary data for a range of AWR snapshots.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbSnapshotRangeSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbSnapshotRangeSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("awrDbId")
+        private String awrDbId;
+
+        public Builder awrDbId(String awrDbId) {
+            this.awrDbId = awrDbId;
+            this.__explicitlySet__.add("awrDbId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbName")
+        private String dbName;
+
+        public Builder dbName(String dbName) {
+            this.dbName = dbName;
+            this.__explicitlySet__.add("dbName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceList")
+        private java.util.List<Integer> instanceList;
+
+        public Builder instanceList(java.util.List<Integer> instanceList) {
+            this.instanceList = instanceList;
+            this.__explicitlySet__.add("instanceList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDbStartup")
+        private java.util.Date timeDbStartup;
+
+        public Builder timeDbStartup(java.util.Date timeDbStartup) {
+            this.timeDbStartup = timeDbStartup;
+            this.__explicitlySet__.add("timeDbStartup");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFirstSnapshotBegin")
+        private java.util.Date timeFirstSnapshotBegin;
+
+        public Builder timeFirstSnapshotBegin(java.util.Date timeFirstSnapshotBegin) {
+            this.timeFirstSnapshotBegin = timeFirstSnapshotBegin;
+            this.__explicitlySet__.add("timeFirstSnapshotBegin");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLatestSnapshotEnd")
+        private java.util.Date timeLatestSnapshotEnd;
+
+        public Builder timeLatestSnapshotEnd(java.util.Date timeLatestSnapshotEnd) {
+            this.timeLatestSnapshotEnd = timeLatestSnapshotEnd;
+            this.__explicitlySet__.add("timeLatestSnapshotEnd");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("firstSnapshotId")
+        private Integer firstSnapshotId;
+
+        public Builder firstSnapshotId(Integer firstSnapshotId) {
+            this.firstSnapshotId = firstSnapshotId;
+            this.__explicitlySet__.add("firstSnapshotId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("latestSnapshotId")
+        private Integer latestSnapshotId;
+
+        public Builder latestSnapshotId(Integer latestSnapshotId) {
+            this.latestSnapshotId = latestSnapshotId;
+            this.__explicitlySet__.add("latestSnapshotId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("snapshotCount")
+        private Long snapshotCount;
+
+        public Builder snapshotCount(Long snapshotCount) {
+            this.snapshotCount = snapshotCount;
+            this.__explicitlySet__.add("snapshotCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("snapshotIntervalInMin")
+        private Integer snapshotIntervalInMin;
+
+        public Builder snapshotIntervalInMin(Integer snapshotIntervalInMin) {
+            this.snapshotIntervalInMin = snapshotIntervalInMin;
+            this.__explicitlySet__.add("snapshotIntervalInMin");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("containerId")
+        private Integer containerId;
+
+        public Builder containerId(Integer containerId) {
+            this.containerId = containerId;
+            this.__explicitlySet__.add("containerId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+        private String dbVersion;
+
+        public Builder dbVersion(String dbVersion) {
+            this.dbVersion = dbVersion;
+            this.__explicitlySet__.add("dbVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("snapshotTimezone")
+        private String snapshotTimezone;
+
+        public Builder snapshotTimezone(String snapshotTimezone) {
+            this.snapshotTimezone = snapshotTimezone;
+            this.__explicitlySet__.add("snapshotTimezone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbSnapshotRangeSummary build() {
+            AwrDbSnapshotRangeSummary __instance__ =
+                    new AwrDbSnapshotRangeSummary(
+                            awrDbId,
+                            dbName,
+                            instanceList,
+                            timeDbStartup,
+                            timeFirstSnapshotBegin,
+                            timeLatestSnapshotEnd,
+                            firstSnapshotId,
+                            latestSnapshotId,
+                            snapshotCount,
+                            snapshotIntervalInMin,
+                            containerId,
+                            dbVersion,
+                            snapshotTimezone);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbSnapshotRangeSummary o) {
+            Builder copiedBuilder =
+                    awrDbId(o.getAwrDbId())
+                            .dbName(o.getDbName())
+                            .instanceList(o.getInstanceList())
+                            .timeDbStartup(o.getTimeDbStartup())
+                            .timeFirstSnapshotBegin(o.getTimeFirstSnapshotBegin())
+                            .timeLatestSnapshotEnd(o.getTimeLatestSnapshotEnd())
+                            .firstSnapshotId(o.getFirstSnapshotId())
+                            .latestSnapshotId(o.getLatestSnapshotId())
+                            .snapshotCount(o.getSnapshotCount())
+                            .snapshotIntervalInMin(o.getSnapshotIntervalInMin())
+                            .containerId(o.getContainerId())
+                            .dbVersion(o.getDbVersion())
+                            .snapshotTimezone(o.getSnapshotTimezone());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The internal ID of the database. The internal ID of the database is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("awrDbId")
+    String awrDbId;
+
+    /**
+     * The name of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbName")
+    String dbName;
+
+    /**
+     * The database instance numbers.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceList")
+    java.util.List<Integer> instanceList;
+
+    /**
+     * The timestamp of the database startup.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDbStartup")
+    java.util.Date timeDbStartup;
+
+    /**
+     * The start time of the earliest snapshot.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeFirstSnapshotBegin")
+    java.util.Date timeFirstSnapshotBegin;
+
+    /**
+     * The end time of the latest snapshot.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLatestSnapshotEnd")
+    java.util.Date timeLatestSnapshotEnd;
+
+    /**
+     * The ID of the earliest snapshot. The snapshot ID is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbSnapshots
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("firstSnapshotId")
+    Integer firstSnapshotId;
+
+    /**
+     * The ID of the latest snapshot. The snapshot ID is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbSnapshots
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("latestSnapshotId")
+    Integer latestSnapshotId;
+
+    /**
+     * The total number of snapshots.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("snapshotCount")
+    Long snapshotCount;
+
+    /**
+     * The interval time between snapshots (in minutes).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("snapshotIntervalInMin")
+    Integer snapshotIntervalInMin;
+
+    /**
+     * ID of the database container. The database container ID is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("containerId")
+    Integer containerId;
+
+    /**
+     * The version of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+    String dbVersion;
+
+    /**
+     * The time zone of the snapshot.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("snapshotTimezone")
+    String snapshotTimezone;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSnapshotSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSnapshotSummary.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR snapshot summary of one snapshot.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbSnapshotSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbSnapshotSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("awrDbId")
+        private String awrDbId;
+
+        public Builder awrDbId(String awrDbId) {
+            this.awrDbId = awrDbId;
+            this.__explicitlySet__.add("awrDbId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceNumber")
+        private Integer instanceNumber;
+
+        public Builder instanceNumber(Integer instanceNumber) {
+            this.instanceNumber = instanceNumber;
+            this.__explicitlySet__.add("instanceNumber");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDbStartup")
+        private java.util.Date timeDbStartup;
+
+        public Builder timeDbStartup(java.util.Date timeDbStartup) {
+            this.timeDbStartup = timeDbStartup;
+            this.__explicitlySet__.add("timeDbStartup");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeBegin")
+        private java.util.Date timeBegin;
+
+        public Builder timeBegin(java.util.Date timeBegin) {
+            this.timeBegin = timeBegin;
+            this.__explicitlySet__.add("timeBegin");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeEnd")
+        private java.util.Date timeEnd;
+
+        public Builder timeEnd(java.util.Date timeEnd) {
+            this.timeEnd = timeEnd;
+            this.__explicitlySet__.add("timeEnd");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("snapshotId")
+        private Integer snapshotId;
+
+        public Builder snapshotId(Integer snapshotId) {
+            this.snapshotId = snapshotId;
+            this.__explicitlySet__.add("snapshotId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorCount")
+        private Long errorCount;
+
+        public Builder errorCount(Long errorCount) {
+            this.errorCount = errorCount;
+            this.__explicitlySet__.add("errorCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbSnapshotSummary build() {
+            AwrDbSnapshotSummary __instance__ =
+                    new AwrDbSnapshotSummary(
+                            awrDbId,
+                            instanceNumber,
+                            timeDbStartup,
+                            timeBegin,
+                            timeEnd,
+                            snapshotId,
+                            errorCount);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbSnapshotSummary o) {
+            Builder copiedBuilder =
+                    awrDbId(o.getAwrDbId())
+                            .instanceNumber(o.getInstanceNumber())
+                            .timeDbStartup(o.getTimeDbStartup())
+                            .timeBegin(o.getTimeBegin())
+                            .timeEnd(o.getTimeEnd())
+                            .snapshotId(o.getSnapshotId())
+                            .errorCount(o.getErrorCount());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Internal ID of the database. The internal ID of the database is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("awrDbId")
+    String awrDbId;
+
+    /**
+     * The database instance number.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceNumber")
+    Integer instanceNumber;
+
+    /**
+     * The timestamp of the database startup.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDbStartup")
+    java.util.Date timeDbStartup;
+
+    /**
+     * The start time of the snapshot.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeBegin")
+    java.util.Date timeBegin;
+
+    /**
+     * The end time of the snapshot.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeEnd")
+    java.util.Date timeEnd;
+
+    /**
+     * The ID of the snapshot. The snapshot ID is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbSnapshots
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("snapshotId")
+    Integer snapshotId;
+
+    /**
+     * The total number of errors.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorCount")
+    Long errorCount;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSqlReport.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSqlReport.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The result of the AWR SQL report.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AwrDbSqlReport.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbSqlReport extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("content")
+        private String content;
+
+        public Builder content(String content) {
+            this.content = content;
+            this.__explicitlySet__.add("content");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("format")
+        private Format format;
+
+        public Builder format(Format format) {
+            this.format = format;
+            this.__explicitlySet__.add("format");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbSqlReport build() {
+            AwrDbSqlReport __instance__ =
+                    new AwrDbSqlReport(name, version, queryKey, dbQueryTimeInSecs, content, format);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbSqlReport o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .content(o.getContent())
+                            .format(o.getFormat());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbSqlReport(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            String content,
+            Format format) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.content = content;
+        this.format = format;
+    }
+
+    /**
+     * The content of the report.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("content")
+    String content;
+    /**
+     * The format of the report.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Format {
+        Html("HTML"),
+        Text("TEXT"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Format> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Format v : Format.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Format(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Format create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Format', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The format of the report.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("format")
+    Format format;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSummary.java
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR summary for a database.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AwrDbSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("awrDbId")
+        private String awrDbId;
+
+        public Builder awrDbId(String awrDbId) {
+            this.awrDbId = awrDbId;
+            this.__explicitlySet__.add("awrDbId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbName")
+        private String dbName;
+
+        public Builder dbName(String dbName) {
+            this.dbName = dbName;
+            this.__explicitlySet__.add("dbName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceList")
+        private java.util.List<Integer> instanceList;
+
+        public Builder instanceList(java.util.List<Integer> instanceList) {
+            this.instanceList = instanceList;
+            this.__explicitlySet__.add("instanceList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeDbStartup")
+        private java.util.Date timeDbStartup;
+
+        public Builder timeDbStartup(java.util.Date timeDbStartup) {
+            this.timeDbStartup = timeDbStartup;
+            this.__explicitlySet__.add("timeDbStartup");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFirstSnapshotBegin")
+        private java.util.Date timeFirstSnapshotBegin;
+
+        public Builder timeFirstSnapshotBegin(java.util.Date timeFirstSnapshotBegin) {
+            this.timeFirstSnapshotBegin = timeFirstSnapshotBegin;
+            this.__explicitlySet__.add("timeFirstSnapshotBegin");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLatestSnapshotEnd")
+        private java.util.Date timeLatestSnapshotEnd;
+
+        public Builder timeLatestSnapshotEnd(java.util.Date timeLatestSnapshotEnd) {
+            this.timeLatestSnapshotEnd = timeLatestSnapshotEnd;
+            this.__explicitlySet__.add("timeLatestSnapshotEnd");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("firstSnapshotId")
+        private Integer firstSnapshotId;
+
+        public Builder firstSnapshotId(Integer firstSnapshotId) {
+            this.firstSnapshotId = firstSnapshotId;
+            this.__explicitlySet__.add("firstSnapshotId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("latestSnapshotId")
+        private Integer latestSnapshotId;
+
+        public Builder latestSnapshotId(Integer latestSnapshotId) {
+            this.latestSnapshotId = latestSnapshotId;
+            this.__explicitlySet__.add("latestSnapshotId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("snapshotCount")
+        private Long snapshotCount;
+
+        public Builder snapshotCount(Long snapshotCount) {
+            this.snapshotCount = snapshotCount;
+            this.__explicitlySet__.add("snapshotCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("snapshotIntervalInMin")
+        private Integer snapshotIntervalInMin;
+
+        public Builder snapshotIntervalInMin(Integer snapshotIntervalInMin) {
+            this.snapshotIntervalInMin = snapshotIntervalInMin;
+            this.__explicitlySet__.add("snapshotIntervalInMin");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("containerId")
+        private Integer containerId;
+
+        public Builder containerId(Integer containerId) {
+            this.containerId = containerId;
+            this.__explicitlySet__.add("containerId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+        private String dbVersion;
+
+        public Builder dbVersion(String dbVersion) {
+            this.dbVersion = dbVersion;
+            this.__explicitlySet__.add("dbVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("snapshotTimezone")
+        private String snapshotTimezone;
+
+        public Builder snapshotTimezone(String snapshotTimezone) {
+            this.snapshotTimezone = snapshotTimezone;
+            this.__explicitlySet__.add("snapshotTimezone");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbSummary build() {
+            AwrDbSummary __instance__ =
+                    new AwrDbSummary(
+                            awrDbId,
+                            dbName,
+                            instanceList,
+                            timeDbStartup,
+                            timeFirstSnapshotBegin,
+                            timeLatestSnapshotEnd,
+                            firstSnapshotId,
+                            latestSnapshotId,
+                            snapshotCount,
+                            snapshotIntervalInMin,
+                            containerId,
+                            dbVersion,
+                            snapshotTimezone);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbSummary o) {
+            Builder copiedBuilder =
+                    awrDbId(o.getAwrDbId())
+                            .dbName(o.getDbName())
+                            .instanceList(o.getInstanceList())
+                            .timeDbStartup(o.getTimeDbStartup())
+                            .timeFirstSnapshotBegin(o.getTimeFirstSnapshotBegin())
+                            .timeLatestSnapshotEnd(o.getTimeLatestSnapshotEnd())
+                            .firstSnapshotId(o.getFirstSnapshotId())
+                            .latestSnapshotId(o.getLatestSnapshotId())
+                            .snapshotCount(o.getSnapshotCount())
+                            .snapshotIntervalInMin(o.getSnapshotIntervalInMin())
+                            .containerId(o.getContainerId())
+                            .dbVersion(o.getDbVersion())
+                            .snapshotTimezone(o.getSnapshotTimezone());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The internal ID of the database. The internal ID of the database is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("awrDbId")
+    String awrDbId;
+
+    /**
+     * The name of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbName")
+    String dbName;
+
+    /**
+     * The database instance numbers.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceList")
+    java.util.List<Integer> instanceList;
+
+    /**
+     * The timestamp of the database startup.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeDbStartup")
+    java.util.Date timeDbStartup;
+
+    /**
+     * The start time of the earliest snapshot.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeFirstSnapshotBegin")
+    java.util.Date timeFirstSnapshotBegin;
+
+    /**
+     * The end time of the latest snapshot.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLatestSnapshotEnd")
+    java.util.Date timeLatestSnapshotEnd;
+
+    /**
+     * The ID of the earliest snapshot. The snapshot ID is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbSnapshots
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("firstSnapshotId")
+    Integer firstSnapshotId;
+
+    /**
+     * The ID of the latest snapshot. The snapshot ID is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbSnapshots
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("latestSnapshotId")
+    Integer latestSnapshotId;
+
+    /**
+     * The total number of snapshots.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("snapshotCount")
+    Long snapshotCount;
+
+    /**
+     * The interval time between snapshots (in minutes).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("snapshotIntervalInMin")
+    Integer snapshotIntervalInMin;
+
+    /**
+     * ID of the database container. The database container ID is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("containerId")
+    Integer containerId;
+
+    /**
+     * The version of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbVersion")
+    String dbVersion;
+
+    /**
+     * The time zone of the snapshot.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("snapshotTimezone")
+    String snapshotTimezone;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSysstatCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSysstatCollection.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR SYSSTAT time series summary data.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbSysstatCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbSysstatCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbSysstatSummary> items;
+
+        public Builder items(java.util.List<AwrDbSysstatSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbSysstatCollection build() {
+            AwrDbSysstatCollection __instance__ =
+                    new AwrDbSysstatCollection(name, version, queryKey, dbQueryTimeInSecs, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbSysstatCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbSysstatCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            java.util.List<AwrDbSysstatSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.items = items;
+    }
+
+    /**
+     * A list of AWR SYSSTAT summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbSysstatSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSysstatSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbSysstatSummary.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The summary of the AWR SYSSTAT data.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbSysstatSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbSysstatSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("category")
+        private String category;
+
+        public Builder category(String category) {
+            this.category = category;
+            this.__explicitlySet__.add("category");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeBegin")
+        private java.util.Date timeBegin;
+
+        public Builder timeBegin(java.util.Date timeBegin) {
+            this.timeBegin = timeBegin;
+            this.__explicitlySet__.add("timeBegin");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeEnd")
+        private java.util.Date timeEnd;
+
+        public Builder timeEnd(java.util.Date timeEnd) {
+            this.timeEnd = timeEnd;
+            this.__explicitlySet__.add("timeEnd");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("avgValue")
+        private Double avgValue;
+
+        public Builder avgValue(Double avgValue) {
+            this.avgValue = avgValue;
+            this.__explicitlySet__.add("avgValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("currentValue")
+        private Double currentValue;
+
+        public Builder currentValue(Double currentValue) {
+            this.currentValue = currentValue;
+            this.__explicitlySet__.add("currentValue");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbSysstatSummary build() {
+            AwrDbSysstatSummary __instance__ =
+                    new AwrDbSysstatSummary(
+                            name, category, timeBegin, timeEnd, avgValue, currentValue);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbSysstatSummary o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .category(o.getCategory())
+                            .timeBegin(o.getTimeBegin())
+                            .timeEnd(o.getTimeEnd())
+                            .avgValue(o.getAvgValue())
+                            .currentValue(o.getCurrentValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the SYSSTAT.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The name of the SYSSTAT category.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("category")
+    String category;
+
+    /**
+     * The start time of the SYSSTAT.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeBegin")
+    java.util.Date timeBegin;
+
+    /**
+     * The end time of the SYSSTAT.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeEnd")
+    java.util.Date timeEnd;
+
+    /**
+     * The average value of the SYSSTAT.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("avgValue")
+    Double avgValue;
+
+    /**
+     * The last value of the SYSSTAT.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currentValue")
+    Double currentValue;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbTopWaitEventCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbTopWaitEventCollection.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR top wait event data.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbTopWaitEventCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbTopWaitEventCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbTopWaitEventSummary> items;
+
+        public Builder items(java.util.List<AwrDbTopWaitEventSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbTopWaitEventCollection build() {
+            AwrDbTopWaitEventCollection __instance__ =
+                    new AwrDbTopWaitEventCollection(
+                            name, version, queryKey, dbQueryTimeInSecs, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbTopWaitEventCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbTopWaitEventCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            java.util.List<AwrDbTopWaitEventSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.items = items;
+    }
+
+    /**
+     * A list of AWR top event summary data.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbTopWaitEventSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbTopWaitEventSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbTopWaitEventSummary.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * A summary of the AWR top wait event data for one event.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbTopWaitEventSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbTopWaitEventSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("waitsPerSec")
+        private Double waitsPerSec;
+
+        public Builder waitsPerSec(Double waitsPerSec) {
+            this.waitsPerSec = waitsPerSec;
+            this.__explicitlySet__.add("waitsPerSec");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("avgWaitTimePerSec")
+        private Double avgWaitTimePerSec;
+
+        public Builder avgWaitTimePerSec(Double avgWaitTimePerSec) {
+            this.avgWaitTimePerSec = avgWaitTimePerSec;
+            this.__explicitlySet__.add("avgWaitTimePerSec");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbTopWaitEventSummary build() {
+            AwrDbTopWaitEventSummary __instance__ =
+                    new AwrDbTopWaitEventSummary(name, waitsPerSec, avgWaitTimePerSec);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbTopWaitEventSummary o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .waitsPerSec(o.getWaitsPerSec())
+                            .avgWaitTimePerSec(o.getAvgWaitTimePerSec());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the event.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The wait count per second.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("waitsPerSec")
+    Double waitsPerSec;
+
+    /**
+     * The average wait time per second.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("avgWaitTimePerSec")
+    Double avgWaitTimePerSec;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbWaitEventBucketCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbWaitEventBucketCollection.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The percentage distribution of waits in the AWR wait event buckets.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbWaitEventBucketCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbWaitEventBucketCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("totalWaits")
+        private Long totalWaits;
+
+        public Builder totalWaits(Long totalWaits) {
+            this.totalWaits = totalWaits;
+            this.__explicitlySet__.add("totalWaits");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbWaitEventBucketSummary> items;
+
+        public Builder items(java.util.List<AwrDbWaitEventBucketSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbWaitEventBucketCollection build() {
+            AwrDbWaitEventBucketCollection __instance__ =
+                    new AwrDbWaitEventBucketCollection(
+                            name, version, queryKey, dbQueryTimeInSecs, totalWaits, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbWaitEventBucketCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .totalWaits(o.getTotalWaits())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbWaitEventBucketCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            Long totalWaits,
+            java.util.List<AwrDbWaitEventBucketSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.totalWaits = totalWaits;
+        this.items = items;
+    }
+
+    /**
+     * The total waits of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalWaits")
+    Long totalWaits;
+
+    /**
+     * A list of AWR wait event buckets.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbWaitEventBucketSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbWaitEventBucketSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbWaitEventBucketSummary.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * A summary of the AWR wait event bucket and waits percentage.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbWaitEventBucketSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbWaitEventBucketSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("category")
+        private String category;
+
+        public Builder category(String category) {
+            this.category = category;
+            this.__explicitlySet__.add("category");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("percentage")
+        private Double percentage;
+
+        public Builder percentage(Double percentage) {
+            this.percentage = percentage;
+            this.__explicitlySet__.add("percentage");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbWaitEventBucketSummary build() {
+            AwrDbWaitEventBucketSummary __instance__ =
+                    new AwrDbWaitEventBucketSummary(category, percentage);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbWaitEventBucketSummary o) {
+            Builder copiedBuilder = category(o.getCategory()).percentage(o.getPercentage());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the wait event frequency category. Normally, it is the upper range of the waits within the AWR wait event bucket.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("category")
+    String category;
+
+    /**
+     * The percentage of waits in a wait event bucket over the total waits of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("percentage")
+    Double percentage;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbWaitEventCollection.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbWaitEventCollection.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR wait event data.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbWaitEventCollection.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbWaitEventCollection extends AwrQueryResult {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+        private String queryKey;
+
+        public Builder queryKey(String queryKey) {
+            this.queryKey = queryKey;
+            this.__explicitlySet__.add("queryKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+        private Double dbQueryTimeInSecs;
+
+        public Builder dbQueryTimeInSecs(Double dbQueryTimeInSecs) {
+            this.dbQueryTimeInSecs = dbQueryTimeInSecs;
+            this.__explicitlySet__.add("dbQueryTimeInSecs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<AwrDbWaitEventSummary> items;
+
+        public Builder items(java.util.List<AwrDbWaitEventSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbWaitEventCollection build() {
+            AwrDbWaitEventCollection __instance__ =
+                    new AwrDbWaitEventCollection(name, version, queryKey, dbQueryTimeInSecs, items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbWaitEventCollection o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .version(o.getVersion())
+                            .queryKey(o.getQueryKey())
+                            .dbQueryTimeInSecs(o.getDbQueryTimeInSecs())
+                            .items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public AwrDbWaitEventCollection(
+            String name,
+            String version,
+            String queryKey,
+            Double dbQueryTimeInSecs,
+            java.util.List<AwrDbWaitEventSummary> items) {
+        super(name, version, queryKey, dbQueryTimeInSecs);
+        this.items = items;
+    }
+
+    /**
+     * A list of AWR wait events.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<AwrDbWaitEventSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbWaitEventSummary.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrDbWaitEventSummary.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The summary of the AWR wait event time series data for one event.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AwrDbWaitEventSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwrDbWaitEventSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeBegin")
+        private java.util.Date timeBegin;
+
+        public Builder timeBegin(java.util.Date timeBegin) {
+            this.timeBegin = timeBegin;
+            this.__explicitlySet__.add("timeBegin");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeEnd")
+        private java.util.Date timeEnd;
+
+        public Builder timeEnd(java.util.Date timeEnd) {
+            this.timeEnd = timeEnd;
+            this.__explicitlySet__.add("timeEnd");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("waitsPerSec")
+        private Double waitsPerSec;
+
+        public Builder waitsPerSec(Double waitsPerSec) {
+            this.waitsPerSec = waitsPerSec;
+            this.__explicitlySet__.add("waitsPerSec");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("avgWaitTimePerSec")
+        private Double avgWaitTimePerSec;
+
+        public Builder avgWaitTimePerSec(Double avgWaitTimePerSec) {
+            this.avgWaitTimePerSec = avgWaitTimePerSec;
+            this.__explicitlySet__.add("avgWaitTimePerSec");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("snapshotId")
+        private Integer snapshotId;
+
+        public Builder snapshotId(Integer snapshotId) {
+            this.snapshotId = snapshotId;
+            this.__explicitlySet__.add("snapshotId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwrDbWaitEventSummary build() {
+            AwrDbWaitEventSummary __instance__ =
+                    new AwrDbWaitEventSummary(
+                            name, timeBegin, timeEnd, waitsPerSec, avgWaitTimePerSec, snapshotId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwrDbWaitEventSummary o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .timeBegin(o.getTimeBegin())
+                            .timeEnd(o.getTimeEnd())
+                            .waitsPerSec(o.getWaitsPerSec())
+                            .avgWaitTimePerSec(o.getAvgWaitTimePerSec())
+                            .snapshotId(o.getSnapshotId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the event.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The begin time of the wait event.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeBegin")
+    java.util.Date timeBegin;
+
+    /**
+     * The end time of the wait event.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeEnd")
+    java.util.Date timeEnd;
+
+    /**
+     * The wait count per second.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("waitsPerSec")
+    Double waitsPerSec;
+
+    /**
+     * The average wait time per second.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("avgWaitTimePerSec")
+    Double avgWaitTimePerSec;
+
+    /**
+     * The ID of the snapshot. The snapshot ID is not the [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     * It can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbSnapshots
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("snapshotId")
+    Integer snapshotId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrQueryResult.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/model/AwrQueryResult.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.model;
+
+/**
+ * The AWR query result.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "awrResultType",
+    defaultImpl = AwrQueryResult.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbParameterChangeCollection.class,
+        name = "AWRDB_DB_PARAMETER_CHANGE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbCpuUsageCollection.class,
+        name = "AWRDB_ASH_CPU_USAGE_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbWaitEventBucketCollection.class,
+        name = "AWRDB_EVENT_HISTOGRAM_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbParameterCollection.class,
+        name = "AWRDB_DB_PARAMETER_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbSysstatCollection.class,
+        name = "AWRDB_SYSSTAT_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbTopWaitEventCollection.class,
+        name = "AWRDB_TOP_EVENT_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbSnapshotCollection.class,
+        name = "AWRDB_SNAPSHOT_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbCollection.class,
+        name = "AWRDB_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbSnapshotRangeCollection.class,
+        name = "AWRDB_SNAPSHOT_RANGE_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbReport.class,
+        name = "AWRDB_DB_REPORT"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbMetricCollection.class,
+        name = "AWRDB_METRICS_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbWaitEventCollection.class,
+        name = "AWRDB_EVENT_SET"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = AwrDbSqlReport.class,
+        name = "AWRDB_SQL_REPORT"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class AwrQueryResult {
+
+    /**
+     * The name of the query result.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The version of the query result.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    /**
+     * The ID assigned to the query instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("queryKey")
+    String queryKey;
+
+    /**
+     * The time taken to query the database tier (in seconds).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbQueryTimeInSecs")
+    Double dbQueryTimeInSecs;
+
+    /**
+     * The result type of AWR query.
+     **/
+    public enum AwrResultType {
+        AwrdbSet("AWRDB_SET"),
+        AwrdbSnapshotRangeSet("AWRDB_SNAPSHOT_RANGE_SET"),
+        AwrdbSnapshotSet("AWRDB_SNAPSHOT_SET"),
+        AwrdbMetricsSet("AWRDB_METRICS_SET"),
+        AwrdbSysstatSet("AWRDB_SYSSTAT_SET"),
+        AwrdbTopEventSet("AWRDB_TOP_EVENT_SET"),
+        AwrdbEventSet("AWRDB_EVENT_SET"),
+        AwrdbEventHistogram("AWRDB_EVENT_HISTOGRAM"),
+        AwrdbDbParameterSet("AWRDB_DB_PARAMETER_SET"),
+        AwrdbDbParameterChange("AWRDB_DB_PARAMETER_CHANGE"),
+        AwrdbAshCpuUsageSet("AWRDB_ASH_CPU_USAGE_SET"),
+        AwrdbDbReport("AWRDB_DB_REPORT"),
+        AwrdbSqlReport("AWRDB_SQL_REPORT"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, AwrResultType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AwrResultType v : AwrResultType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        AwrResultType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AwrResultType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid AwrResultType: " + key);
+        }
+    };
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/GetAwrDbReportRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/GetAwrDbReportRequest.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/GetAwrDbReportExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetAwrDbReportRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetAwrDbReportRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The optional multiple value query parameter to filter the database instance numbers.
+     */
+    private java.util.List<Integer> instNums;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The query parameter to filter the AWR report types.
+     */
+    private ReportType reportType;
+
+    /**
+     * The query parameter to filter the AWR report types.
+     **/
+    public enum ReportType {
+        Awr("AWR"),
+        Ash("ASH"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ReportType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ReportType v : ReportType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ReportType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ReportType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ReportType: " + key);
+        }
+    };
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The format of the AWR report.
+     */
+    private ReportFormat reportFormat;
+
+    /**
+     * The format of the AWR report.
+     **/
+    public enum ReportFormat {
+        Html("HTML"),
+        Text("TEXT"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ReportFormat> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ReportFormat v : ReportFormat.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ReportFormat(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ReportFormat create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ReportFormat: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetAwrDbReportRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAwrDbReportRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            instNums(o.getInstNums());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            reportType(o.getReportType());
+            containerId(o.getContainerId());
+            reportFormat(o.getReportFormat());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetAwrDbReportRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetAwrDbReportRequest
+         */
+        public GetAwrDbReportRequest build() {
+            GetAwrDbReportRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/GetAwrDbSqlReportRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/GetAwrDbSqlReportRequest.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/GetAwrDbSqlReportExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetAwrDbSqlReportRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetAwrDbSqlReportRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The parameter to filter SQL by ID. Note that the SQL ID is generated internally by Oracle for each SQL statement and can be retrieved from AWR Report API (/managedDatabases/{managedDatabaseId}/awrDbs/{awrDbId}/awrDbReport) or Performance Hub API (/internal/managedDatabases/{managedDatabaseId}/actions/retrievePerformanceData)
+     *
+     */
+    private String sqlId;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The format of the AWR report.
+     */
+    private ReportFormat reportFormat;
+
+    /**
+     * The format of the AWR report.
+     **/
+    public enum ReportFormat {
+        Html("HTML"),
+        Text("TEXT"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ReportFormat> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ReportFormat v : ReportFormat.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ReportFormat(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ReportFormat create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ReportFormat: " + key);
+        }
+    };
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetAwrDbSqlReportRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAwrDbSqlReportRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            sqlId(o.getSqlId());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            reportFormat(o.getReportFormat());
+            containerId(o.getContainerId());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetAwrDbSqlReportRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetAwrDbSqlReportRequest
+         */
+        public GetAwrDbSqlReportRequest build() {
+            GetAwrDbSqlReportRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListAwrDbSnapshotsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListAwrDbSnapshotsRequest.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/ListAwrDbSnapshotsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListAwrDbSnapshotsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListAwrDbSnapshotsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort the AWR snapshot summary data.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the AWR snapshot summary data.
+     **/
+    public enum SortBy {
+        TimeBegin("TIME_BEGIN"),
+        SnapshotId("SNAPSHOT_ID"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListAwrDbSnapshotsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAwrDbSnapshotsRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            containerId(o.getContainerId());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListAwrDbSnapshotsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListAwrDbSnapshotsRequest
+         */
+        public ListAwrDbSnapshotsRequest build() {
+            ListAwrDbSnapshotsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListAwrDbsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListAwrDbsRequest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/ListAwrDbsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListAwrDbsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListAwrDbsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The optional single value query parameter to filter the entity name.
+     */
+    private String name;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort the AWR summary data.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the AWR summary data.
+     **/
+    public enum SortBy {
+        EndIntervalTime("END_INTERVAL_TIME"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListAwrDbsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAwrDbsRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            name(o.getName());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListAwrDbsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListAwrDbsRequest
+         */
+        public ListAwrDbsRequest build() {
+            ListAwrDbsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListDatabaseParametersRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListDatabaseParametersRequest.java
@@ -134,7 +134,7 @@ public class ListDatabaseParametersRequest
         }
     };
     /**
-     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order.
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Ascending order is the the default order.
      */
     private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
 

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListJobExecutionsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListJobExecutionsRequest.java
@@ -118,7 +118,7 @@ public class ListJobExecutionsRequest extends com.oracle.bmc.requests.BmcRequest
         }
     };
     /**
-     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order.
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Ascending order is the the default order.
      */
     private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
 

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListJobRunsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListJobRunsRequest.java
@@ -118,7 +118,7 @@ public class ListJobRunsRequest extends com.oracle.bmc.requests.BmcRequest<java.
         }
     };
     /**
-     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order.
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Ascending order is the the default order.
      */
     private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
 

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListJobsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListJobsRequest.java
@@ -113,7 +113,7 @@ public class ListJobsRequest extends com.oracle.bmc.requests.BmcRequest<java.lan
         }
     };
     /**
-     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order.
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Ascending order is the the default order.
      */
     private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
 

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListManagedDatabaseGroupsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListManagedDatabaseGroupsRequest.java
@@ -104,7 +104,7 @@ public class ListManagedDatabaseGroupsRequest
         }
     };
     /**
-     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order.
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Ascending order is the the default order.
      */
     private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
 

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListManagedDatabasesRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListManagedDatabasesRequest.java
@@ -99,7 +99,7 @@ public class ListManagedDatabasesRequest
         }
     };
     /**
-     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order.
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Ascending order is the the default order.
      */
     private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
 

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListTablespacesRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/ListTablespacesRequest.java
@@ -81,7 +81,7 @@ public class ListTablespacesRequest extends com.oracle.bmc.requests.BmcRequest<j
         }
     };
     /**
-     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order.
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Ascending order is the the default order.
      */
     private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
 

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbCpuUsagesRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbCpuUsagesRequest.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbCpuUsagesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeAwrDbCpuUsagesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeAwrDbCpuUsagesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The optional query parameter to filter ASH activities by FOREGROUND or BACKGROUND.
+     */
+    private SessionType sessionType;
+
+    /**
+     * The optional query parameter to filter ASH activities by FOREGROUND or BACKGROUND.
+     **/
+    public enum SessionType {
+        Foreground("FOREGROUND"),
+        Background("BACKGROUND"),
+        All("ALL"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SessionType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SessionType v : SessionType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SessionType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SessionType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SessionType: " + key);
+        }
+    };
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in large paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort the AWR CPU usage summary data.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the AWR CPU usage summary data.
+     **/
+    public enum SortBy {
+        TimeSampled("TIME_SAMPLED"),
+        AvgValue("AVG_VALUE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeAwrDbCpuUsagesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbCpuUsagesRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            sessionType(o.getSessionType());
+            containerId(o.getContainerId());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeAwrDbCpuUsagesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeAwrDbCpuUsagesRequest
+         */
+        public SummarizeAwrDbCpuUsagesRequest build() {
+            SummarizeAwrDbCpuUsagesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbMetricsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbMetricsRequest.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbMetricsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeAwrDbMetricsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeAwrDbMetricsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The required multiple value query parameter to filter the entity name.
+     */
+    private java.util.List<String> name;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in large paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort the AWR time series summary data.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the AWR time series summary data.
+     **/
+    public enum SortBy {
+        Timestamp("TIMESTAMP"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeAwrDbMetricsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbMetricsRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            name(o.getName());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            containerId(o.getContainerId());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeAwrDbMetricsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeAwrDbMetricsRequest
+         */
+        public SummarizeAwrDbMetricsRequest build() {
+            SummarizeAwrDbMetricsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbParameterChangesRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbParameterChangesRequest.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbParameterChangesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeAwrDbParameterChangesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeAwrDbParameterChangesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The required single value query parameter to filter the entity name.
+     */
+    private String name;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in large paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort the AWR database parameter change history data.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the AWR database parameter change history data.
+     **/
+    public enum SortBy {
+        IsChanged("IS_CHANGED"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeAwrDbParameterChangesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbParameterChangesRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            name(o.getName());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            containerId(o.getContainerId());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeAwrDbParameterChangesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeAwrDbParameterChangesRequest
+         */
+        public SummarizeAwrDbParameterChangesRequest build() {
+            SummarizeAwrDbParameterChangesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbParametersRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbParametersRequest.java
@@ -1,0 +1,348 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbParametersExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeAwrDbParametersRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeAwrDbParametersRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The optional multiple value query parameter to filter the entity name.
+     */
+    private java.util.List<String> name;
+
+    /**
+     * The optional contains query parameter to filter the entity name by any part of the name.
+     */
+    private String nameContains;
+
+    /**
+     * The optional query parameter to filter database parameters whose values were changed.
+     */
+    private ValueChanged valueChanged;
+
+    /**
+     * The optional query parameter to filter database parameters whose values were changed.
+     **/
+    public enum ValueChanged {
+        Y("Y"),
+        N("N"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ValueChanged> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ValueChanged v : ValueChanged.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ValueChanged(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ValueChanged create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ValueChanged: " + key);
+        }
+    };
+    /**
+     * The optional query parameter to filter the database parameters that had the default value in the last snapshot.
+     */
+    private ValueDefault valueDefault;
+
+    /**
+     * The optional query parameter to filter the database parameters that had the default value in the last snapshot.
+     **/
+    public enum ValueDefault {
+        True("TRUE"),
+        False("FALSE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ValueDefault> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ValueDefault v : ValueDefault.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ValueDefault(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ValueDefault create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ValueDefault: " + key);
+        }
+    };
+    /**
+     * The optional query parameter to filter the database parameters that had a modified value in the last snapshot.
+     */
+    private ValueModified valueModified;
+
+    /**
+     * The optional query parameter to filter the database parameters that had a modified value in the last snapshot.
+     **/
+    public enum ValueModified {
+        Modified("MODIFIED"),
+        SystemMod("SYSTEM_MOD"),
+        False("FALSE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ValueModified> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ValueModified v : ValueModified.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ValueModified(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ValueModified create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ValueModified: " + key);
+        }
+    };
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in large paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort the AWR database parameter change history data.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the AWR database parameter change history data.
+     **/
+    public enum SortBy {
+        IsChanged("IS_CHANGED"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeAwrDbParametersRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbParametersRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            containerId(o.getContainerId());
+            name(o.getName());
+            nameContains(o.getNameContains());
+            valueChanged(o.getValueChanged());
+            valueDefault(o.getValueDefault());
+            valueModified(o.getValueModified());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeAwrDbParametersRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeAwrDbParametersRequest
+         */
+        public SummarizeAwrDbParametersRequest build() {
+            SummarizeAwrDbParametersRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbSnapshotRangesRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbSnapshotRangesRequest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbSnapshotRangesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeAwrDbSnapshotRangesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeAwrDbSnapshotRangesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The optional single value query parameter to filter the entity name.
+     */
+    private String name;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort the AWR summary data.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the AWR summary data.
+     **/
+    public enum SortBy {
+        EndIntervalTime("END_INTERVAL_TIME"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeAwrDbSnapshotRangesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbSnapshotRangesRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            name(o.getName());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeAwrDbSnapshotRangesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeAwrDbSnapshotRangesRequest
+         */
+        public SummarizeAwrDbSnapshotRangesRequest build() {
+            SummarizeAwrDbSnapshotRangesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbSysstatsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbSysstatsRequest.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbSysstatsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeAwrDbSysstatsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeAwrDbSysstatsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The required multiple value query parameter to filter the entity name.
+     */
+    private java.util.List<String> name;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in large paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort the data within a time period.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the data within a time period.
+     **/
+    public enum SortBy {
+        TimeBegin("TIME_BEGIN"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeAwrDbSysstatsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbSysstatsRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            name(o.getName());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            containerId(o.getContainerId());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeAwrDbSysstatsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeAwrDbSysstatsRequest
+         */
+        public SummarizeAwrDbSysstatsRequest build() {
+            SummarizeAwrDbSysstatsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbTopWaitEventsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbTopWaitEventsRequest.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbTopWaitEventsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeAwrDbTopWaitEventsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeAwrDbTopWaitEventsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The optional query parameter to filter ASH activities by FOREGROUND or BACKGROUND.
+     */
+    private SessionType sessionType;
+
+    /**
+     * The optional query parameter to filter ASH activities by FOREGROUND or BACKGROUND.
+     **/
+    public enum SessionType {
+        Foreground("FOREGROUND"),
+        Background("BACKGROUND"),
+        All("ALL"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SessionType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SessionType v : SessionType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SessionType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SessionType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SessionType: " + key);
+        }
+    };
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The optional query parameter to filter the number of top categories to be returned.
+     */
+    private Integer topN;
+
+    /**
+     * The option to sort the AWR top event summary data.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the AWR top event summary data.
+     **/
+    public enum SortBy {
+        WaitsPersec("WAITS_PERSEC"),
+        AvgWaitTimePersec("AVG_WAIT_TIME_PERSEC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeAwrDbTopWaitEventsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbTopWaitEventsRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            sessionType(o.getSessionType());
+            containerId(o.getContainerId());
+            topN(o.getTopN());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeAwrDbTopWaitEventsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeAwrDbTopWaitEventsRequest
+         */
+        public SummarizeAwrDbTopWaitEventsRequest build() {
+            SummarizeAwrDbTopWaitEventsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbWaitEventBucketsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbWaitEventBucketsRequest.java
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbWaitEventBucketsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeAwrDbWaitEventBucketsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeAwrDbWaitEventBucketsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The required single value query parameter to filter the entity name.
+     */
+    private String name;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The number of buckets within the histogram.
+     */
+    private Integer numBucket;
+
+    /**
+     * The minimum value of the histogram.
+     */
+    private Double minValue;
+
+    /**
+     * The maximum value of the histogram.
+     */
+    private Double maxValue;
+
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in large paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort distribution data.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort distribution data.
+     **/
+    public enum SortBy {
+        Category("CATEGORY"),
+        Percentage("PERCENTAGE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Ascending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeAwrDbWaitEventBucketsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbWaitEventBucketsRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            name(o.getName());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            numBucket(o.getNumBucket());
+            minValue(o.getMinValue());
+            maxValue(o.getMaxValue());
+            containerId(o.getContainerId());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeAwrDbWaitEventBucketsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeAwrDbWaitEventBucketsRequest
+         */
+        public SummarizeAwrDbWaitEventBucketsRequest build() {
+            SummarizeAwrDbWaitEventBucketsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbWaitEventsRequest.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/requests/SummarizeAwrDbWaitEventsRequest.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.requests;
+
+import com.oracle.bmc.databasemanagement.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemanagement/SummarizeAwrDbWaitEventsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SummarizeAwrDbWaitEventsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SummarizeAwrDbWaitEventsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Managed Database.
+     */
+    private String managedDatabaseId;
+
+    /**
+     * The parameter to filter the database by internal ID.
+     * Note that the internal ID of the database can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbs:
+     *
+     */
+    private String awrDbId;
+
+    /**
+     * The optional single value query parameter to filter the database instance number.
+     */
+    private String instNum;
+
+    /**
+     * The optional greater than or equal to filter on the snapshot ID.
+     */
+    private Integer beginSnIdGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the snapshot ID.
+     */
+    private Integer endSnIdLessThanOrEqualTo;
+
+    /**
+     * The optional greater than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeGreaterThanOrEqualTo;
+
+    /**
+     * The optional less than or equal to query parameter to filter the timestamp.
+     */
+    private java.util.Date timeLessThanOrEqualTo;
+
+    /**
+     * The optional multiple value query parameter to filter the entity name.
+     */
+    private java.util.List<String> name;
+
+    /**
+     * The optional query parameter to filter ASH activities by FOREGROUND or BACKGROUND.
+     */
+    private SessionType sessionType;
+
+    /**
+     * The optional query parameter to filter ASH activities by FOREGROUND or BACKGROUND.
+     **/
+    public enum SessionType {
+        Foreground("FOREGROUND"),
+        Background("BACKGROUND"),
+        All("ALL"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SessionType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SessionType v : SessionType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SessionType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SessionType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SessionType: " + key);
+        }
+    };
+    /**
+     * The optional query parameter to filter the database container by an exact ID value.
+     * Note that the database container ID can be retrieved from the following endpoint:
+     * /managedDatabases/{managedDatabaseId}/awrDbSnapshotRanges
+     *
+     */
+    private Integer containerId;
+
+    /**
+     * The page token representing the page, from where the next set of paginated results
+     * are retrieved. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The maximum number of records returned in large paginated response.
+     */
+    private Integer limit;
+
+    /**
+     * The option to sort the data within a time period.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The option to sort the data within a time period.
+     **/
+    public enum SortBy {
+        TimeBegin("TIME_BEGIN"),
+        Name("NAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The option to sort information in ascending (\u2018ASC\u2019) or descending (\u2018DESC\u2019) order. Descending order is the the default order.
+     */
+    private com.oracle.bmc.databasemanagement.model.SortOrders sortOrder;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SummarizeAwrDbWaitEventsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbWaitEventsRequest o) {
+            managedDatabaseId(o.getManagedDatabaseId());
+            awrDbId(o.getAwrDbId());
+            instNum(o.getInstNum());
+            beginSnIdGreaterThanOrEqualTo(o.getBeginSnIdGreaterThanOrEqualTo());
+            endSnIdLessThanOrEqualTo(o.getEndSnIdLessThanOrEqualTo());
+            timeGreaterThanOrEqualTo(o.getTimeGreaterThanOrEqualTo());
+            timeLessThanOrEqualTo(o.getTimeLessThanOrEqualTo());
+            name(o.getName());
+            sessionType(o.getSessionType());
+            containerId(o.getContainerId());
+            page(o.getPage());
+            limit(o.getLimit());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SummarizeAwrDbWaitEventsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SummarizeAwrDbWaitEventsRequest
+         */
+        public SummarizeAwrDbWaitEventsRequest build() {
+            SummarizeAwrDbWaitEventsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/GetAwrDbReportResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/GetAwrDbReportResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetAwrDbReportResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned AwrDbReport instance.
+     */
+    private AwrDbReport awrDbReport;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAwrDbReportResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            awrDbReport(o.getAwrDbReport());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/GetAwrDbSqlReportResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/GetAwrDbSqlReportResponse.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetAwrDbSqlReportResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned AwrDbSqlReport instance.
+     */
+    private AwrDbSqlReport awrDbSqlReport;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAwrDbSqlReportResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            awrDbSqlReport(o.getAwrDbSqlReport());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/ListAwrDbSnapshotsResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/ListAwrDbSnapshotsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListAwrDbSnapshotsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbSnapshotCollection instance.
+     */
+    private AwrDbSnapshotCollection awrDbSnapshotCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAwrDbSnapshotsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbSnapshotCollection(o.getAwrDbSnapshotCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/ListAwrDbsResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/ListAwrDbsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ListAwrDbsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbCollection instance.
+     */
+    private AwrDbCollection awrDbCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListAwrDbsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbCollection(o.getAwrDbCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbCpuUsagesResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbCpuUsagesResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SummarizeAwrDbCpuUsagesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbCpuUsageCollection instance.
+     */
+    private AwrDbCpuUsageCollection awrDbCpuUsageCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbCpuUsagesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbCpuUsageCollection(o.getAwrDbCpuUsageCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbMetricsResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbMetricsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SummarizeAwrDbMetricsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbMetricCollection instance.
+     */
+    private AwrDbMetricCollection awrDbMetricCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbMetricsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbMetricCollection(o.getAwrDbMetricCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbParameterChangesResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbParameterChangesResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SummarizeAwrDbParameterChangesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbParameterChangeCollection instance.
+     */
+    private AwrDbParameterChangeCollection awrDbParameterChangeCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbParameterChangesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbParameterChangeCollection(o.getAwrDbParameterChangeCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbParametersResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbParametersResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SummarizeAwrDbParametersResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbParameterCollection instance.
+     */
+    private AwrDbParameterCollection awrDbParameterCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbParametersResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbParameterCollection(o.getAwrDbParameterCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbSnapshotRangesResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbSnapshotRangesResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SummarizeAwrDbSnapshotRangesResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbSnapshotRangeCollection instance.
+     */
+    private AwrDbSnapshotRangeCollection awrDbSnapshotRangeCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbSnapshotRangesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbSnapshotRangeCollection(o.getAwrDbSnapshotRangeCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbSysstatsResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbSysstatsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SummarizeAwrDbSysstatsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbSysstatCollection instance.
+     */
+    private AwrDbSysstatCollection awrDbSysstatCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbSysstatsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbSysstatCollection(o.getAwrDbSysstatCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbTopWaitEventsResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbTopWaitEventsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SummarizeAwrDbTopWaitEventsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbTopWaitEventCollection instance.
+     */
+    private AwrDbTopWaitEventCollection awrDbTopWaitEventCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbTopWaitEventsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbTopWaitEventCollection(o.getAwrDbTopWaitEventCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbWaitEventBucketsResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbWaitEventBucketsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SummarizeAwrDbWaitEventBucketsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbWaitEventBucketCollection instance.
+     */
+    private AwrDbWaitEventBucketCollection awrDbWaitEventBucketCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbWaitEventBucketsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbWaitEventBucketCollection(o.getAwrDbWaitEventBucketCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbWaitEventsResponse.java
+++ b/bmc-databasemanagement/src/main/java/com/oracle/bmc/databasemanagement/responses/SummarizeAwrDbWaitEventsResponse.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemanagement.responses;
+
+import com.oracle.bmc.databasemanagement.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201101")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class SummarizeAwrDbWaitEventsResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the `page` parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned AwrDbWaitEventCollection instance.
+     */
+    private AwrDbWaitEventCollection awrDbWaitEventCollection;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SummarizeAwrDbWaitEventsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            awrDbWaitEventCollection(o.getAwrDbWaitEventCollection());
+
+            return this;
+        }
+    }
+}

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionConfigurationDetails.java
@@ -53,12 +53,26 @@ public class NotebookSessionConfigurationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionShapeConfigDetails")
+        private NotebookSessionShapeConfigDetails notebookSessionShapeConfigDetails;
+
+        public Builder notebookSessionShapeConfigDetails(
+                NotebookSessionShapeConfigDetails notebookSessionShapeConfigDetails) {
+            this.notebookSessionShapeConfigDetails = notebookSessionShapeConfigDetails;
+            this.__explicitlySet__.add("notebookSessionShapeConfigDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public NotebookSessionConfigurationDetails build() {
             NotebookSessionConfigurationDetails __instance__ =
-                    new NotebookSessionConfigurationDetails(shape, blockStorageSizeInGBs, subnetId);
+                    new NotebookSessionConfigurationDetails(
+                            shape,
+                            blockStorageSizeInGBs,
+                            subnetId,
+                            notebookSessionShapeConfigDetails);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -68,7 +82,9 @@ public class NotebookSessionConfigurationDetails {
             Builder copiedBuilder =
                     shape(o.getShape())
                             .blockStorageSizeInGBs(o.getBlockStorageSizeInGBs())
-                            .subnetId(o.getSubnetId());
+                            .subnetId(o.getSubnetId())
+                            .notebookSessionShapeConfigDetails(
+                                    o.getNotebookSessionShapeConfigDetails());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -102,6 +118,9 @@ public class NotebookSessionConfigurationDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
     String subnetId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionShapeConfigDetails")
+    NotebookSessionShapeConfigDetails notebookSessionShapeConfigDetails;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionShapeConfigDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionShapeConfigDetails.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * Details for the notebook session shape configuration.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = NotebookSessionShapeConfigDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NotebookSessionShapeConfigDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("ocpus")
+        private Float ocpus;
+
+        public Builder ocpus(Float ocpus) {
+            this.ocpus = ocpus;
+            this.__explicitlySet__.add("ocpus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memoryInGBs")
+        private Float memoryInGBs;
+
+        public Builder memoryInGBs(Float memoryInGBs) {
+            this.memoryInGBs = memoryInGBs;
+            this.__explicitlySet__.add("memoryInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NotebookSessionShapeConfigDetails build() {
+            NotebookSessionShapeConfigDetails __instance__ =
+                    new NotebookSessionShapeConfigDetails(ocpus, memoryInGBs);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NotebookSessionShapeConfigDetails o) {
+            Builder copiedBuilder = ocpus(o.getOcpus()).memoryInGBs(o.getMemoryInGBs());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A notebook session instance of type VM.Standard.E3.Flex allows the ocpu count to be specified.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ocpus")
+    Float ocpus;
+
+    /**
+     * A notebook session instance of type VM.Standard.E3.Flex allows memory to be specified. This specifies the size of the memory in GBs.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memoryInGBs")
+    Float memoryInGBs;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionShapeSeries.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionShapeSeries.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The family that the compute shape belongs to.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.extern.slf4j.Slf4j
+public enum NotebookSessionShapeSeries {
+    AmdRome("AMD_ROME"),
+    IntelSkylake("INTEL_SKYLAKE"),
+    NvidiaGpu("NVIDIA_GPU"),
+    Legacy("LEGACY"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, NotebookSessionShapeSeries> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (NotebookSessionShapeSeries v : NotebookSessionShapeSeries.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    NotebookSessionShapeSeries(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static NotebookSessionShapeSeries create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'NotebookSessionShapeSeries', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionShapeSummary.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionShapeSummary.java
@@ -54,12 +54,21 @@ public class NotebookSessionShapeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeSeries")
+        private NotebookSessionShapeSeries shapeSeries;
+
+        public Builder shapeSeries(NotebookSessionShapeSeries shapeSeries) {
+            this.shapeSeries = shapeSeries;
+            this.__explicitlySet__.add("shapeSeries");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public NotebookSessionShapeSummary build() {
             NotebookSessionShapeSummary __instance__ =
-                    new NotebookSessionShapeSummary(name, coreCount, memoryInGBs);
+                    new NotebookSessionShapeSummary(name, coreCount, memoryInGBs, shapeSeries);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -67,7 +76,10 @@ public class NotebookSessionShapeSummary {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(NotebookSessionShapeSummary o) {
             Builder copiedBuilder =
-                    name(o.getName()).coreCount(o.getCoreCount()).memoryInGBs(o.getMemoryInGBs());
+                    name(o.getName())
+                            .coreCount(o.getCoreCount())
+                            .memoryInGBs(o.getMemoryInGBs())
+                            .shapeSeries(o.getShapeSeries());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -101,6 +113,13 @@ public class NotebookSessionShapeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("memoryInGBs")
     Integer memoryInGBs;
+
+    /**
+     * The family that the compute shape belongs to.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeSeries")
+    NotebookSessionShapeSeries shapeSeries;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -22,11 +22,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/gradle-example/src/main/java/ObjectStorageGetNamespaceExample.java
+++ b/bmc-examples/gradle-example/src/main/java/ObjectStorageGetNamespaceExample.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+import com.oracle.bmc.ConfigFileReader;
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.objectstorage.ObjectStorageClient;
+import com.oracle.bmc.objectstorage.requests.GetNamespaceRequest;
+
+/**
+ * This class provides a basic example of how to get Object Storage namespace of a tenancy that is not their own. This
+ * is useful in cross-tenant Object Storage operations. Object Storage namespace can be retrieved using the
+ * compartment id of the target tenancy if the user has necessary permissions to access that tenancy.
+ *
+ * For example if Tenant A wants to access Tenant B's object storage namespace then Tenant A has to define
+ * a policy similar to following:
+ *
+ * DEFINE TENANCY TenantB AS <TenantB OCID>
+ * ENDORSE GROUP <TenantA user group name> TO {OBJECTSTORAGE_NAMESPACE_READ} IN TENANCY TenantB
+ *
+ * and Tenant B should add a policy similar to following:
+ *
+ * DEFINE TENANCY TenantA AS <TenantA OCID>
+ * DEFINE GROUP TenantAGroup AS <TenantA user group OCID>
+ * ADMIT GROUP TenantAGroup OF TENANCY TenantA TO {OBJECTSTORAGE_NAMESPACE_READ} IN TENANCY
+ *
+ * This example covers only GetNamespace operation across tenants. Additional permissions will be required to
+ * perform more Object Storage operations.
+ *
+ */
+public class ObjectStorageGetNamespaceExample {
+    private static final String CONFIG_LOCATION = "~/.oci/config";
+    private static final String CONFIG_PROFILE = "DEFAULT";
+
+    /**
+     * The entry point for the example.
+     *
+     * @param args Arguments to provide to the example. The following arguments are expected:
+     * <ul>
+     *   <li>The first argument is the OCID of the compartment for which we will get the namespace</li>
+     * </ul>
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            throw new IllegalArgumentException(
+                    "Unexpected number of arguments received. Consult the script header comments for expected arguments");
+        }
+
+        final String compartmentId = args[0];
+
+        // Configuring the AuthenticationDetailsProvider. It's assuming there is a default OCI config file
+        // "~/.oci/config", and a profile in that config with the name "DEFAULT". Make changes to the following
+        // line if needed and use ConfigFileReader.parse(CONFIG_LOCATION, CONFIG_PROFILE);
+
+        final ConfigFileReader.ConfigFile configFile = ConfigFileReader.parseDefault();
+
+        final AuthenticationDetailsProvider provider =
+                new ConfigFileAuthenticationDetailsProvider(configFile);
+        ObjectStorageClient objectStorageClient = new ObjectStorageClient(provider);
+        objectStorageClient.setRegion(Region.US_PHOENIX_1);
+
+        // Construct GetNamespaceRequest with the given compartmentId.
+        GetNamespaceRequest getNamespaceRequest =
+                GetNamespaceRequest.builder().compartmentId(compartmentId).build();
+        String namespace = objectStorageClient.getNamespace(getNamespaceRequest).getValue();
+
+        System.out.println(
+                String.format(
+                        "Object Storage namespace for compartment [%s] is [%s]",
+                        compartmentId,
+                        namespace));
+    }
+}

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -353,6 +353,14 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-bastion</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -22,11 +22,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>1.36.5</version>
+        <version>1.37.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -322,6 +322,14 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-bastion</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.oracle.oci.sdk</groupId>
+    <artifactId>oci-java-sdk</artifactId>
+    <version>1.37.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
+  <name>Oracle Cloud Infrastructure SDK - Generic Artifacts Content</name>
+  <description>This project contains the SDK used for Oracle Cloud Infrastructure Generic Artifacts Content</description>
+  <url>https://docs.cloud.oracle.com/Content/API/SDKDocs/javasdk.htm</url>
+  <dependencies>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-common</artifactId>
+      <version>1.37.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/GenericArtifactsContent.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/GenericArtifactsContent.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent;
+
+import com.oracle.bmc.genericartifactscontent.requests.*;
+import com.oracle.bmc.genericartifactscontent.responses.*;
+
+/**
+ * API covering the Generic Artifacts Service content
+ * Use this API to put and get generic artifact content.
+ *
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+public interface GenericArtifactsContent extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Gets the specified artifact's content.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/genericartifactscontent/GetGenericArtifactContentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetGenericArtifactContent API.
+     */
+    GetGenericArtifactContentResponse getGenericArtifactContent(
+            GetGenericArtifactContentRequest request);
+
+    /**
+     * Gets the content of an artifact with a specified `artifactPath` and `version`.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/genericartifactscontent/GetGenericArtifactContentByPathExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetGenericArtifactContentByPath API.
+     */
+    GetGenericArtifactContentByPathResponse getGenericArtifactContentByPath(
+            GetGenericArtifactContentByPathRequest request);
+
+    /**
+     * Uploads an artifact. Provide `artifactPath`, `version` and content. Avoid entering confidential information when you define the path and version.
+     *
+     * Note: This operation consumes a stream.
+     *
+     * If the stream supports {@link java.io.InputStream#mark(int)} and {@link java.io.InputStream#reset()}, when a retry is
+     * necessary, the stream is reset so it starts at the beginning (or whatever the stream's position was at the time this
+     * operation is called}.
+     *
+     * Note this means that if the caller has used {@link java.io.InputStream#mark(int)} before, then the mark
+     * will not be the same anymore after this operation, and a subsequent call to {@link java.io.InputStream#reset()} by
+     * the caller will reset the stream not to the caller's mark, but to the position the stream was in when this operation
+     * was called.
+     *
+     * If the stream is a {@link java.io.FileInputStream}, and the stream's {@link java.nio.channels.FileChannel} position
+     * can be changed (like for a regular file), the stream will be wrapped in such a way that it does provide
+     * support for {@link java.io.InputStream#mark(int)} and {@link java.io.InputStream#reset()}. Then the same procedure as
+     * above is followed. If the stream's {@link java.nio.channels.FileChannel} position cannot be changed (like for a
+     * named pipe), then the stream's contents will be buffered in memory, as described below.
+     *
+     * If the stream does not support {@link java.io.InputStream#mark(int)} and {@link java.io.InputStream#reset()}, then
+     * the stream is wrapped in a {@link java.io.BufferedInputStream}, which means the entire contents may
+     * be buffered in memory. Then the same procedure as above is followed.
+     *
+     * The contents of the stream, except when the stream is a {@link java.io.FileInputStream} whose
+     * {@link java.nio.channels.FileChannel} position can be changed, should be less than 2 GiB in size if retries are used.
+     * This is because streams 2 GiB in size or larger do no guarantee that mark-and-reset can be performed. If the stream
+     * is larger, do not use built-in retries and manage retries yourself.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/genericartifactscontent/PutGenericArtifactContentByPathExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use PutGenericArtifactContentByPath API.
+     */
+    PutGenericArtifactContentByPathResponse putGenericArtifactContentByPath(
+            PutGenericArtifactContentByPathRequest request);
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/GenericArtifactsContentAsync.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/GenericArtifactsContentAsync.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent;
+
+import com.oracle.bmc.genericartifactscontent.requests.*;
+import com.oracle.bmc.genericartifactscontent.responses.*;
+
+/**
+ * API covering the Generic Artifacts Service content
+ * Use this API to put and get generic artifact content.
+ *
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+public interface GenericArtifactsContentAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Gets the specified artifact's content.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetGenericArtifactContentResponse> getGenericArtifactContent(
+            GetGenericArtifactContentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetGenericArtifactContentRequest, GetGenericArtifactContentResponse>
+                    handler);
+
+    /**
+     * Gets the content of an artifact with a specified `artifactPath` and `version`.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetGenericArtifactContentByPathResponse>
+            getGenericArtifactContentByPath(
+                    GetGenericArtifactContentByPathRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    GetGenericArtifactContentByPathRequest,
+                                    GetGenericArtifactContentByPathResponse>
+                            handler);
+
+    /**
+     * Uploads an artifact. Provide `artifactPath`, `version` and content. Avoid entering confidential information when you define the path and version.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<PutGenericArtifactContentByPathResponse>
+            putGenericArtifactContentByPath(
+                    PutGenericArtifactContentByPathRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    PutGenericArtifactContentByPathRequest,
+                                    PutGenericArtifactContentByPathResponse>
+                            handler);
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/GenericArtifactsContentAsyncClient.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/GenericArtifactsContentAsyncClient.java
@@ -1,0 +1,515 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent;
+
+import com.oracle.bmc.genericartifactscontent.internal.http.*;
+import com.oracle.bmc.genericartifactscontent.requests.*;
+import com.oracle.bmc.genericartifactscontent.responses.*;
+
+/**
+ * Async client implementation for GenericArtifactsContent service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GenericArtifactsContentAsyncClient implements GenericArtifactsContentAsync {
+    /**
+     * Service instance for GenericArtifactsContent.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("GENERICARTIFACTSCONTENT")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://generic.{region}.ocir.io")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public GenericArtifactsContentAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public GenericArtifactsContentAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public GenericArtifactsContentAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public GenericArtifactsContentAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public GenericArtifactsContentAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public GenericArtifactsContentAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public GenericArtifactsContentAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    public GenericArtifactsContentAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client = restClientFactory.create(defaultRequestSigner, requestSigners, configuration);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<
+                    Builder, GenericArtifactsContentAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public GenericArtifactsContentAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new GenericArtifactsContentAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetGenericArtifactContentResponse> getGenericArtifactContent(
+            GetGenericArtifactContentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetGenericArtifactContentRequest, GetGenericArtifactContentResponse>
+                    handler) {
+        LOG.trace("Called async getGenericArtifactContent");
+        final GetGenericArtifactContentRequest interceptedRequest =
+                GetGenericArtifactContentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetGenericArtifactContentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetGenericArtifactContentResponse>
+                transformer = GetGenericArtifactContentConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetGenericArtifactContentRequest, GetGenericArtifactContentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetGenericArtifactContentRequest,
+                                GetGenericArtifactContentResponse>,
+                        java.util.concurrent.Future<GetGenericArtifactContentResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetGenericArtifactContentRequest, GetGenericArtifactContentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetGenericArtifactContentByPathResponse>
+            getGenericArtifactContentByPath(
+                    GetGenericArtifactContentByPathRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetGenericArtifactContentByPathRequest,
+                                    GetGenericArtifactContentByPathResponse>
+                            handler) {
+        LOG.trace("Called async getGenericArtifactContentByPath");
+        final GetGenericArtifactContentByPathRequest interceptedRequest =
+                GetGenericArtifactContentByPathConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetGenericArtifactContentByPathConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetGenericArtifactContentByPathResponse>
+                transformer = GetGenericArtifactContentByPathConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetGenericArtifactContentByPathRequest,
+                        GetGenericArtifactContentByPathResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetGenericArtifactContentByPathRequest,
+                                GetGenericArtifactContentByPathResponse>,
+                        java.util.concurrent.Future<GetGenericArtifactContentByPathResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetGenericArtifactContentByPathRequest,
+                    GetGenericArtifactContentByPathResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<PutGenericArtifactContentByPathResponse>
+            putGenericArtifactContentByPath(
+                    PutGenericArtifactContentByPathRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    PutGenericArtifactContentByPathRequest,
+                                    PutGenericArtifactContentByPathResponse>
+                            handler) {
+        LOG.trace("Called async putGenericArtifactContentByPath");
+        if (request.getRetryConfiguration() != null
+                || authenticationDetailsProvider
+                        instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            request =
+                    com.oracle.bmc.retrier.Retriers.wrapBodyInputStreamIfNecessary(
+                            request, PutGenericArtifactContentByPathRequest.builder());
+        }
+        final PutGenericArtifactContentByPathRequest interceptedRequest =
+                PutGenericArtifactContentByPathConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                PutGenericArtifactContentByPathConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, PutGenericArtifactContentByPathResponse>
+                transformer = PutGenericArtifactContentByPathConverter.fromResponse();
+
+        ib.property(
+                com.oracle.bmc.http.internal.AuthnClientFilter.SIGNING_STRATEGY_PROPERTY_NAME,
+                com.oracle.bmc.http.signing.SigningStrategy.EXCLUDE_BODY);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        PutGenericArtifactContentByPathRequest,
+                        PutGenericArtifactContentByPathResponse>
+                handlerToUse =
+                        new com.oracle.bmc.responses.internal.StreamClosingAsyncHandler<>(handler);
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                PutGenericArtifactContentByPathRequest,
+                                PutGenericArtifactContentByPathResponse>,
+                        java.util.concurrent.Future<PutGenericArtifactContentByPathResponse>>
+                futureSupplier = client.putFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    PutGenericArtifactContentByPathRequest,
+                    PutGenericArtifactContentByPathResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {
+                    LOG.debug("Resetting stream");
+                    com.oracle.bmc.retrier.Retriers.tryResetStreamForRetry(
+                            interceptedRequest.getGenericArtifactContentBody(), true);
+                }
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/GenericArtifactsContentClient.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/GenericArtifactsContentClient.java
@@ -1,0 +1,496 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent;
+
+import com.oracle.bmc.genericartifactscontent.internal.http.*;
+import com.oracle.bmc.genericartifactscontent.requests.*;
+import com.oracle.bmc.genericartifactscontent.responses.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GenericArtifactsContentClient implements GenericArtifactsContent {
+    /**
+     * Service instance for GenericArtifactsContent.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("GENERICARTIFACTSCONTENT")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate("https://generic.{region}.ocir.io")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public GenericArtifactsContentClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public GenericArtifactsContentClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public GenericArtifactsContentClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public GenericArtifactsContentClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public GenericArtifactsContentClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public GenericArtifactsContentClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public GenericArtifactsContentClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * Use the {@link Builder} to get access to all these parameters.
+     *
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    protected GenericArtifactsContentClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner, requestSigners, clientConfigurationToUse);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<
+                    Builder, GenericArtifactsContentClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public GenericArtifactsContentClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new GenericArtifactsContentClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public GetGenericArtifactContentResponse getGenericArtifactContent(
+            GetGenericArtifactContentRequest request) {
+        LOG.trace("Called getGenericArtifactContent");
+        final GetGenericArtifactContentRequest interceptedRequest =
+                GetGenericArtifactContentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetGenericArtifactContentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetGenericArtifactContentResponse>
+                transformer = GetGenericArtifactContentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetGenericArtifactContentByPathResponse getGenericArtifactContentByPath(
+            GetGenericArtifactContentByPathRequest request) {
+        LOG.trace("Called getGenericArtifactContentByPath");
+        final GetGenericArtifactContentByPathRequest interceptedRequest =
+                GetGenericArtifactContentByPathConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetGenericArtifactContentByPathConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetGenericArtifactContentByPathResponse>
+                transformer = GetGenericArtifactContentByPathConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public PutGenericArtifactContentByPathResponse putGenericArtifactContentByPath(
+            PutGenericArtifactContentByPathRequest request) {
+        LOG.trace("Called putGenericArtifactContentByPath");
+        try {
+            if (request.getRetryConfiguration() != null
+                    || retryConfiguration != null
+                    || authenticationDetailsProvider
+                            instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+                request =
+                        com.oracle.bmc.retrier.Retriers.wrapBodyInputStreamIfNecessary(
+                                request, PutGenericArtifactContentByPathRequest.builder());
+            }
+            final PutGenericArtifactContentByPathRequest interceptedRequest =
+                    PutGenericArtifactContentByPathConverter.interceptRequest(request);
+            com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                    PutGenericArtifactContentByPathConverter.fromRequest(
+                            client, interceptedRequest);
+            com.google.common.base.Function<
+                            javax.ws.rs.core.Response, PutGenericArtifactContentByPathResponse>
+                    transformer = PutGenericArtifactContentByPathConverter.fromResponse();
+
+            ib.property(
+                    com.oracle.bmc.http.internal.AuthnClientFilter.SIGNING_STRATEGY_PROPERTY_NAME,
+                    com.oracle.bmc.http.signing.SigningStrategy.EXCLUDE_BODY);
+
+            final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                    com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                            interceptedRequest.getRetryConfiguration(), retryConfiguration);
+            return retrier.execute(
+                    interceptedRequest,
+                    retryRequest -> {
+                        final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                                new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                        authenticationDetailsProvider);
+                        return tokenRefreshRetrier.execute(
+                                retryRequest,
+                                retriedRequest -> {
+                                    try {
+                                        javax.ws.rs.core.Response response =
+                                                client.put(
+                                                        ib,
+                                                        retriedRequest
+                                                                .getGenericArtifactContentBody(),
+                                                        retriedRequest);
+                                        return transformer.apply(response);
+                                    } catch (RuntimeException e) {
+                                        if (interceptedRequest.getRetryConfiguration() != null
+                                                || retryConfiguration != null
+                                                || (e instanceof com.oracle.bmc.model.BmcException
+                                                        && tokenRefreshRetrier
+                                                                .getRetryCondition()
+                                                                .shouldBeRetried(
+                                                                        (com.oracle.bmc.model
+                                                                                        .BmcException)
+                                                                                e))) {
+                                            com.oracle.bmc.retrier.Retriers.tryResetStreamForRetry(
+                                                    interceptedRequest
+                                                            .getGenericArtifactContentBody(),
+                                                    true);
+                                        }
+                                        throw e; // rethrow
+                                    }
+                                });
+                    });
+        } finally {
+            com.oracle.bmc.io.internal.KeepOpenInputStream.closeStream(
+                    request.getGenericArtifactContentBody());
+        }
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/internal/http/GetGenericArtifactContentByPathConverter.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/internal/http/GetGenericArtifactContentByPathConverter.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.internal.http;
+
+import com.oracle.bmc.genericartifactscontent.model.*;
+import com.oracle.bmc.genericartifactscontent.requests.*;
+import com.oracle.bmc.genericartifactscontent.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetGenericArtifactContentByPathConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.genericartifactscontent.requests
+                    .GetGenericArtifactContentByPathRequest
+            interceptRequest(
+                    com.oracle.bmc.genericartifactscontent.requests
+                                    .GetGenericArtifactContentByPathRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.genericartifactscontent.requests.GetGenericArtifactContentByPathRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notBlank(request.getArtifactPath(), "artifactPath must not be blank");
+        Validate.notBlank(request.getVersion(), "version must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("generic")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()))
+                        .path("artifactPaths")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getArtifactPath()))
+                        .path("versions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVersion()))
+                        .path("content");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept("application/octet-stream");
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.genericartifactscontent.responses
+                            .GetGenericArtifactContentByPathResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.genericartifactscontent.responses
+                                .GetGenericArtifactContentByPathResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.genericartifactscontent.responses
+                                        .GetGenericArtifactContentByPathResponse>() {
+                            @Override
+                            public com.oracle.bmc.genericartifactscontent.responses
+                                            .GetGenericArtifactContentByPathResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.genericartifactscontent.responses.GetGenericArtifactContentByPathResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.io.InputStream>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        java.io.InputStream.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<java.io.InputStream>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.genericartifactscontent.responses
+                                                .GetGenericArtifactContentByPathResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.genericartifactscontent.responses
+                                                        .GetGenericArtifactContentByPathResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.inputStream(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.genericartifactscontent.responses
+                                                .GetGenericArtifactContentByPathResponse
+                                        responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/internal/http/GetGenericArtifactContentConverter.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/internal/http/GetGenericArtifactContentConverter.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.internal.http;
+
+import com.oracle.bmc.genericartifactscontent.model.*;
+import com.oracle.bmc.genericartifactscontent.requests.*;
+import com.oracle.bmc.genericartifactscontent.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetGenericArtifactContentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.genericartifactscontent.requests.GetGenericArtifactContentRequest
+            interceptRequest(
+                    com.oracle.bmc.genericartifactscontent.requests.GetGenericArtifactContentRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.genericartifactscontent.requests.GetGenericArtifactContentRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getArtifactId(), "artifactId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("generic")
+                        .path("artifacts")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getArtifactId()))
+                        .path("content");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept("application/octet-stream");
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.genericartifactscontent.responses
+                            .GetGenericArtifactContentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.genericartifactscontent.responses
+                                .GetGenericArtifactContentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.genericartifactscontent.responses
+                                        .GetGenericArtifactContentResponse>() {
+                            @Override
+                            public com.oracle.bmc.genericartifactscontent.responses
+                                            .GetGenericArtifactContentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.genericartifactscontent.responses.GetGenericArtifactContentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.io.InputStream>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        java.io.InputStream.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<java.io.InputStream>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.genericartifactscontent.responses
+                                                .GetGenericArtifactContentResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.genericartifactscontent.responses
+                                                        .GetGenericArtifactContentResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.inputStream(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.genericartifactscontent.responses
+                                                .GetGenericArtifactContentResponse
+                                        responseWrapper = builder.build();
+
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/internal/http/PutGenericArtifactContentByPathConverter.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/internal/http/PutGenericArtifactContentByPathConverter.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.genericartifactscontent.model.*;
+import com.oracle.bmc.genericartifactscontent.requests.*;
+import com.oracle.bmc.genericartifactscontent.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class PutGenericArtifactContentByPathConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.genericartifactscontent.requests
+                    .PutGenericArtifactContentByPathRequest
+            interceptRequest(
+                    com.oracle.bmc.genericartifactscontent.requests
+                                    .PutGenericArtifactContentByPathRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.genericartifactscontent.requests.PutGenericArtifactContentByPathRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getRepositoryId(), "repositoryId must not be blank");
+        Validate.notBlank(request.getArtifactPath(), "artifactPath must not be blank");
+        Validate.notBlank(request.getVersion(), "version must not be blank");
+        Validate.notNull(
+                request.getGenericArtifactContentBody(), "genericArtifactContentBody is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("generic")
+                        .path("repositories")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getRepositoryId()))
+                        .path("artifactPaths")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getArtifactPath()))
+                        .path("versions")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVersion()))
+                        .path("content");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.genericartifactscontent.responses
+                            .PutGenericArtifactContentByPathResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.genericartifactscontent.responses
+                                .PutGenericArtifactContentByPathResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.genericartifactscontent.responses
+                                        .PutGenericArtifactContentByPathResponse>() {
+                            @Override
+                            public com.oracle.bmc.genericartifactscontent.responses
+                                            .PutGenericArtifactContentByPathResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.genericartifactscontent.responses.PutGenericArtifactContentByPathResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        GenericArtifact>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        GenericArtifact.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<GenericArtifact> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.genericartifactscontent.responses
+                                                .PutGenericArtifactContentByPathResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.genericartifactscontent.responses
+                                                        .PutGenericArtifactContentByPathResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.genericArtifact(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.genericartifactscontent.responses
+                                                .PutGenericArtifactContentByPathResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/model/GenericArtifact.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/model/GenericArtifact.java
@@ -1,0 +1,326 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.model;
+
+/**
+ * The metadata of the artifact.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = GenericArtifact.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class GenericArtifact {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+        private String repositoryId;
+
+        public Builder repositoryId(String repositoryId) {
+            this.repositoryId = repositoryId;
+            this.__explicitlySet__.add("repositoryId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("artifactPath")
+        private String artifactPath;
+
+        public Builder artifactPath(String artifactPath) {
+            this.artifactPath = artifactPath;
+            this.__explicitlySet__.add("artifactPath");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sha256")
+        private String sha256;
+
+        public Builder sha256(String sha256) {
+            this.sha256 = sha256;
+            this.__explicitlySet__.add("sha256");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+        private Long sizeInBytes;
+
+        public Builder sizeInBytes(Long sizeInBytes) {
+            this.sizeInBytes = sizeInBytes;
+            this.__explicitlySet__.add("sizeInBytes");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GenericArtifact build() {
+            GenericArtifact __instance__ =
+                    new GenericArtifact(
+                            id,
+                            displayName,
+                            compartmentId,
+                            repositoryId,
+                            artifactPath,
+                            version,
+                            sha256,
+                            sizeInBytes,
+                            lifecycleState,
+                            freeformTags,
+                            definedTags,
+                            timeCreated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GenericArtifact o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .repositoryId(o.getRepositoryId())
+                            .artifactPath(o.getArtifactPath())
+                            .version(o.getVersion())
+                            .sha256(o.getSha256())
+                            .sizeInBytes(o.getSizeInBytes())
+                            .lifecycleState(o.getLifecycleState())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .timeCreated(o.getTimeCreated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the artifact.
+     * <p>
+     * Example: `ocid1.genericartifact.oc1..exampleuniqueID`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The artifact name with the format of `<artifact-path>:<artifact-version>`. The artifact name is truncated to a maximum length of 255.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc:1.0.0`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository's compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the repository.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("repositoryId")
+    String repositoryId;
+
+    /**
+     * A user-defined path to describe the location of an artifact. Slashes do not create a directory structure, but you can use slashes to organize the repository. An artifact path does not include an artifact version.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("artifactPath")
+    String artifactPath;
+
+    /**
+     * A user-defined string to describe the artifact version.
+     * <p>
+     * Example: `1.1.0` or `1.2-beta-2`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+
+    /**
+     * The SHA256 digest for the artifact. When you upload an artifact to the repository, a SHA256 digest is calculated and added to the artifact properties.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sha256")
+    String sha256;
+
+    /**
+     * The size of the artifact in bytes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInBytes")
+    Long sizeInBytes;
+    /**
+     * The current state of the artifact.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Available("AVAILABLE"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the artifact.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Department\": \"Finance\"}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: `{\"Operations\": {\"CostCenter\": \"42\"}}`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * An RFC 3339 timestamp indicating when the repository was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/requests/GetGenericArtifactContentByPathRequest.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/requests/GetGenericArtifactContentByPathRequest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.requests;
+
+import com.oracle.bmc.genericartifactscontent.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/genericartifactscontent/GetGenericArtifactContentByPathExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetGenericArtifactContentByPathRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetGenericArtifactContentByPathRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.repository.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * A user-defined path to describe the location of an artifact. You can use slashes to organize the repository, but slashes do not create a directory structure. An artifact path does not include an artifact version.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc`
+     *
+     */
+    private String artifactPath;
+
+    /**
+     * A user-defined string to describe the artifact version.
+     * <p>
+     * Example: `1.1.2` or `1.2-beta-2`
+     *
+     */
+    private String version;
+
+    /**
+     * Unique Oracle-assigned [request ID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm)
+     * <p>
+     * Example: `bxxxxxxx-fxxx-4xxx-9xxx-bxxxxxxxxxxx`
+     * If you contact Oracle about a request, provide this request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetGenericArtifactContentByPathRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetGenericArtifactContentByPathRequest o) {
+            repositoryId(o.getRepositoryId());
+            artifactPath(o.getArtifactPath());
+            version(o.getVersion());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetGenericArtifactContentByPathRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetGenericArtifactContentByPathRequest
+         */
+        public GetGenericArtifactContentByPathRequest build() {
+            GetGenericArtifactContentByPathRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/requests/GetGenericArtifactContentRequest.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/requests/GetGenericArtifactContentRequest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.requests;
+
+import com.oracle.bmc.genericartifactscontent.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/genericartifactscontent/GetGenericArtifactContentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetGenericArtifactContentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetGenericArtifactContentRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the artifact.
+     * <p>
+     * Example: `ocid1.genericartifact.oc1..exampleuniqueID`
+     *
+     */
+    private String artifactId;
+
+    /**
+     * Unique Oracle-assigned [request ID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm)
+     * <p>
+     * Example: `bxxxxxxx-fxxx-4xxx-9xxx-bxxxxxxxxxxx`
+     * If you contact Oracle about a request, provide this request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetGenericArtifactContentRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetGenericArtifactContentRequest o) {
+            artifactId(o.getArtifactId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetGenericArtifactContentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetGenericArtifactContentRequest
+         */
+        public GetGenericArtifactContentRequest build() {
+            GetGenericArtifactContentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/requests/PutGenericArtifactContentByPathRequest.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/requests/PutGenericArtifactContentByPathRequest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.requests;
+
+import com.oracle.bmc.genericartifactscontent.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/genericartifactscontent/PutGenericArtifactContentByPathExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use PutGenericArtifactContentByPathRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class PutGenericArtifactContentByPathRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.io.InputStream> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the repository.
+     * <p>
+     * Example: `ocid1.repository.oc1..exampleuniqueID`
+     *
+     */
+    private String repositoryId;
+
+    /**
+     * A user-defined path to describe the location of an artifact. You can use slashes to organize the repository, but slashes do not create a directory structure. An artifact path does not include an artifact version.
+     * <p>
+     * Example: `project01/my-web-app/artifact-abc`
+     *
+     */
+    private String artifactPath;
+
+    /**
+     * A user-defined string to describe the artifact version.
+     * <p>
+     * Example: `1.1.2` or `1.2-beta-2`
+     *
+     */
+    private String version;
+
+    /**
+     * Uploads an artifact. Provide artifact path, version and content. Avoid entering confidential information when you define the path and version.
+     */
+    private java.io.InputStream genericArtifactContentBody;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match` parameter to the value of the `etag` from a previous GET or POST response for that resource.  The resource will be updated or deleted only if the `etag` you provide matches the resource's current `etag` value. When 'if-match' is provided and its value does not exactly match the 'etag' of the resource on the server, the request fails with the 412 response code.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique Oracle-assigned [request ID](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm)
+     * <p>
+     * Example: `bxxxxxxx-fxxx-4xxx-9xxx-bxxxxxxxxxxx`
+     * If you contact Oracle about a request, provide this request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public java.io.InputStream getBody$() {
+        return genericArtifactContentBody;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    PutGenericArtifactContentByPathRequest, java.io.InputStream> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(PutGenericArtifactContentByPathRequest o) {
+            repositoryId(o.getRepositoryId());
+            artifactPath(o.getArtifactPath());
+            version(o.getVersion());
+            genericArtifactContentBody(o.getGenericArtifactContentBody());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of PutGenericArtifactContentByPathRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of PutGenericArtifactContentByPathRequest
+         */
+        public PutGenericArtifactContentByPathRequest build() {
+            PutGenericArtifactContentByPathRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(java.io.InputStream body) {
+            genericArtifactContentBody(body);
+            return this;
+        }
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/responses/GetGenericArtifactContentByPathResponse.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/responses/GetGenericArtifactContentByPathResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.responses;
+
+import com.oracle.bmc.genericartifactscontent.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetGenericArtifactContentByPathResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned java.io.InputStream instance.
+     */
+    private java.io.InputStream inputStream;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetGenericArtifactContentByPathResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            inputStream(o.getInputStream());
+
+            return this;
+        }
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/responses/GetGenericArtifactContentResponse.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/responses/GetGenericArtifactContentResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.responses;
+
+import com.oracle.bmc.genericartifactscontent.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetGenericArtifactContentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned java.io.InputStream instance.
+     */
+    private java.io.InputStream inputStream;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetGenericArtifactContentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            inputStream(o.getInputStream());
+
+            return this;
+        }
+    }
+}

--- a/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/responses/PutGenericArtifactContentByPathResponse.java
+++ b/bmc-genericartifactscontent/src/main/java/com/oracle/bmc/genericartifactscontent/responses/PutGenericArtifactContentByPathResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.genericartifactscontent.responses;
+
+import com.oracle.bmc.genericartifactscontent.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class PutGenericArtifactContentByPathResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See `if-match`.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned GenericArtifact instance.
+     */
+    private GenericArtifact genericArtifact;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(PutGenericArtifactContentByPathResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            genericArtifact(o.getGenericArtifact());
+
+            return this;
+        }
+    }
+}

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -20,11 +20,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -22,11 +22,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -20,11 +20,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/Limits.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/Limits.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.limits.requests.*;
 import com.oracle.bmc.limits.responses.*;
 
 /**
- * APIs that interact with the resource limits of a specific resource type
+ * APIs that interact with the resource limits of a specific resource type.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181025")
 public interface Limits extends AutoCloseable {
@@ -47,9 +47,9 @@ public interface Limits extends AutoCloseable {
 
     /**
      * For a given compartmentId, resource limit name, and scope, returns the following:
-     *   - the number of available resources associated with the given limit
-     *   - the usage in the selected compartment for the given limit
-     *   Note: not all resource limits support this API. If the value is not available, the API will return 404.
+     *   * The number of available resources associated with the given limit.
+     *   * The usage in the selected compartment for the given limit.
+     *   Note that not all resource limits support this API. If the value is not available, the API returns a 404 response.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -85,7 +85,7 @@ public interface Limits extends AutoCloseable {
 
     /**
      * Returns the list of supported services.
-     * This will include the programmatic service name, along with the friendly service name.
+     * This includes the programmatic service name, along with the friendly service name.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/LimitsAsync.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/LimitsAsync.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.limits.requests.*;
 import com.oracle.bmc.limits.responses.*;
 
 /**
- * APIs that interact with the resource limits of a specific resource type
+ * APIs that interact with the resource limits of a specific resource type.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181025")
 public interface LimitsAsync extends AutoCloseable {
@@ -47,9 +47,9 @@ public interface LimitsAsync extends AutoCloseable {
 
     /**
      * For a given compartmentId, resource limit name, and scope, returns the following:
-     *   - the number of available resources associated with the given limit
-     *   - the usage in the selected compartment for the given limit
-     *   Note: not all resource limits support this API. If the value is not available, the API will return 404.
+     *   * The number of available resources associated with the given limit.
+     *   * The usage in the selected compartment for the given limit.
+     *   Note that not all resource limits support this API. If the value is not available, the API returns a 404 response.
      *
      *
      * @param request The request object containing the details to send
@@ -102,7 +102,7 @@ public interface LimitsAsync extends AutoCloseable {
 
     /**
      * Returns the list of supported services.
-     * This will include the programmatic service name, along with the friendly service name.
+     * This includes the programmatic service name, along with the friendly service name.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/Quotas.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/Quotas.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.limits.requests.*;
 import com.oracle.bmc.limits.responses.*;
 
 /**
- * APIs that interact with the resource limits of a specific resource type
+ * APIs that interact with the resource limits of a specific resource type.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181025")
 public interface Quotas extends AutoCloseable {
@@ -76,7 +76,7 @@ public interface Quotas extends AutoCloseable {
     GetQuotaResponse getQuota(GetQuotaRequest request);
 
     /**
-     * Lists all quotas on resources from the given compartment
+     * Lists all quotas on resources from the given compartment.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/QuotasAsync.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/QuotasAsync.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.limits.requests.*;
 import com.oracle.bmc.limits.responses.*;
 
 /**
- * APIs that interact with the resource limits of a specific resource type
+ * APIs that interact with the resource limits of a specific resource type.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20181025")
 public interface QuotasAsync extends AutoCloseable {
@@ -88,7 +88,7 @@ public interface QuotasAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetQuotaRequest, GetQuotaResponse> handler);
 
     /**
-     * Lists all quotas on resources from the given compartment
+     * Lists all quotas on resources from the given compartment.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/model/LimitDefinitionSummary.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/model/LimitDefinitionSummary.java
@@ -98,6 +98,15 @@ public class LimitDefinitionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isDynamic")
+        private Boolean isDynamic;
+
+        public Builder isDynamic(Boolean isDynamic) {
+            this.isDynamic = isDynamic;
+            this.__explicitlySet__.add("isDynamic");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -111,7 +120,8 @@ public class LimitDefinitionSummary {
                             areQuotasSupported,
                             isResourceAvailabilitySupported,
                             isDeprecated,
-                            isEligibleForLimitIncrease);
+                            isEligibleForLimitIncrease,
+                            isDynamic);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -126,7 +136,8 @@ public class LimitDefinitionSummary {
                             .areQuotasSupported(o.getAreQuotasSupported())
                             .isResourceAvailabilitySupported(o.getIsResourceAvailabilitySupported())
                             .isDeprecated(o.getIsDeprecated())
-                            .isEligibleForLimitIncrease(o.getIsEligibleForLimitIncrease());
+                            .isEligibleForLimitIncrease(o.getIsEligibleForLimitIncrease())
+                            .isDynamic(o.getIsDynamic());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -159,7 +170,7 @@ public class LimitDefinitionSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
     /**
-     * Reflects the scope of the resource limit: which can be Global (across all regions), regional or ad specific.
+     * Reflects the scope of the resource limit, whether Global (across all regions), regional, or availability domain-specific.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -207,7 +218,7 @@ public class LimitDefinitionSummary {
         }
     };
     /**
-     * Reflects the scope of the resource limit: which can be Global (across all regions), regional or ad specific.
+     * Reflects the scope of the resource limit, whether Global (across all regions), regional, or availability domain-specific.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scopeType")
@@ -221,8 +232,8 @@ public class LimitDefinitionSummary {
     Boolean areQuotasSupported;
 
     /**
-     * Reflects if the GetResourceAvailability API is supported for this limit or not.
-     * If not, the API will return an empty JSON response.
+     * Reflects whether or not the GetResourceAvailability API is supported for this limit.
+     * If not, the API returns an empty JSON response.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isResourceAvailabilitySupported")
@@ -241,6 +252,13 @@ public class LimitDefinitionSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEligibleForLimitIncrease")
     Boolean isEligibleForLimitIncrease;
+
+    /**
+     * The limit for this resource has a dynamic value that is based on consumption across all OCI services.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDynamic")
+    Boolean isDynamic;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/model/Quota.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/model/Quota.java
@@ -6,11 +6,11 @@ package com.oracle.bmc.limits.model;
 
 /**
  * Quotas are applied on top of the service limits and inherited through the nested compartment hierarchy.
- * They allow compartment admins to limit resource consumption and set boundaries around acceptable resource use.
- * The word \"quota\" is used by people in different ways:
- *   * An individual statement written in the declarative language
- *   * A collection of statements in a single, named \"quota\" object (which has an Oracle Cloud ID (OCID) assigned to it)
- *   * The overall body of quotas your organization uses to control access to resources
+ * Quotas allow compartment admins to limit resource consumption and set boundaries around acceptable resource use.
+ * The term \"quota\" can be interpreted as the following:
+ *   * An individual statement written in the declarative language.
+ *   * A collection of statements in a single, named \"quota\" object (which has an Oracle Cloud ID (OCID) assigned to it).
+ *   * The overall body of quotas your organization uses to control access to resources.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -190,7 +190,7 @@ public class Quota {
     String description;
 
     /**
-     * Date and time the quota was created, in the format defined by RFC3339.
+     * Date and time the quota was created, in the format defined by RFC 3339.
      * Example: `2016-08-25T21:10:29.600Z`
      *
      **/

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/model/QuotaSummary.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/model/QuotaSummary.java
@@ -5,8 +5,8 @@
 package com.oracle.bmc.limits.model;
 
 /**
- * Entails a subset of all the properties of the corresponding Quota and is recommended to be used in cases requiring
- * security of quota details and slightly better API performance.
+ * Consists of a subset of all the properties of the corresponding quota, and is recommended to be used in cases requiring
+ * security of quota details, and for slightly better API performance.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -169,7 +169,7 @@ public class QuotaSummary {
     String description;
 
     /**
-     * Date and time the quota was created, in the format defined by RFC3339.
+     * Date and time the quota was created, in the format defined by RFC 3339.
      * Example: `2016-08-25T21:10:29.600Z`
      *
      **/

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/model/ResourceAvailability.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/model/ResourceAvailability.java
@@ -5,8 +5,8 @@
 package com.oracle.bmc.limits.model;
 
 /**
- * The availability of a given resource limit, based on the usage, tenant service limits and quotas set for the tenancy.
- * Note: We cannot guarantee this data for all the limits. In those cases, these fields will be empty.
+ * The availability of a given resource limit, based on the usage, tenant service limits, and quotas set for the tenancy.
+ * Note: We cannot guarantee this data for all the limits. In such cases, these fields will be empty.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -110,16 +110,16 @@ public class ResourceAvailability {
     }
 
     /**
-     * The current usage in the given compartment. Because we have introduced resources with fractional counts,
-     * the field will round up to the nearest integer.
+     * The current usage in the given compartment. To support resources with fractional counts,
+     * the field rounds up to the nearest integer.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("used")
     Long used;
 
     /**
-     * The count of available resources. Because we have introduced resources with fractional counts,
-     * the field will round down to the nearest integer.
+     * The count of available resources. To support resources with fractional counts,
+     * the field rounds down to the nearest integer.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("available")
@@ -140,7 +140,7 @@ public class ResourceAvailability {
     java.math.BigDecimal fractionalAvailability;
 
     /**
-     * The effective quota value for given compartment. This field is only present if there is a
+     * The effective quota value for the given compartment. This field is only present if there is a
      * current quota policy affecting the current resource in the target region or availability domain.
      *
      **/

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/model/ServiceSummary.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/model/ServiceSummary.java
@@ -68,7 +68,7 @@ public class ServiceSummary {
     }
 
     /**
-     * The service name. Use this when calling the other APIs.
+     * The service name. Use this when calling other APIs.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/CreateQuotaRequest.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/CreateQuotaRequest.java
@@ -33,10 +33,10 @@ public class CreateQuotaRequest extends com.oracle.bmc.requests.BmcRequest<Creat
 
     /**
      * A token that uniquely identifies a request so it can be retried in case of a timeout or
-     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * server error, without risk of executing that same action again. Retry tokens expire after 24
      * hours, but can be invalidated before then due to conflicting operations (e.g., if a resource
      * has been deleted and purged from the system, then a retry of the original creation request
-     * may be rejected).
+     * can be rejected).
      *
      */
     private String opcRetryToken;

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/DeleteQuotaRequest.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/DeleteQuotaRequest.java
@@ -34,7 +34,7 @@ public class DeleteQuotaRequest extends com.oracle.bmc.requests.BmcRequest<java.
     /**
      * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
      * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
-     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     * is updated or deleted only if the etag you provide matches the resource's current etag value.
      *
      */
     private String ifMatch;

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/GetResourceAvailabilityRequest.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/GetResourceAvailabilityRequest.java
@@ -38,7 +38,7 @@ public class GetResourceAvailabilityRequest
     /**
      * This field is mandatory if the scopeType of the target resource limit is AD.
      * Otherwise, this field should be omitted.
-     * If the above requirements are not met, the API will return a 400 - InvalidParameter response.
+     * If the above requirements are not met, the API returns a 400 - InvalidParameter response.
      *
      */
     private String availabilityDomain;

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/ListLimitDefinitionsRequest.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/ListLimitDefinitionsRequest.java
@@ -79,13 +79,13 @@ public class ListLimitDefinitionsRequest
         }
     };
     /**
-     * The sort order to use, either 'asc' or 'desc'. By default it will be ascending.
+     * The sort order to use, either 'asc' or 'desc'. By default, it is ascending.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'. By default it will be ascending.
+     * The sort order to use, either 'asc' or 'desc'. By default, it is ascending.
      *
      **/
     public enum SortOrder {

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/ListLimitValuesRequest.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/ListLimitValuesRequest.java
@@ -26,7 +26,7 @@ public class ListLimitValuesRequest extends com.oracle.bmc.requests.BmcRequest<j
     private String compartmentId;
 
     /**
-     * The target service name
+     * The target service name.
      */
     private String serviceName;
 
@@ -72,7 +72,7 @@ public class ListLimitValuesRequest extends com.oracle.bmc.requests.BmcRequest<j
         }
     };
     /**
-     * Filter entries by availability domain. This implies that only AD-specific values will be returned.
+     * Filter entries by availability domain. This implies that only AD-specific values are returned.
      *
      */
     private String availabilityDomain;
@@ -83,13 +83,13 @@ public class ListLimitValuesRequest extends com.oracle.bmc.requests.BmcRequest<j
     private String name;
 
     /**
-     * The field to sort by. We will be implicitly sorting by availabilityDomain, as a second level field, if available.
+     * The field to sort by. The sorting is by availabilityDomain, as a second level field, if available.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. We will be implicitly sorting by availabilityDomain, as a second level field, if available.
+     * The field to sort by. The sorting is by availabilityDomain, as a second level field, if available.
      *
      **/
     public enum SortBy {
@@ -124,13 +124,13 @@ public class ListLimitValuesRequest extends com.oracle.bmc.requests.BmcRequest<j
         }
     };
     /**
-     * The sort order to use, either 'asc' or 'desc'. By default it will be ascending.
+     * The sort order to use, either 'asc' or 'desc'. By default, it is ascending.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'. By default it will be ascending.
+     * The sort order to use, either 'asc' or 'desc'. By default, it is ascending.
      *
      **/
     public enum SortOrder {

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/ListQuotasRequest.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/ListQuotasRequest.java
@@ -43,12 +43,12 @@ public class ListQuotasRequest extends com.oracle.bmc.requests.BmcRequest<java.l
     private String name;
 
     /**
-     * Filters returned quotas based on whether the given state.
+     * Filters returned quotas based on the given state.
      */
     private LifecycleState lifecycleState;
 
     /**
-     * Filters returned quotas based on whether the given state.
+     * Filters returned quotas based on the given state.
      **/
     public enum LifecycleState {
         Active("ACTIVE"),
@@ -82,13 +82,13 @@ public class ListQuotasRequest extends com.oracle.bmc.requests.BmcRequest<java.l
         }
     };
     /**
-     * The sort order to use, either 'asc' or 'desc'. By default it will be ascending.
+     * The sort order to use, either 'asc' or 'desc'. By default, it is ascending.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'. By default it will be ascending.
+     * The sort order to use, either 'asc' or 'desc'. By default, it is ascending.
      *
      **/
     public enum SortOrder {
@@ -124,13 +124,13 @@ public class ListQuotasRequest extends com.oracle.bmc.requests.BmcRequest<java.l
         }
     };
     /**
-     * The field to sort by. Only one sort order may be provided. Time created is default ordered as descending. Display name is default ordered as ascending.
+     * The field to sort by. Only one sort order can be provided. Time created is default ordered as descending. Display name is default ordered as ascending.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Time created is default ordered as descending. Display name is default ordered as ascending.
+     * The field to sort by. Only one sort order can be provided. Time created is default ordered as descending. Display name is default ordered as ascending.
      *
      **/
     public enum SortBy {

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/ListServicesRequest.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/ListServicesRequest.java
@@ -68,13 +68,13 @@ public class ListServicesRequest extends com.oracle.bmc.requests.BmcRequest<java
         }
     };
     /**
-     * The sort order to use, either 'asc' or 'desc'. By default it will be ascending.
+     * The sort order to use, either 'asc' or 'desc'. By default, it is ascending.
      *
      */
     private SortOrder sortOrder;
 
     /**
-     * The sort order to use, either 'asc' or 'desc'. By default it will be ascending.
+     * The sort order to use, either 'asc' or 'desc'. By default, it is ascending.
      *
      **/
     public enum SortOrder {

--- a/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/UpdateQuotaRequest.java
+++ b/bmc-limits/src/main/java/com/oracle/bmc/limits/requests/UpdateQuotaRequest.java
@@ -39,7 +39,7 @@ public class UpdateQuotaRequest extends com.oracle.bmc.requests.BmcRequest<Updat
     /**
      * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the `if-match`
      * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
-     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     * is updated or deleted only if the etag you provide matches the resource's current etag value.
      *
      */
     private String ifMatch;

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -22,11 +22,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/model/LogEntry.java
+++ b/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/model/LogEntry.java
@@ -93,7 +93,7 @@ public class LogEntry {
     String id;
 
     /**
-     * Optional. The timestamp associated with the log entry. An RFC3339-formatted date-time string.
+     * Optional. The timestamp associated with the log entry. An RFC3339-formatted date-time string with milliseconds precision.
      * If unspecified, defaults to PutLogsDetails.defaultlogentrytime.
      *
      **/

--- a/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/model/LogEntryBatch.java
+++ b/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/model/LogEntryBatch.java
@@ -134,8 +134,8 @@ public class LogEntryBatch {
     /**
      * The timestamp for all log entries in this batch. This can be
      * considered as the default timestamp for each entry, unless it is
-     * overwritten by the entry time. An RFC3339-formatted date-time
-     * string.
+     * overwritten by the entry time. An RFC3339-formatted date-time string
+     * with milliseconds precision.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("defaultlogentrytime")

--- a/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/requests/PutLogsRequest.java
+++ b/bmc-loggingingestion/src/main/java/com/oracle/bmc/loggingingestion/requests/PutLogsRequest.java
@@ -31,7 +31,7 @@ public class PutLogsRequest extends com.oracle.bmc.requests.BmcRequest<PutLogsDe
 
     /**
      * Effective timestamp, for when the agent started processing the log
-     * segment being sent. An RFC3339-formatted date-time string.
+     * segment being sent. An RFC3339-formatted date-time string with milliseconds precision.
      *
      */
     private java.util.Date timestampOpcAgentProcessing;

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -14,16 +14,17 @@
   <description>This project contains add-on modules for Oracle Cloud Infrastructure</description>
   <url>https://docs.cloud.oracle.com/Content/API/SDKDocs/javasdk.htm</url>
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,21 +17,16 @@
 
 
 
-
-
-
-
-
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -17,16 +17,11 @@
 
 
 
-
-
-
-
-
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/Sddc.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/Sddc.java
@@ -47,6 +47,17 @@ public interface Sddc extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Cancel the pending SDDC downgrade from HCX Enterprise to HCX Advanced
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/ocvp/CancelDowngradeHcxExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CancelDowngradeHcx API.
+     */
+    CancelDowngradeHcxResponse cancelDowngradeHcx(CancelDowngradeHcxRequest request);
+
+    /**
      * Moves an SDDC into a different compartment within the same tenancy. For information
      * about moving resources between compartments, see
      * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
@@ -92,6 +103,17 @@ public interface Sddc extends AutoCloseable {
     DeleteSddcResponse deleteSddc(DeleteSddcRequest request);
 
     /**
+     * Downgrade the specified SDDC from HCX Enterprise to HCX Advanced
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/ocvp/DowngradeHcxExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DowngradeHcx API.
+     */
+    DowngradeHcxResponse downgradeHcx(DowngradeHcxRequest request);
+
+    /**
      * Gets the specified SDDC's information.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -114,8 +136,8 @@ public interface Sddc extends AutoCloseable {
     ListSddcsResponse listSddcs(ListSddcsRequest request);
 
     /**
-     * Lists supported SKUs. HHOUR, MONTH, ONE_YEAR and THREE_YEARS supported by the Oracle Cloud
-     * VMware Solution.
+     * Lists supported SKUs. Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+     * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -139,6 +161,16 @@ public interface Sddc extends AutoCloseable {
             ListSupportedVmwareSoftwareVersionsRequest request);
 
     /**
+     * Refresh HCX on-premise licenses status of the specified SDDC.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/ocvp/RefreshHcxLicenseStatusExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RefreshHcxLicenseStatus API.
+     */
+    RefreshHcxLicenseStatusResponse refreshHcxLicenseStatus(RefreshHcxLicenseStatusRequest request);
+
+    /**
      * Updates the specified SDDC.
      * <p>
      **Important:** Updating an SDDC affects only certain attributes in the `Sddc`
@@ -153,6 +185,17 @@ public interface Sddc extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/ocvp/UpdateSddcExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateSddc API.
      */
     UpdateSddcResponse updateSddc(UpdateSddcRequest request);
+
+    /**
+     * Upgrade the specified SDDC from HCX Advanced to HCX Enterprise.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/ocvp/UpgradeHcxExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpgradeHcx API.
+     */
+    UpgradeHcxResponse upgradeHcx(UpgradeHcxRequest request);
 
     /**
      * Gets the pre-configured waiters available for resources for this service.

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/SddcAsync.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/SddcAsync.java
@@ -47,6 +47,23 @@ public interface SddcAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Cancel the pending SDDC downgrade from HCX Enterprise to HCX Advanced
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CancelDowngradeHcxResponse> cancelDowngradeHcx(
+            CancelDowngradeHcxRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CancelDowngradeHcxRequest, CancelDowngradeHcxResponse>
+                    handler);
+
+    /**
      * Moves an SDDC into a different compartment within the same tenancy. For information
      * about moving resources between compartments, see
      * [Moving Resources to a Different Compartment](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
@@ -106,6 +123,22 @@ public interface SddcAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<DeleteSddcRequest, DeleteSddcResponse> handler);
 
     /**
+     * Downgrade the specified SDDC from HCX Enterprise to HCX Advanced
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DowngradeHcxResponse> downgradeHcx(
+            DowngradeHcxRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DowngradeHcxRequest, DowngradeHcxResponse>
+                    handler);
+
+    /**
      * Gets the specified SDDC's information.
      *
      * @param request The request object containing the details to send
@@ -136,8 +169,8 @@ public interface SddcAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListSddcsRequest, ListSddcsResponse> handler);
 
     /**
-     * Lists supported SKUs. HHOUR, MONTH, ONE_YEAR and THREE_YEARS supported by the Oracle Cloud
-     * VMware Solution.
+     * Lists supported SKUs. Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+     * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
      *
      *
      * @param request The request object containing the details to send
@@ -174,6 +207,22 @@ public interface SddcAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Refresh HCX on-premise licenses status of the specified SDDC.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RefreshHcxLicenseStatusResponse> refreshHcxLicenseStatus(
+            RefreshHcxLicenseStatusRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            RefreshHcxLicenseStatusRequest, RefreshHcxLicenseStatusResponse>
+                    handler);
+
+    /**
      * Updates the specified SDDC.
      * <p>
      **Important:** Updating an SDDC affects only certain attributes in the `Sddc`
@@ -192,4 +241,19 @@ public interface SddcAsync extends AutoCloseable {
     java.util.concurrent.Future<UpdateSddcResponse> updateSddc(
             UpdateSddcRequest request,
             com.oracle.bmc.responses.AsyncHandler<UpdateSddcRequest, UpdateSddcResponse> handler);
+
+    /**
+     * Upgrade the specified SDDC from HCX Advanced to HCX Enterprise.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpgradeHcxResponse> upgradeHcx(
+            UpgradeHcxRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpgradeHcxRequest, UpgradeHcxResponse> handler);
 }

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/SddcAsyncClient.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/SddcAsyncClient.java
@@ -363,6 +363,46 @@ public class SddcAsyncClient implements SddcAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CancelDowngradeHcxResponse> cancelDowngradeHcx(
+            CancelDowngradeHcxRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CancelDowngradeHcxRequest, CancelDowngradeHcxResponse>
+                    handler) {
+        LOG.trace("Called async cancelDowngradeHcx");
+        final CancelDowngradeHcxRequest interceptedRequest =
+                CancelDowngradeHcxConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CancelDowngradeHcxConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CancelDowngradeHcxResponse>
+                transformer = CancelDowngradeHcxConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CancelDowngradeHcxRequest, CancelDowngradeHcxResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CancelDowngradeHcxRequest, CancelDowngradeHcxResponse>,
+                        java.util.concurrent.Future<CancelDowngradeHcxResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CancelDowngradeHcxRequest, CancelDowngradeHcxResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeSddcCompartmentResponse> changeSddcCompartment(
             ChangeSddcCompartmentRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -467,6 +507,45 @@ public class SddcAsyncClient implements SddcAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     DeleteSddcRequest, DeleteSddcResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DowngradeHcxResponse> downgradeHcx(
+            DowngradeHcxRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<DowngradeHcxRequest, DowngradeHcxResponse>
+                    handler) {
+        LOG.trace("Called async downgradeHcx");
+        final DowngradeHcxRequest interceptedRequest =
+                DowngradeHcxConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DowngradeHcxConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DowngradeHcxResponse>
+                transformer = DowngradeHcxConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<DowngradeHcxRequest, DowngradeHcxResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DowngradeHcxRequest, DowngradeHcxResponse>,
+                        java.util.concurrent.Future<DowngradeHcxResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DowngradeHcxRequest, DowngradeHcxResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -637,6 +716,48 @@ public class SddcAsyncClient implements SddcAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<RefreshHcxLicenseStatusResponse> refreshHcxLicenseStatus(
+            RefreshHcxLicenseStatusRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            RefreshHcxLicenseStatusRequest, RefreshHcxLicenseStatusResponse>
+                    handler) {
+        LOG.trace("Called async refreshHcxLicenseStatus");
+        final RefreshHcxLicenseStatusRequest interceptedRequest =
+                RefreshHcxLicenseStatusConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RefreshHcxLicenseStatusConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RefreshHcxLicenseStatusResponse>
+                transformer = RefreshHcxLicenseStatusConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        RefreshHcxLicenseStatusRequest, RefreshHcxLicenseStatusResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RefreshHcxLicenseStatusRequest, RefreshHcxLicenseStatusResponse>,
+                        java.util.concurrent.Future<RefreshHcxLicenseStatusResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RefreshHcxLicenseStatusRequest, RefreshHcxLicenseStatusResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<UpdateSddcResponse> updateSddc(
             UpdateSddcRequest request,
             final com.oracle.bmc.responses.AsyncHandler<UpdateSddcRequest, UpdateSddcResponse>
@@ -661,6 +782,44 @@ public class SddcAsyncClient implements SddcAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     UpdateSddcRequest, UpdateSddcResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpgradeHcxResponse> upgradeHcx(
+            UpgradeHcxRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<UpgradeHcxRequest, UpgradeHcxResponse>
+                    handler) {
+        LOG.trace("Called async upgradeHcx");
+        final UpgradeHcxRequest interceptedRequest = UpgradeHcxConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpgradeHcxConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpgradeHcxResponse>
+                transformer = UpgradeHcxConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<UpgradeHcxRequest, UpgradeHcxResponse> handlerToUse =
+                handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpgradeHcxRequest, UpgradeHcxResponse>,
+                        java.util.concurrent.Future<UpgradeHcxResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpgradeHcxRequest, UpgradeHcxResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/SddcClient.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/SddcClient.java
@@ -441,6 +441,36 @@ public class SddcClient implements Sddc {
     }
 
     @Override
+    public CancelDowngradeHcxResponse cancelDowngradeHcx(CancelDowngradeHcxRequest request) {
+        LOG.trace("Called cancelDowngradeHcx");
+        final CancelDowngradeHcxRequest interceptedRequest =
+                CancelDowngradeHcxConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CancelDowngradeHcxConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CancelDowngradeHcxResponse>
+                transformer = CancelDowngradeHcxConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeSddcCompartmentResponse changeSddcCompartment(
             ChangeSddcCompartmentRequest request) {
         LOG.trace("Called changeSddcCompartment");
@@ -529,6 +559,39 @@ public class SddcClient implements Sddc {
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response =
                                         client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DowngradeHcxResponse downgradeHcx(DowngradeHcxRequest request) {
+        LOG.trace("Called downgradeHcx");
+        final DowngradeHcxRequest interceptedRequest =
+                DowngradeHcxConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DowngradeHcxConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DowngradeHcxResponse>
+                transformer = DowngradeHcxConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getDowngradeHcxDetails(),
+                                                retriedRequest);
                                 return transformer.apply(response);
                             });
                 });
@@ -648,6 +711,37 @@ public class SddcClient implements Sddc {
     }
 
     @Override
+    public RefreshHcxLicenseStatusResponse refreshHcxLicenseStatus(
+            RefreshHcxLicenseStatusRequest request) {
+        LOG.trace("Called refreshHcxLicenseStatus");
+        final RefreshHcxLicenseStatusRequest interceptedRequest =
+                RefreshHcxLicenseStatusConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RefreshHcxLicenseStatusConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, RefreshHcxLicenseStatusResponse>
+                transformer = RefreshHcxLicenseStatusConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public UpdateSddcResponse updateSddc(UpdateSddcRequest request) {
         LOG.trace("Called updateSddc");
         final UpdateSddcRequest interceptedRequest = UpdateSddcConverter.interceptRequest(request);
@@ -673,6 +767,35 @@ public class SddcClient implements Sddc {
                                                 ib,
                                                 retriedRequest.getUpdateSddcDetails(),
                                                 retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpgradeHcxResponse upgradeHcx(UpgradeHcxRequest request) {
+        LOG.trace("Called upgradeHcx");
+        final UpgradeHcxRequest interceptedRequest = UpgradeHcxConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpgradeHcxConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpgradeHcxResponse> transformer =
+                UpgradeHcxConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
                                 return transformer.apply(response);
                             });
                 });

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/internal/http/CancelDowngradeHcxConverter.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/internal/http/CancelDowngradeHcxConverter.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.ocvp.model.*;
+import com.oracle.bmc.ocvp.requests.*;
+import com.oracle.bmc.ocvp.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.extern.slf4j.Slf4j
+public class CancelDowngradeHcxConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.ocvp.requests.CancelDowngradeHcxRequest interceptRequest(
+            com.oracle.bmc.ocvp.requests.CancelDowngradeHcxRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.ocvp.requests.CancelDowngradeHcxRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getSddcId(), "sddcId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200501")
+                        .path("sddcs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getSddcId()))
+                        .path("actions")
+                        .path("cancelDowngradeHcx");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.ocvp.responses.CancelDowngradeHcxResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.ocvp.responses.CancelDowngradeHcxResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.ocvp.responses.CancelDowngradeHcxResponse>() {
+                            @Override
+                            public com.oracle.bmc.ocvp.responses.CancelDowngradeHcxResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.ocvp.responses.CancelDowngradeHcxResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.ocvp.responses.CancelDowngradeHcxResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.ocvp.responses
+                                                        .CancelDowngradeHcxResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.ocvp.responses.CancelDowngradeHcxResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/internal/http/DowngradeHcxConverter.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/internal/http/DowngradeHcxConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.ocvp.model.*;
+import com.oracle.bmc.ocvp.requests.*;
+import com.oracle.bmc.ocvp.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.extern.slf4j.Slf4j
+public class DowngradeHcxConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.ocvp.requests.DowngradeHcxRequest interceptRequest(
+            com.oracle.bmc.ocvp.requests.DowngradeHcxRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.ocvp.requests.DowngradeHcxRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getDowngradeHcxDetails(), "downgradeHcxDetails is required");
+        Validate.notBlank(request.getSddcId(), "sddcId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200501")
+                        .path("sddcs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getSddcId()))
+                        .path("actions")
+                        .path("downgradeHcx");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.ocvp.responses.DowngradeHcxResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.ocvp.responses.DowngradeHcxResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.ocvp.responses.DowngradeHcxResponse>() {
+                            @Override
+                            public com.oracle.bmc.ocvp.responses.DowngradeHcxResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.ocvp.responses.DowngradeHcxResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.ocvp.responses.DowngradeHcxResponse.Builder builder =
+                                        com.oracle.bmc.ocvp.responses.DowngradeHcxResponse.builder()
+                                                .__httpStatusCode__(rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.ocvp.responses.DowngradeHcxResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/internal/http/RefreshHcxLicenseStatusConverter.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/internal/http/RefreshHcxLicenseStatusConverter.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.ocvp.model.*;
+import com.oracle.bmc.ocvp.requests.*;
+import com.oracle.bmc.ocvp.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.extern.slf4j.Slf4j
+public class RefreshHcxLicenseStatusConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.ocvp.requests.RefreshHcxLicenseStatusRequest interceptRequest(
+            com.oracle.bmc.ocvp.requests.RefreshHcxLicenseStatusRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.ocvp.requests.RefreshHcxLicenseStatusRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getSddcId(), "sddcId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200501")
+                        .path("sddcs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getSddcId()))
+                        .path("actions")
+                        .path("refreshHcxLicenses");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.ocvp.responses.RefreshHcxLicenseStatusResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.ocvp.responses.RefreshHcxLicenseStatusResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.ocvp.responses.RefreshHcxLicenseStatusResponse>() {
+                            @Override
+                            public com.oracle.bmc.ocvp.responses.RefreshHcxLicenseStatusResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.ocvp.responses.RefreshHcxLicenseStatusResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.ocvp.responses.RefreshHcxLicenseStatusResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.ocvp.responses
+                                                        .RefreshHcxLicenseStatusResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.ocvp.responses.RefreshHcxLicenseStatusResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/internal/http/UpgradeHcxConverter.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/internal/http/UpgradeHcxConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.ocvp.model.*;
+import com.oracle.bmc.ocvp.requests.*;
+import com.oracle.bmc.ocvp.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.extern.slf4j.Slf4j
+public class UpgradeHcxConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.ocvp.requests.UpgradeHcxRequest interceptRequest(
+            com.oracle.bmc.ocvp.requests.UpgradeHcxRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.ocvp.requests.UpgradeHcxRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getSddcId(), "sddcId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200501")
+                        .path("sddcs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getSddcId()))
+                        .path("actions")
+                        .path("upgradeHcx");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response, com.oracle.bmc.ocvp.responses.UpgradeHcxResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, com.oracle.bmc.ocvp.responses.UpgradeHcxResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.ocvp.responses.UpgradeHcxResponse>() {
+                            @Override
+                            public com.oracle.bmc.ocvp.responses.UpgradeHcxResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.ocvp.responses.UpgradeHcxResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.ocvp.responses.UpgradeHcxResponse.Builder builder =
+                                        com.oracle.bmc.ocvp.responses.UpgradeHcxResponse.builder()
+                                                .__httpStatusCode__(rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.ocvp.responses.UpgradeHcxResponse responseWrapper =
+                                        builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/CreateEsxiHostDetails.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/CreateEsxiHostDetails.java
@@ -139,6 +139,8 @@ public class CreateEsxiHostDetails {
 
     /**
      * Billing option selected during SDDC creation.
+     * Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+     * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
      * {@link #listSupportedSkus(ListSupportedSkusRequest) listSupportedSkus}.
      *
      **/

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/CreateSddcDetails.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/CreateSddcDetails.java
@@ -107,6 +107,15 @@ public class CreateSddcDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isHcxEnterpriseEnabled")
+        private Boolean isHcxEnterpriseEnabled;
+
+        public Builder isHcxEnterpriseEnabled(Boolean isHcxEnterpriseEnabled) {
+            this.isHcxEnterpriseEnabled = isHcxEnterpriseEnabled;
+            this.__explicitlySet__.add("isHcxEnterpriseEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sshAuthorizedKeys")
         private String sshAuthorizedKeys;
 
@@ -249,6 +258,7 @@ public class CreateSddcDetails {
                             initialSku,
                             isHcxEnabled,
                             hcxVlanId,
+                            isHcxEnterpriseEnabled,
                             sshAuthorizedKeys,
                             workloadNetworkCidr,
                             provisioningSubnetId,
@@ -279,6 +289,7 @@ public class CreateSddcDetails {
                             .initialSku(o.getInitialSku())
                             .isHcxEnabled(o.getIsHcxEnabled())
                             .hcxVlanId(o.getHcxVlanId())
+                            .isHcxEnterpriseEnabled(o.getIsHcxEnterpriseEnabled())
                             .sshAuthorizedKeys(o.getSshAuthorizedKeys())
                             .workloadNetworkCidr(o.getWorkloadNetworkCidr())
                             .provisioningSubnetId(o.getProvisioningSubnetId())
@@ -363,7 +374,9 @@ public class CreateSddcDetails {
     Integer esxiHostsCount;
 
     /**
-     * Billing option selected during SDDC creation
+     * Billing option selected during SDDC creation.
+     * Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+     * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
      * {@link #listSupportedSkus(ListSupportedSkusRequest) listSupportedSkus}.
      *
      **/
@@ -384,6 +397,13 @@ public class CreateSddcDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("hcxVlanId")
     String hcxVlanId;
+
+    /**
+     * Indicates whether to enable HCX Enterprise for this SDDC.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHcxEnterpriseEnabled")
+    Boolean isHcxEnterpriseEnabled;
 
     /**
      * One or more public SSH keys to be included in the `~/.ssh/authorized_keys` file for

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/DowngradeHcxDetails.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/DowngradeHcxDetails.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.model;
+
+/**
+ * The HCX on-premise licenses to be reserved when downgrade from HCX Enterprise to HCX Advanced.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DowngradeHcxDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DowngradeHcxDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("reservingHcxOnPremiseLicenseKeys")
+        private java.util.List<String> reservingHcxOnPremiseLicenseKeys;
+
+        public Builder reservingHcxOnPremiseLicenseKeys(
+                java.util.List<String> reservingHcxOnPremiseLicenseKeys) {
+            this.reservingHcxOnPremiseLicenseKeys = reservingHcxOnPremiseLicenseKeys;
+            this.__explicitlySet__.add("reservingHcxOnPremiseLicenseKeys");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DowngradeHcxDetails build() {
+            DowngradeHcxDetails __instance__ =
+                    new DowngradeHcxDetails(reservingHcxOnPremiseLicenseKeys);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DowngradeHcxDetails o) {
+            Builder copiedBuilder =
+                    reservingHcxOnPremiseLicenseKeys(o.getReservingHcxOnPremiseLicenseKeys());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The HCX on-premise licenses keys to be reserved when downgrade from HCX Enterprise to HCX Advanced.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reservingHcxOnPremiseLicenseKeys")
+    java.util.List<String> reservingHcxOnPremiseLicenseKeys;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/EsxiHost.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/EsxiHost.java
@@ -268,6 +268,8 @@ public class EsxiHost {
 
     /**
      * Billing option selected during SDDC creation.
+     * Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+     * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
      * {@link #listSupportedSkus(ListSupportedSkusRequest) listSupportedSkus}.
      *
      **/

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/EsxiHostSummary.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/EsxiHostSummary.java
@@ -260,6 +260,8 @@ public class EsxiHostSummary {
 
     /**
      * Billing option selected during SDDC creation.
+     * Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+     * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
      * {@link #listSupportedSkus(ListSupportedSkusRequest) listSupportedSkus}.
      *
      **/

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/HcxLicenseStatus.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/HcxLicenseStatus.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.model;
+
+/**
+ * HCX on-premise license status
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.extern.slf4j.Slf4j
+public enum HcxLicenseStatus {
+    Available("AVAILABLE"),
+    Consumed("CONSUMED"),
+    Deactivated("DEACTIVATED"),
+    Deleted("DELETED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, HcxLicenseStatus> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (HcxLicenseStatus v : HcxLicenseStatus.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    HcxLicenseStatus(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static HcxLicenseStatus create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'HcxLicenseStatus', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/HcxLicenseSummary.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/HcxLicenseSummary.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.model;
+
+/**
+ * HCX on-premise license information summary.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = HcxLicenseSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class HcxLicenseSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("activationKey")
+        private String activationKey;
+
+        public Builder activationKey(String activationKey) {
+            this.activationKey = activationKey;
+            this.__explicitlySet__.add("activationKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private HcxLicenseStatus status;
+
+        public Builder status(HcxLicenseStatus status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemName")
+        private String systemName;
+
+        public Builder systemName(String systemName) {
+            this.systemName = systemName;
+            this.__explicitlySet__.add("systemName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public HcxLicenseSummary build() {
+            HcxLicenseSummary __instance__ =
+                    new HcxLicenseSummary(activationKey, status, systemName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(HcxLicenseSummary o) {
+            Builder copiedBuilder =
+                    activationKey(o.getActivationKey())
+                            .status(o.getStatus())
+                            .systemName(o.getSystemName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * HCX on-premise license key value
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("activationKey")
+    String activationKey;
+
+    /**
+     * status of HCX on-premise license
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    HcxLicenseStatus status;
+
+    /**
+     * Name of the system that consumed the HCX on-premise license
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemName")
+    String systemName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/OperationTypes.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/OperationTypes.java
@@ -14,6 +14,10 @@ public enum OperationTypes {
     DeleteSddc("DELETE_SDDC"),
     CreateEsxiHost("CREATE_ESXI_HOST"),
     DeleteEsxiHost("DELETE_ESXI_HOST"),
+    UpgradeHcx("UPGRADE_HCX"),
+    DowngradeHcx("DOWNGRADE_HCX"),
+    CancelDowngradeHcx("CANCEL_DOWNGRADE_HCX"),
+    RefreshHcxLicenseStatus("REFRESH_HCX_LICENSE_STATUS"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/Sddc.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/Sddc.java
@@ -357,6 +357,51 @@ public class Sddc {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isHcxEnterpriseEnabled")
+        private Boolean isHcxEnterpriseEnabled;
+
+        public Builder isHcxEnterpriseEnabled(Boolean isHcxEnterpriseEnabled) {
+            this.isHcxEnterpriseEnabled = isHcxEnterpriseEnabled;
+            this.__explicitlySet__.add("isHcxEnterpriseEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isHcxPendingDowngrade")
+        private Boolean isHcxPendingDowngrade;
+
+        public Builder isHcxPendingDowngrade(Boolean isHcxPendingDowngrade) {
+            this.isHcxPendingDowngrade = isHcxPendingDowngrade;
+            this.__explicitlySet__.add("isHcxPendingDowngrade");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("hcxOnPremLicenses")
+        private java.util.List<HcxLicenseSummary> hcxOnPremLicenses;
+
+        public Builder hcxOnPremLicenses(java.util.List<HcxLicenseSummary> hcxOnPremLicenses) {
+            this.hcxOnPremLicenses = hcxOnPremLicenses;
+            this.__explicitlySet__.add("hcxOnPremLicenses");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeHcxBillingCycleEnd")
+        private java.util.Date timeHcxBillingCycleEnd;
+
+        public Builder timeHcxBillingCycleEnd(java.util.Date timeHcxBillingCycleEnd) {
+            this.timeHcxBillingCycleEnd = timeHcxBillingCycleEnd;
+            this.__explicitlySet__.add("timeHcxBillingCycleEnd");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeHcxLicenseStatusUpdated")
+        private java.util.Date timeHcxLicenseStatusUpdated;
+
+        public Builder timeHcxLicenseStatusUpdated(java.util.Date timeHcxLicenseStatusUpdated) {
+            this.timeHcxLicenseStatusUpdated = timeHcxLicenseStatusUpdated;
+            this.__explicitlySet__.add("timeHcxLicenseStatusUpdated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
         private java.util.Date timeCreated;
 
@@ -445,6 +490,11 @@ public class Sddc {
                             hcxVlanId,
                             isHcxEnabled,
                             hcxOnPremKey,
+                            isHcxEnterpriseEnabled,
+                            isHcxPendingDowngrade,
+                            hcxOnPremLicenses,
+                            timeHcxBillingCycleEnd,
+                            timeHcxLicenseStatusUpdated,
                             timeCreated,
                             timeUpdated,
                             lifecycleState,
@@ -493,6 +543,11 @@ public class Sddc {
                             .hcxVlanId(o.getHcxVlanId())
                             .isHcxEnabled(o.getIsHcxEnabled())
                             .hcxOnPremKey(o.getHcxOnPremKey())
+                            .isHcxEnterpriseEnabled(o.getIsHcxEnterpriseEnabled())
+                            .isHcxPendingDowngrade(o.getIsHcxPendingDowngrade())
+                            .hcxOnPremLicenses(o.getHcxOnPremLicenses())
+                            .timeHcxBillingCycleEnd(o.getTimeHcxBillingCycleEnd())
+                            .timeHcxLicenseStatusUpdated(o.getTimeHcxLicenseStatusUpdated())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
@@ -582,7 +637,9 @@ public class Sddc {
     Integer esxiHostsCount;
 
     /**
-     * Billing option selected during SDDC creation
+     * Billing option selected during SDDC creation.
+     * Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+     * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
      * {@link #listSupportedSkus(ListSupportedSkusRequest) listSupportedSkus}.
      *
      **/
@@ -917,6 +974,44 @@ public class Sddc {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("hcxOnPremKey")
     String hcxOnPremKey;
+
+    /**
+     * Indicates whether HCX Enterprise is enabled for this SDDC.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHcxEnterpriseEnabled")
+    Boolean isHcxEnterpriseEnabled;
+
+    /**
+     * Indicates whether SDDC is pending downgrade from HCX Enterprise to HCX Advanced.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isHcxPendingDowngrade")
+    Boolean isHcxPendingDowngrade;
+
+    /**
+     * The activation licenses to use on the on-premises HCX Enterprise appliance you site pair with HCX Manager in your VMware Solution.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hcxOnPremLicenses")
+    java.util.List<HcxLicenseSummary> hcxOnPremLicenses;
+
+    /**
+     * The date and time current HCX Enterprise billing cycle ends, in the format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeHcxBillingCycleEnd")
+    java.util.Date timeHcxBillingCycleEnd;
+
+    /**
+     * The date and time the SDDC's HCX on-premise license status was updated, in the format defined by
+     * [RFC3339](https://tools.ietf.org/html/rfc3339).
+     * <p>
+     * Example: `2016-08-25T21:10:29.600Z`
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeHcxLicenseStatusUpdated")
+    java.util.Date timeHcxLicenseStatusUpdated;
 
     /**
      * The date and time the SDDC was created, in the format defined by

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/SupportedSkuSummary.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/SupportedSkuSummary.java
@@ -5,7 +5,8 @@
 package com.oracle.bmc.ocvp.model;
 
 /**
- * A specific SKU. HOUR, MONTH, ONE_YEAR and THREE_YEARS supported by the Oracle Cloud VMware Solution.
+ * A specific SKU. Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+ * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -28,9 +29,9 @@ public class SupportedSkuSummary {
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
         @com.fasterxml.jackson.annotation.JsonProperty("name")
-        private Name name;
+        private Sku name;
 
-        public Builder name(Name name) {
+        public Builder name(Sku name) {
             this.name = name;
             this.__explicitlySet__.add("name");
             return this;
@@ -64,55 +65,8 @@ public class SupportedSkuSummary {
     /**
      * name of SKU
      **/
-    @lombok.extern.slf4j.Slf4j
-    public enum Name {
-        Hour("HOUR"),
-        Month("MONTH"),
-        OneYear("ONE_YEAR"),
-        ThreeYears("THREE_YEARS"),
-
-        /**
-         * This value is used if a service returns a value for this enum that is not recognized by this
-         * version of the SDK.
-         */
-        UnknownEnumValue(null);
-
-        private final String value;
-        private static java.util.Map<String, Name> map;
-
-        static {
-            map = new java.util.HashMap<>();
-            for (Name v : Name.values()) {
-                if (v != UnknownEnumValue) {
-                    map.put(v.getValue(), v);
-                }
-            }
-        }
-
-        Name(String value) {
-            this.value = value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonValue
-        public String getValue() {
-            return value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonCreator
-        public static Name create(String key) {
-            if (map.containsKey(key)) {
-                return map.get(key);
-            }
-            LOG.warn(
-                    "Received unknown value '{}' for enum 'Name', returning UnknownEnumValue", key);
-            return UnknownEnumValue;
-        }
-    };
-    /**
-     * name of SKU
-     **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
-    Name name;
+    Sku name;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/SupportedSkuSummaryCollection.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/SupportedSkuSummaryCollection.java
@@ -5,7 +5,9 @@
 package com.oracle.bmc.ocvp.model;
 
 /**
- * A specific SKU. HOUR, MONTH, ONE_YEAR and THREE_YEARS supported by the Oracle Cloud VMware Solution.
+ * A specific SKU. Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+ * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
+ *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/UpdateEsxiHostDetails.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/model/UpdateEsxiHostDetails.java
@@ -104,7 +104,9 @@ public class UpdateEsxiHostDetails {
     String displayName;
 
     /**
-     * Billing option to switch to once existing billing cycle ends.
+     * Billing option to switch to after the existing billing cycle ends.
+     * Oracle Cloud Infrastructure VMware Solution supports the following billing interval SKUs:
+     * HOUR, MONTH, ONE_YEAR, and THREE_YEARS.
      * {@link #listSupportedSkus(ListSupportedSkusRequest) listSupportedSkus}.
      *
      **/

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/requests/CancelDowngradeHcxRequest.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/requests/CancelDowngradeHcxRequest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.requests;
+
+import com.oracle.bmc.ocvp.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/ocvp/CancelDowngradeHcxExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CancelDowngradeHcxRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CancelDowngradeHcxRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the SDDC.
+     *
+     */
+    private String sddcId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request. If you need to contact Oracle about a particular
+     * request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CancelDowngradeHcxRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CancelDowngradeHcxRequest o) {
+            sddcId(o.getSddcId());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CancelDowngradeHcxRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CancelDowngradeHcxRequest
+         */
+        public CancelDowngradeHcxRequest build() {
+            CancelDowngradeHcxRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/requests/DowngradeHcxRequest.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/requests/DowngradeHcxRequest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.requests;
+
+import com.oracle.bmc.ocvp.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/ocvp/DowngradeHcxExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DowngradeHcxRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DowngradeHcxRequest extends com.oracle.bmc.requests.BmcRequest<DowngradeHcxDetails> {
+
+    /**
+     * The HCX on-premise license keys to be reserved when downgrade from HCX Enterprise to HCX Advanced.
+     */
+    private DowngradeHcxDetails downgradeHcxDetails;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the SDDC.
+     *
+     */
+    private String sddcId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request. If you need to contact Oracle about a particular
+     * request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public DowngradeHcxDetails getBody$() {
+        return downgradeHcxDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DowngradeHcxRequest, DowngradeHcxDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DowngradeHcxRequest o) {
+            downgradeHcxDetails(o.getDowngradeHcxDetails());
+            sddcId(o.getSddcId());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DowngradeHcxRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DowngradeHcxRequest
+         */
+        public DowngradeHcxRequest build() {
+            DowngradeHcxRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(DowngradeHcxDetails body) {
+            downgradeHcxDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/requests/RefreshHcxLicenseStatusRequest.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/requests/RefreshHcxLicenseStatusRequest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.requests;
+
+import com.oracle.bmc.ocvp.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/ocvp/RefreshHcxLicenseStatusExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use RefreshHcxLicenseStatusRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RefreshHcxLicenseStatusRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the SDDC.
+     *
+     */
+    private String sddcId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request. If you need to contact Oracle about a particular
+     * request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RefreshHcxLicenseStatusRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RefreshHcxLicenseStatusRequest o) {
+            sddcId(o.getSddcId());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RefreshHcxLicenseStatusRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RefreshHcxLicenseStatusRequest
+         */
+        public RefreshHcxLicenseStatusRequest build() {
+            RefreshHcxLicenseStatusRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/requests/UpgradeHcxRequest.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/requests/UpgradeHcxRequest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.requests;
+
+import com.oracle.bmc.ocvp.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/ocvp/UpgradeHcxExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpgradeHcxRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpgradeHcxRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the SDDC.
+     *
+     */
+    private String sddcId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the `if-match` parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request. If you need to contact Oracle about a particular
+     * request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpgradeHcxRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpgradeHcxRequest o) {
+            sddcId(o.getSddcId());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpgradeHcxRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpgradeHcxRequest
+         */
+        public UpgradeHcxRequest build() {
+            UpgradeHcxRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/responses/CancelDowngradeHcxResponse.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/responses/CancelDowngradeHcxResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.responses;
+
+import com.oracle.bmc.ocvp.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class CancelDowngradeHcxResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CancelDowngradeHcxResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/responses/DowngradeHcxResponse.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/responses/DowngradeHcxResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.responses;
+
+import com.oracle.bmc.ocvp.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class DowngradeHcxResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DowngradeHcxResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/responses/RefreshHcxLicenseStatusResponse.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/responses/RefreshHcxLicenseStatusResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.responses;
+
+import com.oracle.bmc.ocvp.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class RefreshHcxLicenseStatusResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RefreshHcxLicenseStatusResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/responses/UpgradeHcxResponse.java
+++ b/bmc-ocvp/src/main/java/com/oracle/bmc/ocvp/responses/UpgradeHcxResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.ocvp.responses;
+
+import com.oracle.bmc.ocvp.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200501")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class UpgradeHcxResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpgradeHcxResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -20,11 +20,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/src/main/java/com/oracle/bmc/secrets/Secrets.java
+++ b/bmc-secrets/src/main/java/com/oracle/bmc/secrets/Secrets.java
@@ -46,7 +46,7 @@ public interface Secrets extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Gets a secret bundle that matches either the specified `stage`, `label`, or `versionNumber` parameter.
+     * Gets a secret bundle that matches either the specified `stage`, `secretVersionName`, or `versionNumber` parameter.
      * If none of these parameters are provided, the bundle for the secret version marked as `CURRENT` will be returned.
      *
      * @param request The request object containing the details to send
@@ -56,6 +56,18 @@ public interface Secrets extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/secrets/GetSecretBundleExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetSecretBundle API.
      */
     GetSecretBundleResponse getSecretBundle(GetSecretBundleRequest request);
+
+    /**
+     * Gets a secret bundle by secret name and vault ID, and secret version that matches either the specified `stage`, `secretVersionName`, or `versionNumber` parameter.
+     * If none of these parameters are provided, the bundle for the secret version marked as `CURRENT` is returned.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/secrets/GetSecretBundleByNameExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetSecretBundleByName API.
+     */
+    GetSecretBundleByNameResponse getSecretBundleByName(GetSecretBundleByNameRequest request);
 
     /**
      * Lists all secret bundle versions for the specified secret.

--- a/bmc-secrets/src/main/java/com/oracle/bmc/secrets/SecretsAsync.java
+++ b/bmc-secrets/src/main/java/com/oracle/bmc/secrets/SecretsAsync.java
@@ -46,7 +46,7 @@ public interface SecretsAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Gets a secret bundle that matches either the specified `stage`, `label`, or `versionNumber` parameter.
+     * Gets a secret bundle that matches either the specified `stage`, `secretVersionName`, or `versionNumber` parameter.
      * If none of these parameters are provided, the bundle for the secret version marked as `CURRENT` will be returned.
      *
      *
@@ -60,6 +60,24 @@ public interface SecretsAsync extends AutoCloseable {
     java.util.concurrent.Future<GetSecretBundleResponse> getSecretBundle(
             GetSecretBundleRequest request,
             com.oracle.bmc.responses.AsyncHandler<GetSecretBundleRequest, GetSecretBundleResponse>
+                    handler);
+
+    /**
+     * Gets a secret bundle by secret name and vault ID, and secret version that matches either the specified `stage`, `secretVersionName`, or `versionNumber` parameter.
+     * If none of these parameters are provided, the bundle for the secret version marked as `CURRENT` is returned.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetSecretBundleByNameResponse> getSecretBundleByName(
+            GetSecretBundleByNameRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetSecretBundleByNameRequest, GetSecretBundleByNameResponse>
                     handler);
 
     /**

--- a/bmc-secrets/src/main/java/com/oracle/bmc/secrets/SecretsAsyncClient.java
+++ b/bmc-secrets/src/main/java/com/oracle/bmc/secrets/SecretsAsyncClient.java
@@ -403,6 +403,47 @@ public class SecretsAsyncClient implements SecretsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetSecretBundleByNameResponse> getSecretBundleByName(
+            GetSecretBundleByNameRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetSecretBundleByNameRequest, GetSecretBundleByNameResponse>
+                    handler) {
+        LOG.trace("Called async getSecretBundleByName");
+        final GetSecretBundleByNameRequest interceptedRequest =
+                GetSecretBundleByNameConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetSecretBundleByNameConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetSecretBundleByNameResponse>
+                transformer = GetSecretBundleByNameConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetSecretBundleByNameRequest, GetSecretBundleByNameResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetSecretBundleByNameRequest, GetSecretBundleByNameResponse>,
+                        java.util.concurrent.Future<GetSecretBundleByNameResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetSecretBundleByNameRequest, GetSecretBundleByNameResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListSecretBundleVersionsResponse> listSecretBundleVersions(
             ListSecretBundleVersionsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-secrets/src/main/java/com/oracle/bmc/secrets/SecretsClient.java
+++ b/bmc-secrets/src/main/java/com/oracle/bmc/secrets/SecretsClient.java
@@ -396,6 +396,36 @@ public class SecretsClient implements Secrets {
     }
 
     @Override
+    public GetSecretBundleByNameResponse getSecretBundleByName(
+            GetSecretBundleByNameRequest request) {
+        LOG.trace("Called getSecretBundleByName");
+        final GetSecretBundleByNameRequest interceptedRequest =
+                GetSecretBundleByNameConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetSecretBundleByNameConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetSecretBundleByNameResponse>
+                transformer = GetSecretBundleByNameConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListSecretBundleVersionsResponse listSecretBundleVersions(
             ListSecretBundleVersionsRequest request) {
         LOG.trace("Called listSecretBundleVersions");

--- a/bmc-secrets/src/main/java/com/oracle/bmc/secrets/internal/http/GetSecretBundleByNameConverter.java
+++ b/bmc-secrets/src/main/java/com/oracle/bmc/secrets/internal/http/GetSecretBundleByNameConverter.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.secrets.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.secrets.model.*;
+import com.oracle.bmc.secrets.requests.*;
+import com.oracle.bmc.secrets.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190301")
+@lombok.extern.slf4j.Slf4j
+public class GetSecretBundleByNameConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.secrets.requests.GetSecretBundleByNameRequest interceptRequest(
+            com.oracle.bmc.secrets.requests.GetSecretBundleByNameRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.secrets.requests.GetSecretBundleByNameRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getSecretName(), "secretName is required");
+        Validate.notNull(request.getVaultId(), "vaultId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190301")
+                        .path("secretbundles")
+                        .path("actions")
+                        .path("getByName");
+
+        target =
+                target.queryParam(
+                        "secretName",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getSecretName()));
+
+        target =
+                target.queryParam(
+                        "vaultId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getVaultId()));
+
+        if (request.getVersionNumber() != null) {
+            target =
+                    target.queryParam(
+                            "versionNumber",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getVersionNumber()));
+        }
+
+        if (request.getSecretVersionName() != null) {
+            target =
+                    target.queryParam(
+                            "secretVersionName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSecretVersionName()));
+        }
+
+        if (request.getStage() != null) {
+            target =
+                    target.queryParam(
+                            "stage",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getStage().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.secrets.responses.GetSecretBundleByNameResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.secrets.responses.GetSecretBundleByNameResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.secrets.responses.GetSecretBundleByNameResponse>() {
+                            @Override
+                            public com.oracle.bmc.secrets.responses.GetSecretBundleByNameResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.secrets.responses.GetSecretBundleByNameResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        SecretBundle>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        SecretBundle.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<SecretBundle> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.secrets.responses.GetSecretBundleByNameResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.secrets.responses
+                                                        .GetSecretBundleByNameResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.secretBundle(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.secrets.responses.GetSecretBundleByNameResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-secrets/src/main/java/com/oracle/bmc/secrets/requests/GetSecretBundleByNameRequest.java
+++ b/bmc-secrets/src/main/java/com/oracle/bmc/secrets/requests/GetSecretBundleByNameRequest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.secrets.requests;
+
+import com.oracle.bmc.secrets.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/secrets/GetSecretBundleByNameExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetSecretBundleByNameRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190301")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetSecretBundleByNameRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * A user-friendly name for the secret. Secret names are unique within a vault. Secret names are case-sensitive.
+     */
+    private String secretName;
+
+    /**
+     * The OCID of the vault that contains the secret.
+     */
+    private String vaultId;
+
+    /**
+     * Unique identifier for the request.
+     */
+    private String opcRequestId;
+
+    /**
+     * The version number of the secret.
+     */
+    private Long versionNumber;
+
+    /**
+     * The name of the secret. (This might be referred to as the name of the secret version. Names are unique across the different versions of a secret.)
+     */
+    private String secretVersionName;
+
+    /**
+     * The rotation state of the secret version.
+     */
+    private Stage stage;
+
+    /**
+     * The rotation state of the secret version.
+     **/
+    public enum Stage {
+        Current("CURRENT"),
+        Pending("PENDING"),
+        Latest("LATEST"),
+        Previous("PREVIOUS"),
+        Deprecated("DEPRECATED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Stage> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Stage v : Stage.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Stage(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Stage create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Stage: " + key);
+        }
+    };
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetSecretBundleByNameRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetSecretBundleByNameRequest o) {
+            secretName(o.getSecretName());
+            vaultId(o.getVaultId());
+            opcRequestId(o.getOpcRequestId());
+            versionNumber(o.getVersionNumber());
+            secretVersionName(o.getSecretVersionName());
+            stage(o.getStage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetSecretBundleByNameRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetSecretBundleByNameRequest
+         */
+        public GetSecretBundleByNameRequest build() {
+            GetSecretBundleByNameRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-secrets/src/main/java/com/oracle/bmc/secrets/responses/GetSecretBundleByNameResponse.java
+++ b/bmc-secrets/src/main/java/com/oracle/bmc/secrets/responses/GetSecretBundleByNameResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.secrets.responses;
+
+import com.oracle.bmc.secrets.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190301")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class GetSecretBundleByNameResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please provide the request ID.
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned SecretBundle instance.
+     */
+    private SecretBundle secretBundle;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetSecretBundleByNameResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            secretBundle(o.getSecretBundle());
+
+            return this;
+        }
+    }
+}

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -20,11 +20,12 @@
 
 
 
+
   <dependencies>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>1.36.5</version>
+    <version>1.37.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>1.36.5</version>
+      <version>1.37.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>1.36.5</version>
+  <version>1.37.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>
@@ -708,6 +708,8 @@
     <module>bmc-servicecatalog</module>
     <module>bmc-ailanguage</module>
     <module>bmc-operatoraccesscontrol</module>
+    <module>bmc-bastion</module>
+    <module>bmc-genericartifactscontent</module>
     <module>bmc-full</module>
     <module>bmc-shaded</module>
   </modules>


### PR DESCRIPTION
### Added

- Support for the Generic Artifacts service

- Support for the Bastion service

- Support for reading secrets by name in the Vault service

- Support for the isDynamic field when listing definitions in the Limits service

- Support for getting billable image sizes in the Compute service

- Support for getting Automatic Workload Repository (AWR) data on external databases in the Database Management service

- Support for the VM.Standard.E3.Flex flexible compute shape with customizable OCPUs and memory on notebooks in the Data Science service

- Support for container images and generic artifacts billing in the Registry service

- Support for the HCX Enterprise add-on in the VMware Solution service



### Breaking Changes

- Return type of method `public com.oracle.bmc.ocvp.model.SupportedSkuSummary$Name getName()` has been changed to `com.oracle.bmc.ocvp.model.Sku` in the model `SupportedSkuSummary` in the Ocvp service

- Class `com.oracle.bmc.ocvp.model.SupportedSkuSummary$Name` has been removed from the model `SupportedSkuSummary` in the Ocvp service