### PR TITLE
Releasing version 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.3.2 - 2021-08-03
+### Added
+- Support for manually copying volume group backups across regions in the Block Volume service
+- Support for work requests for the copy volume backup and copy boot volume backup operations in the Block Volume service
+- Support for specifying external Hive metastores during application creation in the Data Flow service
+- Support for changing the compartment of a backup in the MySQL Database service
+- Support for model catalog features including provenance, metadata, schemas, and artifact introspection in the Data Science service
+- Support for Exadata system network bonding in the Database service
+- Support for creating autonomous databases with early patching enabled in the Database service
+
 ## 2.3.1 - 2021-07-27
 ### Added
 - Support for filtering by tag on capacity planning and SQL warehouse list operations in the Operations Insights service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,504 +19,504 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
@@ -158,6 +158,18 @@ public interface Blockstorage extends AutoCloseable {
     CopyVolumeBackupResponse copyVolumeBackup(CopyVolumeBackupRequest request);
 
     /**
+     * Creates a volume group backup copy in specified region. For general information about volume group backups,
+     * see [Overview of Block Volume Service Backups](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumebackups.htm)
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/core/CopyVolumeGroupBackupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CopyVolumeGroupBackup API.
+     */
+    CopyVolumeGroupBackupResponse copyVolumeGroupBackup(CopyVolumeGroupBackupRequest request);
+
+    /**
      * Creates a new boot volume in the specified compartment from an existing boot volume or a boot volume backup.
      * For general information about boot volumes, see [Boot Volumes](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/bootvolumes.htm).
      * You may optionally specify a *display name* for the volume, which is simply a friendly name or

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
@@ -207,6 +207,24 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Creates a volume group backup copy in specified region. For general information about volume group backups,
+     * see [Overview of Block Volume Service Backups](https://docs.cloud.oracle.com/Content/Block/Concepts/blockvolumebackups.htm)
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CopyVolumeGroupBackupResponse> copyVolumeGroupBackup(
+            CopyVolumeGroupBackupRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CopyVolumeGroupBackupRequest, CopyVolumeGroupBackupResponse>
+                    handler);
+
+    /**
      * Creates a new boot volume in the specified compartment from an existing boot volume or a boot volume backup.
      * For general information about boot volumes, see [Boot Volumes](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/bootvolumes.htm).
      * You may optionally specify a *display name* for the volume, which is simply a friendly name or

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsyncClient.java
@@ -764,6 +764,53 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CopyVolumeGroupBackupResponse> copyVolumeGroupBackup(
+            CopyVolumeGroupBackupRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CopyVolumeGroupBackupRequest, CopyVolumeGroupBackupResponse>
+                    handler) {
+        LOG.trace("Called async copyVolumeGroupBackup");
+        final CopyVolumeGroupBackupRequest interceptedRequest =
+                CopyVolumeGroupBackupConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CopyVolumeGroupBackupConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CopyVolumeGroupBackupResponse>
+                transformer = CopyVolumeGroupBackupConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CopyVolumeGroupBackupRequest, CopyVolumeGroupBackupResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CopyVolumeGroupBackupRequest, CopyVolumeGroupBackupResponse>,
+                        java.util.concurrent.Future<CopyVolumeGroupBackupResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getCopyVolumeGroupBackupDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CopyVolumeGroupBackupRequest, CopyVolumeGroupBackupResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateBootVolumeResponse> createBootVolume(
             CreateBootVolumeRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageClient.java
@@ -728,6 +728,40 @@ public class BlockstorageClient implements Blockstorage {
     }
 
     @Override
+    public CopyVolumeGroupBackupResponse copyVolumeGroupBackup(
+            CopyVolumeGroupBackupRequest request) {
+        LOG.trace("Called copyVolumeGroupBackup");
+        final CopyVolumeGroupBackupRequest interceptedRequest =
+                CopyVolumeGroupBackupConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CopyVolumeGroupBackupConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CopyVolumeGroupBackupResponse>
+                transformer = CopyVolumeGroupBackupConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCopyVolumeGroupBackupDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateBootVolumeResponse createBootVolume(CreateBootVolumeRequest request) {
         LOG.trace("Called createBootVolume");
         final CreateBootVolumeRequest interceptedRequest =

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageWaiters.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageWaiters.java
@@ -39,6 +39,119 @@ public class BlockstorageWaiters {
      * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
      *
      * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<CopyBootVolumeBackupRequest, CopyBootVolumeBackupResponse>
+            forCopyBootVolumeBackup(CopyBootVolumeBackupRequest request) {
+        return forCopyBootVolumeBackup(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<CopyBootVolumeBackupRequest, CopyBootVolumeBackupResponse>
+            forCopyBootVolumeBackup(
+                    CopyBootVolumeBackupRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<CopyBootVolumeBackupResponse>() {
+                    @Override
+                    public CopyBootVolumeBackupResponse call() throws Exception {
+                        final CopyBootVolumeBackupResponse response =
+                                client.copyBootVolumeBackup(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<CopyVolumeBackupRequest, CopyVolumeBackupResponse>
+            forCopyVolumeBackup(CopyVolumeBackupRequest request) {
+        return forCopyVolumeBackup(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<CopyVolumeBackupRequest, CopyVolumeBackupResponse>
+            forCopyVolumeBackup(
+                    CopyVolumeBackupRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<CopyVolumeBackupResponse>() {
+                    @Override
+                    public CopyVolumeBackupResponse call() throws Exception {
+                        final CopyVolumeBackupResponse response = client.copyVolumeBackup(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
      * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code Waiter} instance
      */

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CopyBootVolumeBackupConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CopyBootVolumeBackupConverter.java
@@ -119,6 +119,42 @@ public class CopyBootVolumeBackupConverter {
                                                     String.class));
                                 }
 
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        contentLocationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "content-location");
+                                if (contentLocationHeader.isPresent()) {
+                                    builder.contentLocation(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "content-location",
+                                                    contentLocationHeader.get().get(0),
+                                                    String.class));
+                                }
+
                                 com.oracle.bmc.core.responses.CopyBootVolumeBackupResponse
                                         responseWrapper = builder.build();
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CopyVolumeBackupConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CopyVolumeBackupConverter.java
@@ -118,6 +118,42 @@ public class CopyVolumeBackupConverter {
                                                     String.class));
                                 }
 
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        locationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "location");
+                                if (locationHeader.isPresent()) {
+                                    builder.location(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "location",
+                                                    locationHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        contentLocationHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "content-location");
+                                if (contentLocationHeader.isPresent()) {
+                                    builder.contentLocation(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "content-location",
+                                                    contentLocationHeader.get().get(0),
+                                                    String.class));
+                                }
+
                                 com.oracle.bmc.core.responses.CopyVolumeBackupResponse
                                         responseWrapper = builder.build();
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CopyVolumeGroupBackupConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/CopyVolumeGroupBackupConverter.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class CopyVolumeGroupBackupConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.CopyVolumeGroupBackupRequest interceptRequest(
+            com.oracle.bmc.core.requests.CopyVolumeGroupBackupRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.CopyVolumeGroupBackupRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getVolumeGroupBackupId(), "volumeGroupBackupId must not be blank");
+        Validate.notNull(
+                request.getCopyVolumeGroupBackupDetails(),
+                "copyVolumeGroupBackupDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("volumeGroupBackups")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVolumeGroupBackupId()))
+                        .path("actions")
+                        .path("copy");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.CopyVolumeGroupBackupResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.CopyVolumeGroupBackupResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses.CopyVolumeGroupBackupResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses.CopyVolumeGroupBackupResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.CopyVolumeGroupBackupResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        VolumeGroupBackup>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        VolumeGroupBackup.class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<VolumeGroupBackup>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses.CopyVolumeGroupBackupResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .CopyVolumeGroupBackupResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.volumeGroupBackup(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses.CopyVolumeGroupBackupResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CopyVolumeGroupBackupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CopyVolumeGroupBackupDetails.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CopyVolumeGroupBackupDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CopyVolumeGroupBackupDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("destinationRegion")
+        private String destinationRegion;
+
+        public Builder destinationRegion(String destinationRegion) {
+            this.destinationRegion = destinationRegion;
+            this.__explicitlySet__.add("destinationRegion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+        private String kmsKeyId;
+
+        public Builder kmsKeyId(String kmsKeyId) {
+            this.kmsKeyId = kmsKeyId;
+            this.__explicitlySet__.add("kmsKeyId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CopyVolumeGroupBackupDetails build() {
+            CopyVolumeGroupBackupDetails __instance__ =
+                    new CopyVolumeGroupBackupDetails(destinationRegion, displayName, kmsKeyId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CopyVolumeGroupBackupDetails o) {
+            Builder copiedBuilder =
+                    destinationRegion(o.getDestinationRegion())
+                            .displayName(o.getDisplayName())
+                            .kmsKeyId(o.getKmsKeyId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The name of the destination region.
+     * <p>
+     * Example: {@code us-ashburn-1}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("destinationRegion")
+    String destinationRegion;
+
+    /**
+     * A user-friendly name for the volume group backup. Does not have to be unique and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The OCID of the Key Management key in the destination region which will be the master encryption key
+     * for the copied volume group backup.
+     * If you do not specify this attribute the volume group backup will be encrypted with the Oracle-provided encryption
+     * key when it is copied to the destination region.
+     * <p>
+     *
+     * For more information about the Key Management service and encryption keys, see
+     * [Overview of Key Management](https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm) and
+     * [Using Keys](https://docs.cloud.oracle.com/Content/KeyManagement/Tasks/usingkeys.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+    String kmsKeyId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationInstanceSourceViaImageDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceConfigurationInstanceSourceViaImageDetails.java
@@ -89,7 +89,7 @@ public class InstanceConfigurationInstanceSourceViaImageDetails
 
     /**
      * The size of the boot volume in GBs. The minimum value is 50 GB and the maximum
-     * value is 16384 GB (16TB).
+     * value is 32,768 GB (32 TB).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeSizeInGBs")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSourceViaImageDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/InstanceSourceViaImageDetails.java
@@ -98,7 +98,7 @@ public class InstanceSourceViaImageDetails extends InstanceSourceDetails {
     }
 
     /**
-     * The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 16384 GB (16TB).
+     * The size of the boot volume in GBs. Minimum value is 50 GB and maximum value is 32,768 GB (32 TB).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("bootVolumeSizeInGBs")

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/CopyVolumeGroupBackupRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/CopyVolumeGroupBackupRequest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/core/CopyVolumeGroupBackupExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CopyVolumeGroupBackupRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CopyVolumeGroupBackupRequest
+        extends com.oracle.bmc.requests.BmcRequest<CopyVolumeGroupBackupDetails> {
+
+    /**
+     * The Oracle Cloud ID (OCID) that uniquely identifies the volume group backup.
+     *
+     */
+    private String volumeGroupBackupId;
+
+    /**
+     * Request to create a cross-region copy of given volume group backup.
+     */
+    private CopyVolumeGroupBackupDetails copyVolumeGroupBackupDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     * If you need to contact Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public CopyVolumeGroupBackupDetails getBody$() {
+        return copyVolumeGroupBackupDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CopyVolumeGroupBackupRequest, CopyVolumeGroupBackupDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CopyVolumeGroupBackupRequest o) {
+            volumeGroupBackupId(o.getVolumeGroupBackupId());
+            copyVolumeGroupBackupDetails(o.getCopyVolumeGroupBackupDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CopyVolumeGroupBackupRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CopyVolumeGroupBackupRequest
+         */
+        public CopyVolumeGroupBackupRequest build() {
+            CopyVolumeGroupBackupRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(CopyVolumeGroupBackupDetails body) {
+            copyVolumeGroupBackupDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/CopyBootVolumeBackupResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/CopyBootVolumeBackupResponse.java
@@ -31,6 +31,25 @@ public class CopyBootVolumeBackupResponse {
     private String opcRequestId;
 
     /**
+     * The OCID of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Location of the resource.
+     *
+     */
+    private String location;
+
+    /**
+     * Location of the resource.
+     *
+     */
+    private String contentLocation;
+
+    /**
      * The returned BootVolumeBackup instance.
      */
     private BootVolumeBackup bootVolumeBackup;
@@ -44,6 +63,9 @@ public class CopyBootVolumeBackupResponse {
             __httpStatusCode__(o.get__httpStatusCode__());
             etag(o.getEtag());
             opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            location(o.getLocation());
+            contentLocation(o.getContentLocation());
             bootVolumeBackup(o.getBootVolumeBackup());
 
             return this;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/CopyVolumeBackupResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/CopyVolumeBackupResponse.java
@@ -31,6 +31,25 @@ public class CopyVolumeBackupResponse {
     private String opcRequestId;
 
     /**
+     * The OCID of the work request. Use [GetWorkRequest](https://docs.cloud.oracle.com/api/#/en/workrequests/20160918/WorkRequest/GetWorkRequest)
+     * with this ID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Location of the resource.
+     *
+     */
+    private String location;
+
+    /**
+     * Location of the resource.
+     *
+     */
+    private String contentLocation;
+
+    /**
      * The returned VolumeBackup instance.
      */
     private VolumeBackup volumeBackup;
@@ -44,6 +63,9 @@ public class CopyVolumeBackupResponse {
             __httpStatusCode__(o.get__httpStatusCode__());
             etag(o.getEtag());
             opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            location(o.getLocation());
+            contentLocation(o.getContentLocation());
             volumeBackup(o.getVolumeBackup());
 
             return this;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/CopyVolumeGroupBackupResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/CopyVolumeGroupBackupResponse.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class CopyVolumeGroupBackupResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VolumeGroupBackup instance.
+     */
+    private VolumeGroupBackup volumeGroupBackup;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CopyVolumeGroupBackupResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            volumeGroupBackup(o.getVolumeGroupBackup());
+
+            return this;
+        }
+    }
+}

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -679,6 +679,16 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+        private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
+
+        public Builder autonomousMaintenanceScheduleType(
+                AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType) {
+            this.autonomousMaintenanceScheduleType = autonomousMaintenanceScheduleType;
+            this.__explicitlySet__.add("autonomousMaintenanceScheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -756,7 +766,8 @@ public class AutonomousDatabase {
                             timeLocalDataGuardEnabled,
                             dataguardRegionType,
                             timeDataGuardRoleChanged,
-                            peerDbIds);
+                            peerDbIds,
+                            autonomousMaintenanceScheduleType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -837,7 +848,9 @@ public class AutonomousDatabase {
                             .timeLocalDataGuardEnabled(o.getTimeLocalDataGuardEnabled())
                             .dataguardRegionType(o.getDataguardRegionType())
                             .timeDataGuardRoleChanged(o.getTimeDataGuardRoleChanged())
-                            .peerDbIds(o.getPeerDbIds());
+                            .peerDbIds(o.getPeerDbIds())
+                            .autonomousMaintenanceScheduleType(
+                                    o.getAutonomousMaintenanceScheduleType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -1930,6 +1943,61 @@ public class AutonomousDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("peerDbIds")
     java.util.List<String> peerDbIds;
+    /**
+     * The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+     * follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum AutonomousMaintenanceScheduleType {
+        Early("EARLY"),
+        Regular("REGULAR"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, AutonomousMaintenanceScheduleType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AutonomousMaintenanceScheduleType v : AutonomousMaintenanceScheduleType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        AutonomousMaintenanceScheduleType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AutonomousMaintenanceScheduleType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'AutonomousMaintenanceScheduleType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+     * follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+    AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -681,6 +681,16 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+        private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
+
+        public Builder autonomousMaintenanceScheduleType(
+                AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType) {
+            this.autonomousMaintenanceScheduleType = autonomousMaintenanceScheduleType;
+            this.__explicitlySet__.add("autonomousMaintenanceScheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -758,7 +768,8 @@ public class AutonomousDatabaseSummary {
                             timeLocalDataGuardEnabled,
                             dataguardRegionType,
                             timeDataGuardRoleChanged,
-                            peerDbIds);
+                            peerDbIds,
+                            autonomousMaintenanceScheduleType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -839,7 +850,9 @@ public class AutonomousDatabaseSummary {
                             .timeLocalDataGuardEnabled(o.getTimeLocalDataGuardEnabled())
                             .dataguardRegionType(o.getDataguardRegionType())
                             .timeDataGuardRoleChanged(o.getTimeDataGuardRoleChanged())
-                            .peerDbIds(o.getPeerDbIds());
+                            .peerDbIds(o.getPeerDbIds())
+                            .autonomousMaintenanceScheduleType(
+                                    o.getAutonomousMaintenanceScheduleType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -1932,6 +1945,61 @@ public class AutonomousDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("peerDbIds")
     java.util.List<String> peerDbIds;
+    /**
+     * The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+     * follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum AutonomousMaintenanceScheduleType {
+        Early("EARLY"),
+        Regular("REGULAR"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, AutonomousMaintenanceScheduleType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AutonomousMaintenanceScheduleType v : AutonomousMaintenanceScheduleType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        AutonomousMaintenanceScheduleType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AutonomousMaintenanceScheduleType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'AutonomousMaintenanceScheduleType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+     * follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+    AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
@@ -400,6 +400,50 @@ public class CreateAutonomousDatabaseBase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("customerContacts")
     java.util.List<CustomerContact> customerContacts;
+    /**
+     * The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+     * follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+     *
+     **/
+    public enum AutonomousMaintenanceScheduleType {
+        Early("EARLY"),
+        Regular("REGULAR"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, AutonomousMaintenanceScheduleType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (AutonomousMaintenanceScheduleType v : AutonomousMaintenanceScheduleType.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        AutonomousMaintenanceScheduleType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static AutonomousMaintenanceScheduleType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid AutonomousMaintenanceScheduleType: " + key);
+        }
+    };
+    /**
+     * The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
+     * follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+    AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
 
     /**
      * The source of the database: Use {@code NONE} for creating a new Autonomous Database. Use {@code DATABASE} for creating a new Autonomous Database by cloning an existing Autonomous Database.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
@@ -297,6 +297,16 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+        private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
+
+        public Builder autonomousMaintenanceScheduleType(
+                AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType) {
+            this.autonomousMaintenanceScheduleType = autonomousMaintenanceScheduleType;
+            this.__explicitlySet__.add("autonomousMaintenanceScheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
         private String sourceId;
 
@@ -350,6 +360,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             definedTags,
                             dbVersion,
                             customerContacts,
+                            autonomousMaintenanceScheduleType,
                             sourceId,
                             cloneType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -389,6 +400,8 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
                             .customerContacts(o.getCustomerContacts())
+                            .autonomousMaintenanceScheduleType(
+                                    o.getAutonomousMaintenanceScheduleType())
                             .sourceId(o.getSourceId())
                             .cloneType(o.getCloneType());
 
@@ -435,6 +448,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
             java.util.List<CustomerContact> customerContacts,
+            AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             String sourceId,
             CloneType cloneType) {
         super(
@@ -466,7 +480,8 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                 freeformTags,
                 definedTags,
                 dbVersion,
-                customerContacts);
+                customerContacts,
+                autonomousMaintenanceScheduleType);
         this.sourceId = sourceId;
         this.cloneType = cloneType;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
@@ -297,6 +297,16 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+        private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
+
+        public Builder autonomousMaintenanceScheduleType(
+                AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType) {
+            this.autonomousMaintenanceScheduleType = autonomousMaintenanceScheduleType;
+            this.__explicitlySet__.add("autonomousMaintenanceScheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -331,7 +341,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             freeformTags,
                             definedTags,
                             dbVersion,
-                            customerContacts);
+                            customerContacts,
+                            autonomousMaintenanceScheduleType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -368,7 +379,9 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
-                            .customerContacts(o.getCustomerContacts());
+                            .customerContacts(o.getCustomerContacts())
+                            .autonomousMaintenanceScheduleType(
+                                    o.getAutonomousMaintenanceScheduleType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -412,7 +425,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             java.util.Map<String, String> freeformTags,
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
-            java.util.List<CustomerContact> customerContacts) {
+            java.util.List<CustomerContact> customerContacts,
+            AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType) {
         super(
                 compartmentId,
                 dbName,
@@ -442,7 +456,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                 freeformTags,
                 definedTags,
                 dbVersion,
-                customerContacts);
+                customerContacts,
+                autonomousMaintenanceScheduleType);
     }
 
     @com.fasterxml.jackson.annotation.JsonIgnore

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
@@ -297,6 +297,16 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+        private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
+
+        public Builder autonomousMaintenanceScheduleType(
+                AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType) {
+            this.autonomousMaintenanceScheduleType = autonomousMaintenanceScheduleType;
+            this.__explicitlySet__.add("autonomousMaintenanceScheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("autonomousDatabaseBackupId")
         private String autonomousDatabaseBackupId;
 
@@ -350,6 +360,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             definedTags,
                             dbVersion,
                             customerContacts,
+                            autonomousMaintenanceScheduleType,
                             autonomousDatabaseBackupId,
                             cloneType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -389,6 +400,8 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
                             .customerContacts(o.getCustomerContacts())
+                            .autonomousMaintenanceScheduleType(
+                                    o.getAutonomousMaintenanceScheduleType())
                             .autonomousDatabaseBackupId(o.getAutonomousDatabaseBackupId())
                             .cloneType(o.getCloneType());
 
@@ -435,6 +448,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
             java.util.List<CustomerContact> customerContacts,
+            AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             String autonomousDatabaseBackupId,
             CloneType cloneType) {
         super(
@@ -466,7 +480,8 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                 freeformTags,
                 definedTags,
                 dbVersion,
-                customerContacts);
+                customerContacts,
+                autonomousMaintenanceScheduleType);
         this.autonomousDatabaseBackupId = autonomousDatabaseBackupId;
         this.cloneType = cloneType;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
@@ -298,6 +298,16 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+        private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
+
+        public Builder autonomousMaintenanceScheduleType(
+                AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType) {
+            this.autonomousMaintenanceScheduleType = autonomousMaintenanceScheduleType;
+            this.__explicitlySet__.add("autonomousMaintenanceScheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("autonomousDatabaseId")
         private String autonomousDatabaseId;
 
@@ -360,6 +370,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             definedTags,
                             dbVersion,
                             customerContacts,
+                            autonomousMaintenanceScheduleType,
                             autonomousDatabaseId,
                             timestamp,
                             cloneType);
@@ -400,6 +411,8 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
                             .customerContacts(o.getCustomerContacts())
+                            .autonomousMaintenanceScheduleType(
+                                    o.getAutonomousMaintenanceScheduleType())
                             .autonomousDatabaseId(o.getAutonomousDatabaseId())
                             .timestamp(o.getTimestamp())
                             .cloneType(o.getCloneType());
@@ -447,6 +460,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
             java.util.List<CustomerContact> customerContacts,
+            AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             String autonomousDatabaseId,
             java.util.Date timestamp,
             CloneType cloneType) {
@@ -479,7 +493,8 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                 freeformTags,
                 definedTags,
                 dbVersion,
-                customerContacts);
+                customerContacts,
+                autonomousMaintenanceScheduleType);
         this.autonomousDatabaseId = autonomousDatabaseId;
         this.timestamp = timestamp;
         this.cloneType = cloneType;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCrossRegionAutonomousDatabaseDataGuardDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCrossRegionAutonomousDatabaseDataGuardDetails.java
@@ -298,6 +298,16 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+        private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
+
+        public Builder autonomousMaintenanceScheduleType(
+                AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType) {
+            this.autonomousMaintenanceScheduleType = autonomousMaintenanceScheduleType;
+            this.__explicitlySet__.add("autonomousMaintenanceScheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
         private String sourceId;
 
@@ -342,6 +352,7 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
                             definedTags,
                             dbVersion,
                             customerContacts,
+                            autonomousMaintenanceScheduleType,
                             sourceId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -380,6 +391,8 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
                             .customerContacts(o.getCustomerContacts())
+                            .autonomousMaintenanceScheduleType(
+                                    o.getAutonomousMaintenanceScheduleType())
                             .sourceId(o.getSourceId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -425,6 +438,7 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
             java.util.List<CustomerContact> customerContacts,
+            AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             String sourceId) {
         super(
                 compartmentId,
@@ -455,7 +469,8 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
                 freeformTags,
                 definedTags,
                 dbVersion,
-                customerContacts);
+                customerContacts,
+                autonomousMaintenanceScheduleType);
         this.sourceId = sourceId;
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
@@ -297,6 +297,16 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
+        private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
+
+        public Builder autonomousMaintenanceScheduleType(
+                AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType) {
+            this.autonomousMaintenanceScheduleType = autonomousMaintenanceScheduleType;
+            this.__explicitlySet__.add("autonomousMaintenanceScheduleType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
         private String sourceId;
 
@@ -350,6 +360,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             definedTags,
                             dbVersion,
                             customerContacts,
+                            autonomousMaintenanceScheduleType,
                             sourceId,
                             refreshableMode);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -389,6 +400,8 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             .definedTags(o.getDefinedTags())
                             .dbVersion(o.getDbVersion())
                             .customerContacts(o.getCustomerContacts())
+                            .autonomousMaintenanceScheduleType(
+                                    o.getAutonomousMaintenanceScheduleType())
                             .sourceId(o.getSourceId())
                             .refreshableMode(o.getRefreshableMode());
 
@@ -435,6 +448,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             java.util.Map<String, java.util.Map<String, Object>> definedTags,
             String dbVersion,
             java.util.List<CustomerContact> customerContacts,
+            AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             String sourceId,
             RefreshableMode refreshableMode) {
         super(
@@ -466,7 +480,8 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                 freeformTags,
                 definedTags,
                 dbVersion,
-                customerContacts);
+                customerContacts,
+                autonomousMaintenanceScheduleType);
         this.sourceId = sourceId;
         this.refreshableMode = refreshableMode;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNode.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNode.java
@@ -60,6 +60,42 @@ public class DbNode {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("hostIpId")
+        private String hostIpId;
+
+        public Builder hostIpId(String hostIpId) {
+            this.hostIpId = hostIpId;
+            this.__explicitlySet__.add("hostIpId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupIpId")
+        private String backupIpId;
+
+        public Builder backupIpId(String backupIpId) {
+            this.backupIpId = backupIpId;
+            this.__explicitlySet__.add("backupIpId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vnic2Id")
+        private String vnic2Id;
+
+        public Builder vnic2Id(String vnic2Id) {
+            this.vnic2Id = vnic2Id;
+            this.__explicitlySet__.add("vnic2Id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupVnic2Id")
+        private String backupVnic2Id;
+
+        public Builder backupVnic2Id(String backupVnic2Id) {
+            this.backupVnic2Id = backupVnic2Id;
+            this.__explicitlySet__.add("backupVnic2Id");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleState lifecycleState;
 
@@ -151,6 +187,10 @@ public class DbNode {
                             dbSystemId,
                             vnicId,
                             backupVnicId,
+                            hostIpId,
+                            backupIpId,
+                            vnic2Id,
+                            backupVnic2Id,
                             lifecycleState,
                             hostname,
                             faultDomain,
@@ -171,6 +211,10 @@ public class DbNode {
                             .dbSystemId(o.getDbSystemId())
                             .vnicId(o.getVnicId())
                             .backupVnicId(o.getBackupVnicId())
+                            .hostIpId(o.getHostIpId())
+                            .backupIpId(o.getBackupIpId())
+                            .vnic2Id(o.getVnic2Id())
+                            .backupVnic2Id(o.getBackupVnic2Id())
                             .lifecycleState(o.getLifecycleState())
                             .hostname(o.getHostname())
                             .faultDomain(o.getFaultDomain())
@@ -216,6 +260,42 @@ public class DbNode {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("backupVnicId")
     String backupVnicId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the host IP address associated with the database node.
+     * <p>
+     **Note:** Applies only to Exadata Cloud Service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostIpId")
+    String hostIpId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup IP address associated with the database node.
+     * <p>
+     **Note:** Applies only to Exadata Cloud Service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("backupIpId")
+    String backupIpId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the second VNIC.
+     * <p>
+     **Note:** Applies only to Exadata Cloud Service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vnic2Id")
+    String vnic2Id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the second backup VNIC.
+     * <p>
+     **Note:** Applies only to Exadata Cloud Service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("backupVnic2Id")
+    String backupVnic2Id;
     /**
      * The current state of the database node.
      **/

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNodeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNodeSummary.java
@@ -65,6 +65,42 @@ public class DbNodeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("hostIpId")
+        private String hostIpId;
+
+        public Builder hostIpId(String hostIpId) {
+            this.hostIpId = hostIpId;
+            this.__explicitlySet__.add("hostIpId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupIpId")
+        private String backupIpId;
+
+        public Builder backupIpId(String backupIpId) {
+            this.backupIpId = backupIpId;
+            this.__explicitlySet__.add("backupIpId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vnic2Id")
+        private String vnic2Id;
+
+        public Builder vnic2Id(String vnic2Id) {
+            this.vnic2Id = vnic2Id;
+            this.__explicitlySet__.add("vnic2Id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("backupVnic2Id")
+        private String backupVnic2Id;
+
+        public Builder backupVnic2Id(String backupVnic2Id) {
+            this.backupVnic2Id = backupVnic2Id;
+            this.__explicitlySet__.add("backupVnic2Id");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleState lifecycleState;
 
@@ -156,6 +192,10 @@ public class DbNodeSummary {
                             dbSystemId,
                             vnicId,
                             backupVnicId,
+                            hostIpId,
+                            backupIpId,
+                            vnic2Id,
+                            backupVnic2Id,
                             lifecycleState,
                             hostname,
                             faultDomain,
@@ -176,6 +216,10 @@ public class DbNodeSummary {
                             .dbSystemId(o.getDbSystemId())
                             .vnicId(o.getVnicId())
                             .backupVnicId(o.getBackupVnicId())
+                            .hostIpId(o.getHostIpId())
+                            .backupIpId(o.getBackupIpId())
+                            .vnic2Id(o.getVnic2Id())
+                            .backupVnic2Id(o.getBackupVnic2Id())
                             .lifecycleState(o.getLifecycleState())
                             .hostname(o.getHostname())
                             .faultDomain(o.getFaultDomain())
@@ -221,6 +265,42 @@ public class DbNodeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("backupVnicId")
     String backupVnicId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the host IP address associated with the database node.
+     * <p>
+     **Note:** Applies only to Exadata Cloud Service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostIpId")
+    String hostIpId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the backup IP address associated with the database node.
+     * <p>
+     **Note:** Applies only to Exadata Cloud Service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("backupIpId")
+    String backupIpId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the second VNIC.
+     * <p>
+     **Note:** Applies only to Exadata Cloud Service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vnic2Id")
+    String vnic2Id;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the second backup VNIC.
+     * <p>
+     **Note:** Applies only to Exadata Cloud Service.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("backupVnic2Id")
+    String backupVnic2Id;
     /**
      * The current state of the database node.
      **/

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/Application.java
+++ b/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/Application.java
@@ -179,6 +179,15 @@ public class Application {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+        private String metastoreId;
+
+        public Builder metastoreId(String metastoreId) {
+            this.metastoreId = metastoreId;
+            this.__explicitlySet__.add("metastoreId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("numExecutors")
         private Integer numExecutors;
 
@@ -283,6 +292,7 @@ public class Application {
                             language,
                             lifecycleState,
                             logsBucketUri,
+                            metastoreId,
                             numExecutors,
                             ownerPrincipalId,
                             ownerUserName,
@@ -316,6 +326,7 @@ public class Application {
                             .language(o.getLanguage())
                             .lifecycleState(o.getLifecycleState())
                             .logsBucketUri(o.getLogsBucketUri())
+                            .metastoreId(o.getMetastoreId())
                             .numExecutors(o.getNumExecutors())
                             .ownerPrincipalId(o.getOwnerPrincipalId())
                             .ownerUserName(o.getOwnerUserName())
@@ -477,6 +488,13 @@ public class Application {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logsBucketUri")
     String logsBucketUri;
+
+    /**
+     * The OCID of OCI Hive Metastore.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+    String metastoreId;
 
     /**
      * The number of executor VMs requested.

--- a/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/CreateApplicationDetails.java
+++ b/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/CreateApplicationDetails.java
@@ -163,6 +163,15 @@ public class CreateApplicationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+        private String metastoreId;
+
+        public Builder metastoreId(String metastoreId) {
+            this.metastoreId = metastoreId;
+            this.__explicitlySet__.add("metastoreId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("numExecutors")
         private Integer numExecutors;
 
@@ -229,6 +238,7 @@ public class CreateApplicationDetails {
                             freeformTags,
                             language,
                             logsBucketUri,
+                            metastoreId,
                             numExecutors,
                             parameters,
                             privateEndpointId,
@@ -256,6 +266,7 @@ public class CreateApplicationDetails {
                             .freeformTags(o.getFreeformTags())
                             .language(o.getLanguage())
                             .logsBucketUri(o.getLogsBucketUri())
+                            .metastoreId(o.getMetastoreId())
                             .numExecutors(o.getNumExecutors())
                             .parameters(o.getParameters())
                             .privateEndpointId(o.getPrivateEndpointId())
@@ -399,6 +410,13 @@ public class CreateApplicationDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logsBucketUri")
     String logsBucketUri;
+
+    /**
+     * The OCID of OCI Hive Metastore.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+    String metastoreId;
 
     /**
      * The number of executor VMs requested.

--- a/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/CreateRunDetails.java
+++ b/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/CreateRunDetails.java
@@ -18,6 +18,7 @@ package com.oracle.bmc.dataflow.model;
  *   - executorShape
  *   - freeformTags
  *   - logsBucketUri
+ *   - metastoreId
  *   - numExecutors
  *   - parameters
  *   - sparkVersion
@@ -165,6 +166,15 @@ public class CreateRunDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+        private String metastoreId;
+
+        public Builder metastoreId(String metastoreId) {
+            this.metastoreId = metastoreId;
+            this.__explicitlySet__.add("metastoreId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("numExecutors")
         private Integer numExecutors;
 
@@ -219,6 +229,7 @@ public class CreateRunDetails {
                             executorShape,
                             freeformTags,
                             logsBucketUri,
+                            metastoreId,
                             numExecutors,
                             parameters,
                             sparkVersion,
@@ -242,6 +253,7 @@ public class CreateRunDetails {
                             .executorShape(o.getExecutorShape())
                             .freeformTags(o.getFreeformTags())
                             .logsBucketUri(o.getLogsBucketUri())
+                            .metastoreId(o.getMetastoreId())
                             .numExecutors(o.getNumExecutors())
                             .parameters(o.getParameters())
                             .sparkVersion(o.getSparkVersion())
@@ -362,6 +374,13 @@ public class CreateRunDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logsBucketUri")
     String logsBucketUri;
+
+    /**
+     * The OCID of OCI Hive Metastore.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+    String metastoreId;
 
     /**
      * The number of executor VMs requested.

--- a/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/Run.java
+++ b/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/Run.java
@@ -206,6 +206,15 @@ public class Run {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+        private String metastoreId;
+
+        public Builder metastoreId(String metastoreId) {
+            this.metastoreId = metastoreId;
+            this.__explicitlySet__.add("metastoreId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("numExecutors")
         private Integer numExecutors;
 
@@ -376,6 +385,7 @@ public class Run {
                             lifecycleDetails,
                             lifecycleState,
                             logsBucketUri,
+                            metastoreId,
                             numExecutors,
                             opcRequestId,
                             ownerPrincipalId,
@@ -419,6 +429,7 @@ public class Run {
                             .lifecycleDetails(o.getLifecycleDetails())
                             .lifecycleState(o.getLifecycleState())
                             .logsBucketUri(o.getLogsBucketUri())
+                            .metastoreId(o.getMetastoreId())
                             .numExecutors(o.getNumExecutors())
                             .opcRequestId(o.getOpcRequestId())
                             .ownerPrincipalId(o.getOwnerPrincipalId())
@@ -608,6 +619,13 @@ public class Run {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logsBucketUri")
     String logsBucketUri;
+
+    /**
+     * The OCID of OCI Hive Metastore.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+    String metastoreId;
 
     /**
      * The number of executor VMs requested.

--- a/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/UpdateApplicationDetails.java
+++ b/bmc-dataflow/src/main/java/com/oracle/bmc/dataflow/model/UpdateApplicationDetails.java
@@ -163,6 +163,15 @@ public class UpdateApplicationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+        private String metastoreId;
+
+        public Builder metastoreId(String metastoreId) {
+            this.metastoreId = metastoreId;
+            this.__explicitlySet__.add("metastoreId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("numExecutors")
         private Integer numExecutors;
 
@@ -220,6 +229,7 @@ public class UpdateApplicationDetails {
                             executorShape,
                             freeformTags,
                             logsBucketUri,
+                            metastoreId,
                             numExecutors,
                             parameters,
                             privateEndpointId,
@@ -246,6 +256,7 @@ public class UpdateApplicationDetails {
                             .executorShape(o.getExecutorShape())
                             .freeformTags(o.getFreeformTags())
                             .logsBucketUri(o.getLogsBucketUri())
+                            .metastoreId(o.getMetastoreId())
                             .numExecutors(o.getNumExecutors())
                             .parameters(o.getParameters())
                             .privateEndpointId(o.getPrivateEndpointId())
@@ -388,6 +399,13 @@ public class UpdateApplicationDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("logsBucketUri")
     String logsBucketUri;
+
+    /**
+     * The OCID of OCI Hive Metastore.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("metastoreId")
+    String metastoreId;
 
     /**
      * The number of executor VMs requested.

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScience.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScience.java
@@ -472,10 +472,10 @@ public interface DataScience extends AutoCloseable {
     UpdateModelResponse updateModel(UpdateModelRequest request);
 
     /**
-     * Updates the properties of a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
-     * the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
-     * `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
-     * Changes will take effect the next time the model deployment is activated.
+     * Updates the properties of a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time
+     * when the model deployment\u2019s lifecycle state is ACTIVE or NEEDS_ATTENTION i.e `instanceShapeName`, `instanceCount` and `modelId`, separately `loadBalancerShape` or `CategoryLogDetails`
+     * can also be updated independently. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state. Changes will take effect the next time the model
+     * deployment is activated.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceAsync.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/DataScienceAsync.java
@@ -657,10 +657,10 @@ public interface DataScienceAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<UpdateModelRequest, UpdateModelResponse> handler);
 
     /**
-     * Updates the properties of a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time when
-     * the model deployment's lifecycle state is ACTIVE i.e `instanceShapeName` can be updated along with `modelId`, similarly `logId` can be updated along with `logGroupId`. But
-     * `instanceShapeName` or `modelId` cannot be updated along with `logId` or `logGroupId`. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
-     * Changes will take effect the next time the model deployment is activated.
+     * Updates the properties of a model deployment. Some of the properties of `modelDeploymentConfigurationDetails` or `CategoryLogDetails` can also be updated with zero down time
+     * when the model deployment\u2019s lifecycle state is ACTIVE or NEEDS_ATTENTION i.e `instanceShapeName`, `instanceCount` and `modelId`, separately `loadBalancerShape` or `CategoryLogDetails`
+     * can also be updated independently. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state. Changes will take effect the next time the model
+     * deployment is activated.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateModelDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateModelDetails.java
@@ -81,6 +81,42 @@ public class CreateModelDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customMetadataList")
+        private java.util.List<Metadata> customMetadataList;
+
+        public Builder customMetadataList(java.util.List<Metadata> customMetadataList) {
+            this.customMetadataList = customMetadataList;
+            this.__explicitlySet__.add("customMetadataList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedMetadataList")
+        private java.util.List<Metadata> definedMetadataList;
+
+        public Builder definedMetadataList(java.util.List<Metadata> definedMetadataList) {
+            this.definedMetadataList = definedMetadataList;
+            this.__explicitlySet__.add("definedMetadataList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputSchema")
+        private String inputSchema;
+
+        public Builder inputSchema(String inputSchema) {
+            this.inputSchema = inputSchema;
+            this.__explicitlySet__.add("inputSchema");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputSchema")
+        private String outputSchema;
+
+        public Builder outputSchema(String outputSchema) {
+            this.outputSchema = outputSchema;
+            this.__explicitlySet__.add("outputSchema");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -92,7 +128,11 @@ public class CreateModelDetails {
                             displayName,
                             description,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            customMetadataList,
+                            definedMetadataList,
+                            inputSchema,
+                            outputSchema);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -105,7 +145,11 @@ public class CreateModelDetails {
                             .displayName(o.getDisplayName())
                             .description(o.getDescription())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .customMetadataList(o.getCustomMetadataList())
+                            .definedMetadataList(o.getDefinedMetadataList())
+                            .inputSchema(o.getInputSchema())
+                            .outputSchema(o.getOutputSchema());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -160,6 +204,30 @@ public class CreateModelDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * An array of custom metadata details for the model.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customMetadataList")
+    java.util.List<Metadata> customMetadataList;
+
+    /**
+     * An array of defined metadata details for the model.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedMetadataList")
+    java.util.List<Metadata> definedMetadataList;
+
+    /**
+     * Input schema file content in String format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("inputSchema")
+    String inputSchema;
+
+    /**
+     * Output schema file content in String format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("outputSchema")
+    String outputSchema;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateModelProvenanceDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateModelProvenanceDetails.java
@@ -71,13 +71,27 @@ public class CreateModelProvenanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("trainingId")
+        private String trainingId;
+
+        public Builder trainingId(String trainingId) {
+            this.trainingId = trainingId;
+            this.__explicitlySet__.add("trainingId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateModelProvenanceDetails build() {
             CreateModelProvenanceDetails __instance__ =
                     new CreateModelProvenanceDetails(
-                            repositoryUrl, gitBranch, gitCommit, scriptDir, trainingScript);
+                            repositoryUrl,
+                            gitBranch,
+                            gitCommit,
+                            scriptDir,
+                            trainingScript,
+                            trainingId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -89,7 +103,8 @@ public class CreateModelProvenanceDetails {
                             .gitBranch(o.getGitBranch())
                             .gitCommit(o.getGitCommit())
                             .scriptDir(o.getScriptDir())
-                            .trainingScript(o.getTrainingScript());
+                            .trainingScript(o.getTrainingScript())
+                            .trainingId(o.getTrainingId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -133,6 +148,12 @@ public class CreateModelProvenanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("trainingScript")
     String trainingScript;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("trainingId")
+    String trainingId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/Metadata.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/Metadata.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * Defines properties of each model metadata.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Metadata.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class Metadata {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("key")
+        private String key;
+
+        public Builder key(String key) {
+            this.key = key;
+            this.__explicitlySet__.add("key");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            this.__explicitlySet__.add("value");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("category")
+        private String category;
+
+        public Builder category(String category) {
+            this.category = category;
+            this.__explicitlySet__.add("category");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public Metadata build() {
+            Metadata __instance__ = new Metadata(key, value, description, category);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(Metadata o) {
+            Builder copiedBuilder =
+                    key(o.getKey())
+                            .value(o.getValue())
+                            .description(o.getDescription())
+                            .category(o.getCategory());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Key of the model Metadata. The key can either be user defined or OCI defined.
+     *    List of OCI defined keys:
+     *          * useCaseType
+     *          * libraryName
+     *          * libraryVersion
+     *          * estimatorClass
+     *          * hyperParameters
+     *          * testartifactresults
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    String key;
+
+    /**
+     * Allowed values for useCaseType:
+     *              binary_classification, regression, multinomial_classification, clustering, recommender,
+     *              dimensionality_reduction/representation, time_series_forecasting, anomaly_detection,
+     *              topic_modeling, ner, sentiment_analysis, image_classification, object_localization, other
+     * <p>
+     * Allowed values for libraryName:
+     *              scikit-learn, xgboost, tensorflow, pytorch, mxnet, keras, lightGBM, pymc3, pyOD, spacy,
+     *              prophet, sktime, statsmodels, cuml, oracle_automl, h2o, transformers, nltk, emcee, pystan,
+     *              bert, gensim, flair, word2vec, ensemble, other
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    String value;
+
+    /**
+     * Description of model metadata
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * Category of model metadata which should be null for defined metadata.For custom metadata is should be one of the following values "Performance,Training Profile,Training and Validation Datasets,Training Environment,other".
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("category")
+    String category;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/Model.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/Model.java
@@ -115,6 +115,42 @@ public class Model {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customMetadataList")
+        private java.util.List<Metadata> customMetadataList;
+
+        public Builder customMetadataList(java.util.List<Metadata> customMetadataList) {
+            this.customMetadataList = customMetadataList;
+            this.__explicitlySet__.add("customMetadataList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedMetadataList")
+        private java.util.List<Metadata> definedMetadataList;
+
+        public Builder definedMetadataList(java.util.List<Metadata> definedMetadataList) {
+            this.definedMetadataList = definedMetadataList;
+            this.__explicitlySet__.add("definedMetadataList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("inputSchema")
+        private String inputSchema;
+
+        public Builder inputSchema(String inputSchema) {
+            this.inputSchema = inputSchema;
+            this.__explicitlySet__.add("inputSchema");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("outputSchema")
+        private String outputSchema;
+
+        public Builder outputSchema(String outputSchema) {
+            this.outputSchema = outputSchema;
+            this.__explicitlySet__.add("outputSchema");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -130,7 +166,11 @@ public class Model {
                             timeCreated,
                             createdBy,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            customMetadataList,
+                            definedMetadataList,
+                            inputSchema,
+                            outputSchema);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -147,7 +187,11 @@ public class Model {
                             .timeCreated(o.getTimeCreated())
                             .createdBy(o.getCreatedBy())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .customMetadataList(o.getCustomMetadataList())
+                            .definedMetadataList(o.getDefinedMetadataList())
+                            .inputSchema(o.getInputSchema())
+                            .outputSchema(o.getOutputSchema());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -226,6 +270,30 @@ public class Model {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * An array of custom metadata details for the model.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customMetadataList")
+    java.util.List<Metadata> customMetadataList;
+
+    /**
+     * An array of defined metadata details for the model.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedMetadataList")
+    java.util.List<Metadata> definedMetadataList;
+
+    /**
+     * Input schema file content in String format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("inputSchema")
+    String inputSchema;
+
+    /**
+     * Output schema file content in String format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("outputSchema")
+    String outputSchema;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeployment.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelDeployment.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datascience.model;
 
 /**
- * Model deployments are interactive coding environments for data scientists.
+ * Model deployments are used by data scientists to perform predictions from the model hosted on an HTTP server.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelProvenance.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ModelProvenance.java
@@ -69,13 +69,27 @@ public class ModelProvenance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("trainingId")
+        private String trainingId;
+
+        public Builder trainingId(String trainingId) {
+            this.trainingId = trainingId;
+            this.__explicitlySet__.add("trainingId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ModelProvenance build() {
             ModelProvenance __instance__ =
                     new ModelProvenance(
-                            repositoryUrl, gitBranch, gitCommit, scriptDir, trainingScript);
+                            repositoryUrl,
+                            gitBranch,
+                            gitCommit,
+                            scriptDir,
+                            trainingScript,
+                            trainingId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -87,7 +101,8 @@ public class ModelProvenance {
                             .gitBranch(o.getGitBranch())
                             .gitCommit(o.getGitCommit())
                             .scriptDir(o.getScriptDir())
-                            .trainingScript(o.getTrainingScript());
+                            .trainingScript(o.getTrainingScript())
+                            .trainingId(o.getTrainingId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -131,6 +146,12 @@ public class ModelProvenance {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("trainingScript")
     String trainingScript;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("trainingId")
+    String trainingId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelDetails.java
@@ -64,12 +64,36 @@ public class UpdateModelDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customMetadataList")
+        private java.util.List<Metadata> customMetadataList;
+
+        public Builder customMetadataList(java.util.List<Metadata> customMetadataList) {
+            this.customMetadataList = customMetadataList;
+            this.__explicitlySet__.add("customMetadataList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedMetadataList")
+        private java.util.List<Metadata> definedMetadataList;
+
+        public Builder definedMetadataList(java.util.List<Metadata> definedMetadataList) {
+            this.definedMetadataList = definedMetadataList;
+            this.__explicitlySet__.add("definedMetadataList");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateModelDetails build() {
             UpdateModelDetails __instance__ =
-                    new UpdateModelDetails(displayName, description, freeformTags, definedTags);
+                    new UpdateModelDetails(
+                            displayName,
+                            description,
+                            freeformTags,
+                            definedTags,
+                            customMetadataList,
+                            definedMetadataList);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -80,7 +104,9 @@ public class UpdateModelDetails {
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .customMetadataList(o.getCustomMetadataList())
+                            .definedMetadataList(o.getDefinedMetadataList());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -123,6 +149,18 @@ public class UpdateModelDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * An array of custom metadata details for the model.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customMetadataList")
+    java.util.List<Metadata> customMetadataList;
+
+    /**
+     * An array of defined metadata details for the model.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedMetadataList")
+    java.util.List<Metadata> definedMetadataList;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelProvenanceDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/UpdateModelProvenanceDetails.java
@@ -71,13 +71,27 @@ public class UpdateModelProvenanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("trainingId")
+        private String trainingId;
+
+        public Builder trainingId(String trainingId) {
+            this.trainingId = trainingId;
+            this.__explicitlySet__.add("trainingId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateModelProvenanceDetails build() {
             UpdateModelProvenanceDetails __instance__ =
                     new UpdateModelProvenanceDetails(
-                            repositoryUrl, gitBranch, gitCommit, scriptDir, trainingScript);
+                            repositoryUrl,
+                            gitBranch,
+                            gitCommit,
+                            scriptDir,
+                            trainingScript,
+                            trainingId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -89,7 +103,8 @@ public class UpdateModelProvenanceDetails {
                             .gitBranch(o.getGitBranch())
                             .gitCommit(o.getGitCommit())
                             .scriptDir(o.getScriptDir())
-                            .trainingScript(o.getTrainingScript());
+                            .trainingScript(o.getTrainingScript())
+                            .trainingId(o.getTrainingId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -133,6 +148,12 @@ public class UpdateModelProvenanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("trainingScript")
     String trainingScript;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of a training session(Job or NotebookSession) in which the model was trained. It is used for model reproducibility purposes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("trainingId")
+    String trainingId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelArtifactRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/CreateModelArtifactRequest.java
@@ -49,7 +49,14 @@ public class CreateModelArtifactRequest
     private String opcRetryToken;
 
     /**
-     * The content disposition of the body.
+     * This header allows you to specify a filename during upload. This file name is used to dispose of the file contents
+     * while downloading the file. If this optional field is not populated in the request, then the OCID of the model is used for the file
+     * name when downloading.
+     * Example: {@code {"Content-Disposition": "attachment"
+     *            "filename"="model.tar.gz"
+     *            "Content-Length": "2347"
+     *            "Content-Type": "application/gzip"}}
+     *
      */
     private String contentDisposition;
 

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateModelDeploymentRequest.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/requests/UpdateModelDeploymentRequest.java
@@ -26,10 +26,10 @@ public class UpdateModelDeploymentRequest
     private String modelDeploymentId;
 
     /**
-     * Details for updating a model deployment. Some of the properties of {@code modelDeploymentConfigurationDetails} or {@code CategoryLogDetails} can also be updated with zero down time when
-     * the model deployment's lifecycle state is ACTIVE i.e {@code instanceShapeName} can be updated along with {@code modelId}, similarly {@code logId} can be updated along with {@code logGroupId}. But
-     * {@code instanceShapeName} or {@code modelId} cannot be updated along with {@code logId} or {@code logGroupId}. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state.
-     * Changes will take effect the next time the model deployment is activated.
+     * Details for updating a model deployment. Some of the properties of {@code modelDeploymentConfigurationDetails} or {@code CategoryLogDetails} can also be updated with zero down time
+     * when the model deployment\u2019s lifecycle state is ACTIVE or NEEDS_ATTENTION i.e {@code instanceShapeName}, {@code instanceCount} and {@code modelId}, separately {@code loadBalancerShape} or
+     * {@code CategoryLogDetails} can also be updated independently. All of the fields can be updated when the deployment is in the INACTIVE lifecycle state. Changes will take effect the next
+     * time the model deployment is activated.
      *
      */
     private UpdateModelDeploymentDetails updateModelDeploymentDetails;

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackups.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackups.java
@@ -46,6 +46,18 @@ public interface DbBackups extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Moves a DB System Backup into a different compartment.
+     * When provided, If-Match is checked against ETag values of the Backup.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ChangeBackupCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeBackupCompartment API.
+     */
+    ChangeBackupCompartmentResponse changeBackupCompartment(ChangeBackupCompartmentRequest request);
+
+    /**
      * Create a backup of a DB System.
      *
      * @param request The request object containing the details to send

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackupsAsync.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackupsAsync.java
@@ -46,6 +46,24 @@ public interface DbBackupsAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Moves a DB System Backup into a different compartment.
+     * When provided, If-Match is checked against ETag values of the Backup.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeBackupCompartmentResponse> changeBackupCompartment(
+            ChangeBackupCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeBackupCompartmentRequest, ChangeBackupCompartmentResponse>
+                    handler);
+
+    /**
      * Create a backup of a DB System.
      *
      *

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackupsAsyncClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackupsAsyncClient.java
@@ -377,6 +377,53 @@ public class DbBackupsAsyncClient implements DbBackupsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ChangeBackupCompartmentResponse> changeBackupCompartment(
+            ChangeBackupCompartmentRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ChangeBackupCompartmentRequest, ChangeBackupCompartmentResponse>
+                    handler) {
+        LOG.trace("Called async changeBackupCompartment");
+        final ChangeBackupCompartmentRequest interceptedRequest =
+                ChangeBackupCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeBackupCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeBackupCompartmentResponse>
+                transformer = ChangeBackupCompartmentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeBackupCompartmentRequest, ChangeBackupCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeBackupCompartmentRequest, ChangeBackupCompartmentResponse>,
+                        java.util.concurrent.Future<ChangeBackupCompartmentResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getChangeBackupCompartmentDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeBackupCompartmentRequest, ChangeBackupCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<CreateBackupResponse> createBackup(
             CreateBackupRequest request,
             final com.oracle.bmc.responses.AsyncHandler<CreateBackupRequest, CreateBackupResponse>

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackupsClient.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/DbBackupsClient.java
@@ -452,6 +452,40 @@ public class DbBackupsClient implements DbBackups {
     }
 
     @Override
+    public ChangeBackupCompartmentResponse changeBackupCompartment(
+            ChangeBackupCompartmentRequest request) {
+        LOG.trace("Called changeBackupCompartment");
+        final ChangeBackupCompartmentRequest interceptedRequest =
+                ChangeBackupCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeBackupCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ChangeBackupCompartmentResponse>
+                transformer = ChangeBackupCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getChangeBackupCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public CreateBackupResponse createBackup(CreateBackupRequest request) {
         LOG.trace("Called createBackup");
         final CreateBackupRequest interceptedRequest =

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ChangeBackupCompartmentConverter.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/internal/http/ChangeBackupCompartmentConverter.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.mysql.model.*;
+import com.oracle.bmc.mysql.requests.*;
+import com.oracle.bmc.mysql.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.extern.slf4j.Slf4j
+public class ChangeBackupCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.mysql.requests.ChangeBackupCompartmentRequest interceptRequest(
+            com.oracle.bmc.mysql.requests.ChangeBackupCompartmentRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.mysql.requests.ChangeBackupCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getBackupId(), "backupId must not be blank");
+        Validate.notNull(
+                request.getChangeBackupCompartmentDetails(),
+                "changeBackupCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20190415")
+                        .path("backups")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getBackupId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.mysql.responses.ChangeBackupCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.mysql.responses.ChangeBackupCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.mysql.responses.ChangeBackupCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.mysql.responses.ChangeBackupCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.mysql.responses.ChangeBackupCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.mysql.responses.ChangeBackupCompartmentResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.mysql.responses
+                                                        .ChangeBackupCompartmentResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.mysql.responses.ChangeBackupCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChangeBackupCompartmentDetails.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ChangeBackupCompartmentDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.model;
+
+/**
+ * OCID of the target compartment for DB System Backup change compartment request.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeBackupCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeBackupCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeBackupCompartmentDetails build() {
+            ChangeBackupCompartmentDetails __instance__ =
+                    new ChangeBackupCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeBackupCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * OCID of the target compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ChangeBackupCompartmentRequest.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/requests/ChangeBackupCompartmentRequest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.requests;
+
+import com.oracle.bmc.mysql.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/mysql/ChangeBackupCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeBackupCompartmentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ChangeBackupCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<ChangeBackupCompartmentDetails> {
+
+    /**
+     * The OCID of the Backup
+     */
+    private String backupId;
+
+    /**
+     * Target compartment for a DB System Backup.
+     */
+    private ChangeBackupCompartmentDetails changeBackupCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a
+     * resource, set the {@code If-Match} header to the value of the etag from a
+     * previous GET or POST response for that resource. The resource will be
+     * updated or deleted only if the etag you provide matches the resource's
+     * current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Customer-defined unique identifier for the request. If you need to
+     * contact Oracle about a specific request, please provide the request
+     * ID that you supplied in this header with the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations (for example, if a resource has been
+     * deleted and purged from the system, then a retry of the original
+     * creation request may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public ChangeBackupCompartmentDetails getBody$() {
+        return changeBackupCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeBackupCompartmentRequest, ChangeBackupCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeBackupCompartmentRequest o) {
+            backupId(o.getBackupId());
+            changeBackupCompartmentDetails(o.getChangeBackupCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeBackupCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeBackupCompartmentRequest
+         */
+        public ChangeBackupCompartmentRequest build() {
+            ChangeBackupCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(ChangeBackupCompartmentDetails body) {
+            changeBackupCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ChangeBackupCompartmentResponse.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/responses/ChangeBackupCompartmentResponse.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.mysql.responses;
+
+import com.oracle.bmc.mysql.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190415")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode
+@lombok.Getter
+public class ChangeBackupCompartmentResponse {
+    /**
+     * HTTP status code returned by the operation.
+     */
+    private final int __httpStatusCode__;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    public static class Builder {
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeBackupCompartmentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+
+            return this;
+        }
+    }
+}

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.3.1</version>
+  <version>2.3.2</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for manually copying volume group backups across regions in the Block Volume service

- Support for work requests for the copy volume backup and copy boot volume backup operations in the Block Volume service

- Support for specifying external Hive metastores during application creation in the Data Flow service

- Support for changing the compartment of a backup in the MySQL Database service

- Support for model catalog features including provenance, metadata, schemas, and artifact introspection in the Data Science service

- Support for Exadata system network bonding in the Database service

- Support for creating autonomous databases with early patching enabled in the Database service