### PR TITLE
Releasing version 2.7.0

### DIFF
--- a/ApacheConnector-README.md
+++ b/ApacheConnector-README.md
@@ -173,9 +173,9 @@ An example of configuring a proxy can be found [here](https://github.com/oracle/
 
 `ApacheConfigurator` by default configures a connection pool with `defaultMaxConnectionsPerRoute` and
 `maximumOpenConnections`. Please make sure to close all `InputStreams` obtained from the response object by
-calling close on the stream object if doing partial read. If the stream is read completely, then the SDK will try to
+calling close on the stream object if doing partial read or if not reading at all. If the stream is read completely, then the SDK will try to
 auto-close the stream to release the connection from the connection pool. 
-To manually close the stream in case of partial read of stream. Please call close on the stream.
+To manually close the stream in case of partial read of stream/no read. Please call close on the stream.
 For example - `GetObjectReponse.getInputStream().close()` or
 use try-with-resources. Otherwise, a partial read without closing will lead to the connection not being released from 
 the pool and results in hanging for an indefinite time.
@@ -189,10 +189,10 @@ Use `ApacheConnectionClosingStrategy.ImmediateClosingStrategy` for large files w
 
 Note : If both the above Apache Connection closing strategies do not give you optimal results for your use-cases, please consider switching back to Jersey Default `HttpUrlConnectorProvider` using the method stated in the above section.
 
-An example can be found [here](http://https://github.com/oracle/oci-java-sdk/tree/master/bmc-examples/src/main/java/ApacheConnectorPropertiesExample.java  "here")
+An example can be found [here](https://github.com/oracle/oci-java-sdk/tree/master/bmc-examples/src/main/java/ApacheConnectorPropertiesExample.java  "here")
 
 ## More info
-More examples related to customizing Apache Connector can be found [here](http://https://github.com/oracle/oci-java-sdk/tree/master/bmc-examples/src/main/java/ApacheConnectorPropertiesExample.java  "here") 
+More examples related to customizing Apache Connector can be found [here](https://github.com/oracle/oci-java-sdk/tree/master/bmc-examples/src/main/java/ApacheConnectorPropertiesExample.java  "here") 
 
 ## License
 Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.7.0 - 2021-10-05
+### Added
+- Support for configuring Binlog variables in the MySQL Database service
+- Support new response value "OPERATOR" for backup creationType in list and get MDS backup API in the MySQL Database service
+- Support for SetAutoUpgradableConfig and GetAutoUpgradableConfig operations in Management Agent Cloud service
+- Support for additional installType filter for List Management Agents, Images and Count API operations in Management Agent Cloud service
+- Support for list and read DeploymentUpgrade, cancel and restore DeploymentBackup in the Golden Gate service
+- Support for non-autonomous databases targets, executing Pre-Migration advisor, uploading Datapump logs into Object Storage bucket, and filtering Database Objects in the Database Migration service
+- Support for calling Oracle Cloud Infrastructure services in the ap-ibaraki-1 region
+
+### Breaking changes
+- Return type of method `public com.oracle.bmc.databasemigration.model.LifecycleStates getLifecycleState()` has been changed to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in the Database Migration service
+- Method `public java.lang.String getCompartmentId()` has been removed from model `com.oracle.bmc.databasemigration.model.UpdateAgentDetails` in the Database Migration service
+- Method `public java.util.Date getTimeStamp()` has been removed from the model `com.oracle.bmc.databasemigration.model.WorkRequestError` in the Database Migration service
+- Method `public java.util.Date getTimeStamp()` has been removed from the model `com.oracle.bmc.databasemigration.model.WorkRequestLogEntry` in the Database Migration service
+- Return type of method `public com.oracle.bmc.databasemigration.model.LifecycleStates getLifecycleState()` has been changed to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in `com.oracle.bmc.databasemigration.requests.ListMigrationsRequest` in the Database Migration service
+- Method `public java.lang.String getDisplayName()` has been removed from `com.oracle.bmc.databasemigration.requests.ListWorkRequestErrorsRequest` in the Database Migration service
+- Removed field `DisplayName` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestErrorsRequest$SortBy` in the Database Migration service
+- Removed field `TimeCreated` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestErrorsRequest$SortBy` in the Database Migration service
+- Method `public java.lang.String getDisplayName()` has been removed from `com.oracle.bmc.databasemigration.requests.ListWorkRequestLogsRequest` in the Database Migration service
+- Removed field `DisplayName` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestLogsRequest$SortBy` in the Database Migration service
+- Removed field `TimeCreated` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestLogsRequest$SortBy` in the Database Migration service
+- Method `public java.lang.String getDisplayName()` has been removed from `com.oracle.bmc.databasemigration.requests.ListWorkRequestsRequest` in the Database Migration service
+- Removed field `DisplayName` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestsRequest$SortBy` in the Database Migration service
+- Removed field `TimeCreated` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestsRequest$SortBy` in the Database Migration service
+- Parameter 2 of `public com.oracle.bmc.waiter.Waiter forMigration(com.oracle.bmc.databasemigration.requests.GetMigrationRequest, com.oracle.bmc.databasemigration.model.LifecycleStates[])` has changed its type to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates[]` in `com.oracle.bmc.databasemigration.DatabaseMigrationWaiters` in the Database Migration service
+- Parameter 2 of `public com.oracle.bmc.waiter.Waiter forMigration(com.oracle.bmc.databasemigration.requests.GetMigrationRequest, com.oracle.bmc.databasemigration.model.LifecycleStates, com.oracle.bmc.waiter.TerminationStrategy, com.oracle.bmc.waiter.DelayStrategy)` has changed its type to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in `com.oracle.bmc.databasemigration.DatabaseMigrationWaiters` in the Database Migration service
+- Parameter 4 of `public com.oracle.bmc.waiter.Waiter forMigration(com.oracle.bmc.databasemigration.requests.GetMigrationRequest, com.oracle.bmc.waiter.TerminationStrategy, com.oracle.bmc.waiter.DelayStrategy, com.oracle.bmc.databasemigration.model.LifecycleStates[])` has changed its type to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates[]` in `com.oracle.bmc.databasemigration.DatabaseMigrationWaiters` in the Database Migration service
+- Return type of method `public com.oracle.bmc.databasemigration.model.LifecycleStates getLifecycleState()` has been changed to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in the model `com.oracle.bmc.databasemigration.model.Migration` in the Database Migration service
+- Return type of method `public com.oracle.bmc.databasemigration.model.LifecycleStates getLifecycleState()` has been changed to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in the model `com.oracle.bmc.databasemigration.model.MigrationSummary` in the Database Migration service
+- Method `public java.lang.Boolean getIsAgentAutoUpgradable()` has been removed from `com.oracle.bmc.managementagent.model.UpdateManagementAgentDetails` in the Management Agent Cloud service
+
 ## 2.6.0 - 2021-09-28
 ### Added
 - Support for autonomous databases and clones on shared infrastructure not requiring mTLS in the Database service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,504 +19,504 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-common/src/main/java/com/oracle/bmc/Region.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Region.java
@@ -115,6 +115,7 @@ public final class Region implements Serializable, Comparable<Region> {
 
     // OC8
     public static final Region AP_CHIYODA_1 = register("ap-chiyoda-1", Realm.OC8, "nja");
+    public static final Region AP_IBARAKI_1 = register("ap-ibaraki-1", Realm.OC8, "ukb");
 
     private static final Map<String, Map<Region, String>> SERVICE_TO_REGION_ENDPOINTS =
             new HashMap<>();

--- a/bmc-common/src/test/resources/regions.json
+++ b/bmc-common/src/test/resources/regions.json
@@ -1,188 +1,194 @@
 [
     {
-        "regionKey": "yny",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ap-chuncheon-1",
+        "regionKey": "yny", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ap-chuncheon-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "hyd",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ap-hyderabad-1",
+        "regionKey": "hyd", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ap-hyderabad-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "mel",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ap-melbourne-1",
+        "regionKey": "mel", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ap-melbourne-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "bom",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ap-mumbai-1",
+        "regionKey": "bom", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ap-mumbai-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "kix",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ap-osaka-1",
+        "regionKey": "kix", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ap-osaka-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "icn",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ap-seoul-1",
+        "regionKey": "icn", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ap-seoul-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "syd",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ap-sydney-1",
+        "regionKey": "syd", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ap-sydney-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "nrt",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ap-tokyo-1",
+        "regionKey": "nrt", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ap-tokyo-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "yul",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ca-montreal-1",
+        "regionKey": "yul", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ca-montreal-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "yyz",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "ca-toronto-1",
+        "regionKey": "yyz", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "ca-toronto-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "ams",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "eu-amsterdam-1",
+        "regionKey": "ams", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "eu-amsterdam-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "fra",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "eu-frankfurt-1",
+        "regionKey": "fra", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "eu-frankfurt-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "zrh",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "eu-zurich-1",
+        "regionKey": "zrh", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "eu-zurich-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "jed",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "me-jeddah-1",
+        "regionKey": "jed", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "me-jeddah-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "gru",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "sa-saopaulo-1",
+        "regionKey": "gru", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "sa-saopaulo-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "lhr",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "uk-london-1",
+        "regionKey": "lhr", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "uk-london-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "iad",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "us-ashburn-1",
+        "regionKey": "iad", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "us-ashburn-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "phx",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "us-phoenix-1",
+        "regionKey": "phx", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "us-phoenix-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "sjc",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "us-sanjose-1",
+        "regionKey": "sjc", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "us-sanjose-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "dxb",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "me-dubai-1",
+        "regionKey": "dxb", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "me-dubai-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "cwl",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "uk-cardiff-1",
+        "regionKey": "cwl", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "uk-cardiff-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "scl",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "sa-santiago-1",
+        "regionKey": "scl", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "sa-santiago-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "vcp",
-        "realmDomainComponent": "oraclecloud.com",
-        "regionIdentifier": "sa-vinhedo-1",
+        "regionKey": "vcp", 
+        "realmDomainComponent": "oraclecloud.com", 
+        "regionIdentifier": "sa-vinhedo-1", 
         "realmKey": "OC1"
-    },
+    }, 
     {
-        "regionKey": "lfi",
-        "realmDomainComponent": "oraclegovcloud.com",
-        "regionIdentifier": "us-langley-1",
+        "regionKey": "lfi", 
+        "realmDomainComponent": "oraclegovcloud.com", 
+        "regionIdentifier": "us-langley-1", 
         "realmKey": "OC2"
-    },
+    }, 
     {
-        "regionKey": "luf",
-        "realmDomainComponent": "oraclegovcloud.com",
-        "regionIdentifier": "us-luke-1",
+        "regionKey": "luf", 
+        "realmDomainComponent": "oraclegovcloud.com", 
+        "regionIdentifier": "us-luke-1", 
         "realmKey": "OC2"
-    },
+    }, 
     {
-        "regionKey": "ric",
-        "realmDomainComponent": "oraclegovcloud.com",
-        "regionIdentifier": "us-gov-ashburn-1",
+        "regionKey": "ric", 
+        "realmDomainComponent": "oraclegovcloud.com", 
+        "regionIdentifier": "us-gov-ashburn-1", 
         "realmKey": "OC3"
-    },
+    }, 
     {
-        "regionKey": "pia",
-        "realmDomainComponent": "oraclegovcloud.com",
-        "regionIdentifier": "us-gov-chicago-1",
+        "regionKey": "pia", 
+        "realmDomainComponent": "oraclegovcloud.com", 
+        "regionIdentifier": "us-gov-chicago-1", 
         "realmKey": "OC3"
-    },
+    }, 
     {
-        "regionKey": "tus",
-        "realmDomainComponent": "oraclegovcloud.com",
-        "regionIdentifier": "us-gov-phoenix-1",
+        "regionKey": "tus", 
+        "realmDomainComponent": "oraclegovcloud.com", 
+        "regionIdentifier": "us-gov-phoenix-1", 
         "realmKey": "OC3"
-    },
+    }, 
     {
-        "regionKey": "ltn",
-        "realmDomainComponent": "oraclegovcloud.uk",
-        "regionIdentifier": "uk-gov-london-1",
+        "regionKey": "ltn", 
+        "realmDomainComponent": "oraclegovcloud.uk", 
+        "regionIdentifier": "uk-gov-london-1", 
         "realmKey": "OC4"
-    },
+    }, 
     {
-        "regionKey": "brs",
-        "realmDomainComponent": "oraclegovcloud.uk",
-        "regionIdentifier": "uk-gov-cardiff-1",
+        "regionKey": "brs", 
+        "realmDomainComponent": "oraclegovcloud.uk", 
+        "regionIdentifier": "uk-gov-cardiff-1", 
         "realmKey": "OC4"
-    },
+    }, 
     {
-        "regionKey": "nja",
-        "realmDomainComponent": "oraclecloud8.com",
-        "regionIdentifier": "ap-chiyoda-1",
+        "regionKey": "nja", 
+        "realmDomainComponent": "oraclecloud8.com", 
+        "regionIdentifier": "ap-chiyoda-1", 
         "realmKey": "OC8"
+    }, 
+    {
+        "regionKey": "ukb", 
+        "realmDomainComponent": "oraclecloud8.com", 
+        "regionIdentifier": "ap-ibaraki-1", 
+        "realmKey": "oc8"
     }
 ]

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigration.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigration.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.responses.*;
 /**
  * Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 public interface DatabaseMigration extends AutoCloseable {
 
     /**
@@ -46,7 +46,6 @@ public interface DatabaseMigration extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Aborts a Migration Job (either Evaluation or Migration).
      *
      * @param request The request object containing the details to send
@@ -58,7 +57,6 @@ public interface DatabaseMigration extends AutoCloseable {
     AbortJobResponse abortJob(AbortJobRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Used to configure an ODMS Agent Compartment ID.
      *
      * @param request The request object containing the details to send
@@ -70,7 +68,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ChangeAgentCompartmentResponse changeAgentCompartment(ChangeAgentCompartmentRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Used to change the Database Connection compartment.
      *
      * @param request The request object containing the details to send
@@ -83,7 +80,6 @@ public interface DatabaseMigration extends AutoCloseable {
             ChangeConnectionCompartmentRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Used to change the Migration compartment.
      *
      * @param request The request object containing the details to send
@@ -96,7 +92,6 @@ public interface DatabaseMigration extends AutoCloseable {
             ChangeMigrationCompartmentRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Clone a configuration from an existing Migration.
      *
      * @param request The request object containing the details to send
@@ -108,7 +103,6 @@ public interface DatabaseMigration extends AutoCloseable {
     CloneMigrationResponse cloneMigration(CloneMigrationRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Create a Database Connection resource that contains the details to connect to either a Source or Target Database
      * in the migration.
      *
@@ -121,7 +115,6 @@ public interface DatabaseMigration extends AutoCloseable {
     CreateConnectionResponse createConnection(CreateConnectionRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Create a Migration resource that contains all the details to perform the
      * database migration operation, such as source and destination database
      * details, credentials, etc.
@@ -135,7 +128,6 @@ public interface DatabaseMigration extends AutoCloseable {
     CreateMigrationResponse createMigration(CreateMigrationRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Delete the ODMS Agent represented by the specified ODMS Agent ID.
      *
      * @param request The request object containing the details to send
@@ -147,7 +139,6 @@ public interface DatabaseMigration extends AutoCloseable {
     DeleteAgentResponse deleteAgent(DeleteAgentRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Deletes the Database Connection represented by the specified connection ID.
      *
      * @param request The request object containing the details to send
@@ -159,7 +150,6 @@ public interface DatabaseMigration extends AutoCloseable {
     DeleteConnectionResponse deleteConnection(DeleteConnectionRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Deletes the migration job represented by the given job ID.
      *
      * @param request The request object containing the details to send
@@ -171,7 +161,6 @@ public interface DatabaseMigration extends AutoCloseable {
     DeleteJobResponse deleteJob(DeleteJobRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Deletes the Migration represented by the specified migration ID.
      *
      * @param request The request object containing the details to send
@@ -183,7 +172,6 @@ public interface DatabaseMigration extends AutoCloseable {
     DeleteMigrationResponse deleteMigration(DeleteMigrationRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Start Validate Migration job.
      *
      * @param request The request object containing the details to send
@@ -195,7 +183,17 @@ public interface DatabaseMigration extends AutoCloseable {
     EvaluateMigrationResponse evaluateMigration(EvaluateMigrationRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
+     * Get the Pre-Migration Advisor report details
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/GetAdvisorReportExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAdvisorReport API.
+     */
+    GetAdvisorReportResponse getAdvisorReport(GetAdvisorReportRequest request);
+
+    /**
      * Display the ODMS Agent configuration.
      *
      * @param request The request object containing the details to send
@@ -207,7 +205,6 @@ public interface DatabaseMigration extends AutoCloseable {
     GetAgentResponse getAgent(GetAgentRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Display Database Connection details.
      *
      * @param request The request object containing the details to send
@@ -219,7 +216,6 @@ public interface DatabaseMigration extends AutoCloseable {
     GetConnectionResponse getConnection(GetConnectionRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Get a migration job.
      *
      * @param request The request object containing the details to send
@@ -231,7 +227,6 @@ public interface DatabaseMigration extends AutoCloseable {
     GetJobResponse getJob(GetJobRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Get the migration Job Output content as a String.
      *
      * @param request The request object containing the details to send
@@ -243,7 +238,6 @@ public interface DatabaseMigration extends AutoCloseable {
     GetJobOutputContentResponse getJobOutputContent(GetJobOutputContentRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Display Migration details.
      *
      * @param request The request object containing the details to send
@@ -255,7 +249,6 @@ public interface DatabaseMigration extends AutoCloseable {
     GetMigrationResponse getMigration(GetMigrationRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Gets the details of a work request.
      *
      * @param request The request object containing the details to send
@@ -267,7 +260,6 @@ public interface DatabaseMigration extends AutoCloseable {
     GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Get details of the ODMS Agent Images available to install on-premises.
      *
      * @param request The request object containing the details to send
@@ -279,7 +271,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ListAgentImagesResponse listAgentImages(ListAgentImagesRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Display the name of all the existing ODMS Agents in the server.
      *
      * @param request The request object containing the details to send
@@ -291,7 +282,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ListAgentsResponse listAgents(ListAgentsRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * List all Database Connections.
      *
      * @param request The request object containing the details to send
@@ -303,7 +293,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ListConnectionsResponse listConnections(ListConnectionsRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * List the Job Outputs
      *
      * @param request The request object containing the details to send
@@ -315,7 +304,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ListJobOutputsResponse listJobOutputs(ListJobOutputsRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * List all the names of the Migration jobs associated to the specified
      * migration site.
      *
@@ -328,7 +316,18 @@ public interface DatabaseMigration extends AutoCloseable {
     ListJobsResponse listJobs(ListJobsRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
+     * Display sample object types to exclude or include for a Migration.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListMigrationObjectTypesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListMigrationObjectTypes API.
+     */
+    ListMigrationObjectTypesResponse listMigrationObjectTypes(
+            ListMigrationObjectTypesRequest request);
+
+    /**
      * List all Migrations.
      *
      * @param request The request object containing the details to send
@@ -340,7 +339,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ListMigrationsResponse listMigrations(ListMigrationsRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Gets the errors for a work request.
      *
      * @param request The request object containing the details to send
@@ -352,7 +350,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ListWorkRequestErrorsResponse listWorkRequestErrors(ListWorkRequestErrorsRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Gets the logs for a work request.
      *
      * @param request The request object containing the details to send
@@ -364,7 +361,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ListWorkRequestLogsResponse listWorkRequestLogs(ListWorkRequestLogsRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Lists the work requests in a compartment or for a specified resource.
      *
      * @param request The request object containing the details to send
@@ -376,7 +372,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Resume a migration Job.
      *
      * @param request The request object containing the details to send
@@ -388,7 +383,6 @@ public interface DatabaseMigration extends AutoCloseable {
     ResumeJobResponse resumeJob(ResumeJobRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Display Migration Phases for a specified migration.
      *
      * @param request The request object containing the details to send
@@ -400,7 +394,6 @@ public interface DatabaseMigration extends AutoCloseable {
     RetrieveSupportedPhasesResponse retrieveSupportedPhases(RetrieveSupportedPhasesRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Start Migration job.
      *
      * @param request The request object containing the details to send
@@ -412,7 +405,6 @@ public interface DatabaseMigration extends AutoCloseable {
     StartMigrationResponse startMigration(StartMigrationRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Modifies the ODMS Agent represented by the given ODMS Agent ID.
      *
      * @param request The request object containing the details to send
@@ -424,7 +416,6 @@ public interface DatabaseMigration extends AutoCloseable {
     UpdateAgentResponse updateAgent(UpdateAgentRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Update Database Connection resource details.
      *
      * @param request The request object containing the details to send
@@ -436,7 +427,6 @@ public interface DatabaseMigration extends AutoCloseable {
     UpdateConnectionResponse updateConnection(UpdateConnectionRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Update Migration Job resource details.
      *
      * @param request The request object containing the details to send
@@ -448,7 +438,6 @@ public interface DatabaseMigration extends AutoCloseable {
     UpdateJobResponse updateJob(UpdateJobRequest request);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Update Migration resource details.
      *
      * @param request The request object containing the details to send

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsync.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsync.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.responses.*;
 /**
  * Use the Oracle Cloud Infrastructure Database Migration APIs to perform database migration operations.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 public interface DatabaseMigrationAsync extends AutoCloseable {
 
     /**
@@ -46,7 +46,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Aborts a Migration Job (either Evaluation or Migration).
      *
      *
@@ -62,7 +61,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<AbortJobRequest, AbortJobResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Used to configure an ODMS Agent Compartment ID.
      *
      *
@@ -80,7 +78,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Used to change the Database Connection compartment.
      *
      *
@@ -98,7 +95,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Used to change the Migration compartment.
      *
      *
@@ -116,7 +112,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Clone a configuration from an existing Migration.
      *
      *
@@ -133,7 +128,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Create a Database Connection resource that contains the details to connect to either a Source or Target Database
      * in the migration.
      *
@@ -151,7 +145,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Create a Migration resource that contains all the details to perform the
      * database migration operation, such as source and destination database
      * details, credentials, etc.
@@ -170,7 +163,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Delete the ODMS Agent represented by the specified ODMS Agent ID.
      *
      *
@@ -186,7 +178,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<DeleteAgentRequest, DeleteAgentResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Deletes the Database Connection represented by the specified connection ID.
      *
      *
@@ -203,7 +194,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Deletes the migration job represented by the given job ID.
      *
      *
@@ -219,7 +209,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<DeleteJobRequest, DeleteJobResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Deletes the Migration represented by the specified migration ID.
      *
      *
@@ -236,7 +225,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Start Validate Migration job.
      *
      *
@@ -254,7 +242,22 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
+     * Get the Pre-Migration Advisor report details
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetAdvisorReportResponse> getAdvisorReport(
+            GetAdvisorReportRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetAdvisorReportRequest, GetAdvisorReportResponse>
+                    handler);
+
+    /**
      * Display the ODMS Agent configuration.
      *
      *
@@ -270,7 +273,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetAgentRequest, GetAgentResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Display Database Connection details.
      *
      *
@@ -287,7 +289,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Get a migration job.
      *
      *
@@ -303,7 +304,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetJobRequest, GetJobResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Get the migration Job Output content as a String.
      *
      *
@@ -321,7 +321,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Display Migration details.
      *
      *
@@ -338,7 +337,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Gets the details of a work request.
      *
      *
@@ -355,7 +353,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Get details of the ODMS Agent Images available to install on-premises.
      *
      *
@@ -372,7 +369,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Display the name of all the existing ODMS Agents in the server.
      *
      *
@@ -388,7 +384,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListAgentsRequest, ListAgentsResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * List all Database Connections.
      *
      *
@@ -405,7 +400,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * List the Job Outputs
      *
      *
@@ -422,7 +416,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * List all the names of the Migration jobs associated to the specified
      * migration site.
      *
@@ -439,7 +432,23 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListJobsRequest, ListJobsResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
+     * Display sample object types to exclude or include for a Migration.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListMigrationObjectTypesResponse> listMigrationObjectTypes(
+            ListMigrationObjectTypesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListMigrationObjectTypesRequest, ListMigrationObjectTypesResponse>
+                    handler);
+
+    /**
      * List all Migrations.
      *
      *
@@ -456,7 +465,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Gets the errors for a work request.
      *
      *
@@ -474,7 +482,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Gets the logs for a work request.
      *
      *
@@ -492,7 +499,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Lists the work requests in a compartment or for a specified resource.
      *
      *
@@ -509,7 +515,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Resume a migration Job.
      *
      *
@@ -525,7 +530,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ResumeJobRequest, ResumeJobResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Display Migration Phases for a specified migration.
      *
      *
@@ -543,7 +547,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Start Migration job.
      *
      *
@@ -560,7 +563,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Modifies the ODMS Agent represented by the given ODMS Agent ID.
      *
      *
@@ -576,7 +578,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<UpdateAgentRequest, UpdateAgentResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Update Database Connection resource details.
      *
      *
@@ -593,7 +594,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Update Migration Job resource details.
      *
      *
@@ -609,7 +609,6 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<UpdateJobRequest, UpdateJobResponse> handler);
 
     /**
-     * Note: Deprecated. Use the new resource model APIs instead.
      * Update Migration resource details.
      *
      *

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsyncClient.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsyncClient.java
@@ -21,7 +21,7 @@ import com.oracle.bmc.databasemigration.responses.*;
  * Future.isDone/isCancelled.<br/>
  * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class DatabaseMigrationAsyncClient implements DatabaseMigrationAsync {
     /**
@@ -889,6 +889,45 @@ public class DatabaseMigrationAsyncClient implements DatabaseMigrationAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetAdvisorReportResponse> getAdvisorReport(
+            GetAdvisorReportRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetAdvisorReportRequest, GetAdvisorReportResponse>
+                    handler) {
+        LOG.trace("Called async getAdvisorReport");
+        final GetAdvisorReportRequest interceptedRequest =
+                GetAdvisorReportConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAdvisorReportConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetAdvisorReportResponse>
+                transformer = GetAdvisorReportConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetAdvisorReportRequest, GetAdvisorReportResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetAdvisorReportRequest, GetAdvisorReportResponse>,
+                        java.util.concurrent.Future<GetAdvisorReportResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetAdvisorReportRequest, GetAdvisorReportResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetAgentResponse> getAgent(
             GetAgentRequest request,
             final com.oracle.bmc.responses.AsyncHandler<GetAgentRequest, GetAgentResponse>
@@ -1298,6 +1337,47 @@ public class DatabaseMigrationAsyncClient implements DatabaseMigrationAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListJobsRequest, ListJobsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListMigrationObjectTypesResponse> listMigrationObjectTypes(
+            ListMigrationObjectTypesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListMigrationObjectTypesRequest, ListMigrationObjectTypesResponse>
+                    handler) {
+        LOG.trace("Called async listMigrationObjectTypes");
+        final ListMigrationObjectTypesRequest interceptedRequest =
+                ListMigrationObjectTypesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListMigrationObjectTypesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListMigrationObjectTypesResponse>
+                transformer = ListMigrationObjectTypesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListMigrationObjectTypesRequest, ListMigrationObjectTypesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListMigrationObjectTypesRequest, ListMigrationObjectTypesResponse>,
+                        java.util.concurrent.Future<ListMigrationObjectTypesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListMigrationObjectTypesRequest, ListMigrationObjectTypesResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationClient.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationClient.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.internal.http.*;
 import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class DatabaseMigrationClient implements DatabaseMigration {
     /**
@@ -831,6 +831,34 @@ public class DatabaseMigrationClient implements DatabaseMigration {
     }
 
     @Override
+    public GetAdvisorReportResponse getAdvisorReport(GetAdvisorReportRequest request) {
+        LOG.trace("Called getAdvisorReport");
+        final GetAdvisorReportRequest interceptedRequest =
+                GetAdvisorReportConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAdvisorReportConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetAdvisorReportResponse>
+                transformer = GetAdvisorReportConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetAgentResponse getAgent(GetAgentRequest request) {
         LOG.trace("Called getAgent");
         final GetAgentRequest interceptedRequest = GetAgentConverter.interceptRequest(request);
@@ -1123,6 +1151,35 @@ public class DatabaseMigrationClient implements DatabaseMigration {
                 ListJobsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListJobsResponse> transformer =
                 ListJobsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListMigrationObjectTypesResponse listMigrationObjectTypes(
+            ListMigrationObjectTypesRequest request) {
+        LOG.trace("Called listMigrationObjectTypes");
+        final ListMigrationObjectTypesRequest interceptedRequest =
+                ListMigrationObjectTypesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListMigrationObjectTypesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListMigrationObjectTypesResponse>
+                transformer = ListMigrationObjectTypesConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationPaginators.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationPaginators.java
@@ -25,7 +25,7 @@ import com.oracle.bmc.databasemigration.responses.*;
  * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
  * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.RequiredArgsConstructor
 public class DatabaseMigrationPaginators {
     private final DatabaseMigration client;
@@ -583,6 +583,126 @@ public class DatabaseMigrationPaginators {
                     public java.util.List<com.oracle.bmc.databasemigration.model.JobSummary> apply(
                             ListJobsResponse response) {
                         return response.getJobCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listMigrationObjectTypes operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListMigrationObjectTypesResponse> listMigrationObjectTypesResponseIterator(
+            final ListMigrationObjectTypesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListMigrationObjectTypesRequest.Builder, ListMigrationObjectTypesRequest,
+                ListMigrationObjectTypesResponse>(
+                new com.google.common.base.Supplier<ListMigrationObjectTypesRequest.Builder>() {
+                    @Override
+                    public ListMigrationObjectTypesRequest.Builder get() {
+                        return ListMigrationObjectTypesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListMigrationObjectTypesResponse, String>() {
+                    @Override
+                    public String apply(ListMigrationObjectTypesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListMigrationObjectTypesRequest.Builder>,
+                        ListMigrationObjectTypesRequest>() {
+                    @Override
+                    public ListMigrationObjectTypesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListMigrationObjectTypesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListMigrationObjectTypesRequest, ListMigrationObjectTypesResponse>() {
+                    @Override
+                    public ListMigrationObjectTypesResponse apply(
+                            ListMigrationObjectTypesRequest request) {
+                        return client.listMigrationObjectTypes(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.databasemigration.model.MigrationObjectTypeSummary} objects
+     * contained in responses from the listMigrationObjectTypes operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.databasemigration.model.MigrationObjectTypeSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.databasemigration.model.MigrationObjectTypeSummary>
+            listMigrationObjectTypesRecordIterator(final ListMigrationObjectTypesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListMigrationObjectTypesRequest.Builder, ListMigrationObjectTypesRequest,
+                ListMigrationObjectTypesResponse,
+                com.oracle.bmc.databasemigration.model.MigrationObjectTypeSummary>(
+                new com.google.common.base.Supplier<ListMigrationObjectTypesRequest.Builder>() {
+                    @Override
+                    public ListMigrationObjectTypesRequest.Builder get() {
+                        return ListMigrationObjectTypesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListMigrationObjectTypesResponse, String>() {
+                    @Override
+                    public String apply(ListMigrationObjectTypesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListMigrationObjectTypesRequest.Builder>,
+                        ListMigrationObjectTypesRequest>() {
+                    @Override
+                    public ListMigrationObjectTypesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListMigrationObjectTypesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListMigrationObjectTypesRequest, ListMigrationObjectTypesResponse>() {
+                    @Override
+                    public ListMigrationObjectTypesResponse apply(
+                            ListMigrationObjectTypesRequest request) {
+                        return client.listMigrationObjectTypes(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListMigrationObjectTypesResponse,
+                        java.util.List<
+                                com.oracle.bmc.databasemigration.model
+                                        .MigrationObjectTypeSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.databasemigration.model
+                                            .MigrationObjectTypeSummary>
+                            apply(ListMigrationObjectTypesResponse response) {
+                        return response.getMigrationObjectTypeSummaryCollection().getItems();
                     }
                 });
     }

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationWaiters.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationWaiters.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.databasemigration.responses.*;
  * <p>
  * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.RequiredArgsConstructor
 public class DatabaseMigrationWaiters {
     private final java.util.concurrent.ExecutorService executorService;
@@ -317,7 +317,7 @@ public class DatabaseMigrationWaiters {
      */
     public com.oracle.bmc.waiter.Waiter<GetMigrationRequest, GetMigrationResponse> forMigration(
             GetMigrationRequest request,
-            com.oracle.bmc.databasemigration.model.LifecycleStates... targetStates) {
+            com.oracle.bmc.databasemigration.model.MigrationLifecycleStates... targetStates) {
         org.apache.commons.lang3.Validate.notEmpty(
                 targetStates, "At least one targetState must be provided");
         org.apache.commons.lang3.Validate.noNullElements(
@@ -338,7 +338,7 @@ public class DatabaseMigrationWaiters {
      */
     public com.oracle.bmc.waiter.Waiter<GetMigrationRequest, GetMigrationResponse> forMigration(
             GetMigrationRequest request,
-            com.oracle.bmc.databasemigration.model.LifecycleStates targetState,
+            com.oracle.bmc.databasemigration.model.MigrationLifecycleStates targetState,
             com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
             com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
         org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
@@ -362,7 +362,7 @@ public class DatabaseMigrationWaiters {
             GetMigrationRequest request,
             com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
             com.oracle.bmc.waiter.DelayStrategy delayStrategy,
-            com.oracle.bmc.databasemigration.model.LifecycleStates... targetStates) {
+            com.oracle.bmc.databasemigration.model.MigrationLifecycleStates... targetStates) {
         org.apache.commons.lang3.Validate.notEmpty(
                 targetStates, "At least one targetState must be provided");
         org.apache.commons.lang3.Validate.noNullElements(
@@ -378,8 +378,8 @@ public class DatabaseMigrationWaiters {
     private com.oracle.bmc.waiter.Waiter<GetMigrationRequest, GetMigrationResponse> forMigration(
             com.oracle.bmc.waiter.BmcGenericWaiter waiter,
             final GetMigrationRequest request,
-            final com.oracle.bmc.databasemigration.model.LifecycleStates... targetStates) {
-        final java.util.Set<com.oracle.bmc.databasemigration.model.LifecycleStates>
+            final com.oracle.bmc.databasemigration.model.MigrationLifecycleStates... targetStates) {
+        final java.util.Set<com.oracle.bmc.databasemigration.model.MigrationLifecycleStates>
                 targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
 
         return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
@@ -401,7 +401,8 @@ public class DatabaseMigrationWaiters {
                             }
                         },
                         targetStatesSet.contains(
-                                com.oracle.bmc.databasemigration.model.LifecycleStates.Deleted)),
+                                com.oracle.bmc.databasemigration.model.MigrationLifecycleStates
+                                        .Deleted)),
                 request);
     }
 

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/AbortJobConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/AbortJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class AbortJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class AbortJobConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("jobs")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ChangeAgentCompartmentConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ChangeAgentCompartmentConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ChangeAgentCompartmentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -36,7 +36,7 @@ public class ChangeAgentCompartmentConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("agents")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ChangeConnectionCompartmentConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ChangeConnectionCompartmentConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ChangeConnectionCompartmentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -36,7 +36,7 @@ public class ChangeConnectionCompartmentConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("connections")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ChangeMigrationCompartmentConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ChangeMigrationCompartmentConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ChangeMigrationCompartmentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -36,7 +36,7 @@ public class ChangeMigrationCompartmentConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("migrations")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/CloneMigrationConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/CloneMigrationConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class CloneMigrationConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -32,7 +32,7 @@ public class CloneMigrationConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("migrations")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/CreateConnectionConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/CreateConnectionConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class CreateConnectionConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -32,7 +32,7 @@ public class CreateConnectionConverter {
                 request.getCreateConnectionDetails(), "createConnectionDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20200720").path("connections");
+                client.getBaseTarget().path("/20210929").path("connections");
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/CreateMigrationConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/CreateMigrationConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class CreateMigrationConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -30,7 +30,7 @@ public class CreateMigrationConverter {
         Validate.notNull(request.getCreateMigrationDetails(), "createMigrationDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20200720").path("migrations");
+                client.getBaseTarget().path("/20210929").path("migrations");
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/DeleteAgentConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/DeleteAgentConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class DeleteAgentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class DeleteAgentConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("agents")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/DeleteConnectionConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/DeleteConnectionConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class DeleteConnectionConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -32,7 +32,7 @@ public class DeleteConnectionConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("connections")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/DeleteJobConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/DeleteJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class DeleteJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class DeleteJobConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("jobs")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/DeleteMigrationConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/DeleteMigrationConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class DeleteMigrationConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class DeleteMigrationConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("migrations")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/EvaluateMigrationConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/EvaluateMigrationConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class EvaluateMigrationConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -32,7 +32,7 @@ public class EvaluateMigrationConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("migrations")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetAdvisorReportConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetAdvisorReportConverter.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemigration.model.*;
+import com.oracle.bmc.databasemigration.requests.*;
+import com.oracle.bmc.databasemigration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public class GetAdvisorReportConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemigration.requests.GetAdvisorReportRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemigration.requests.GetAdvisorReportRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemigration.requests.GetAdvisorReportRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getJobId(), "jobId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210929")
+                        .path("jobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getJobId()))
+                        .path("advisorReport");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemigration.responses.GetAdvisorReportResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemigration.responses.GetAdvisorReportResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemigration.responses
+                                        .GetAdvisorReportResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemigration.responses
+                                            .GetAdvisorReportResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemigration.responses.GetAdvisorReportResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.databasemigration.model
+                                                                .AdvisorReport>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.databasemigration.model
+                                                                        .AdvisorReport
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.databasemigration.model
+                                                        .AdvisorReport>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemigration.responses.GetAdvisorReportResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.databasemigration.responses
+                                                        .GetAdvisorReportResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.advisorReport(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.oracle.bmc.databasemigration.responses.GetAdvisorReportResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetAgentConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetAgentConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class GetAgentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class GetAgentConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("agents")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetConnectionConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetConnectionConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class GetConnectionConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class GetConnectionConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("connections")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetJobConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class GetJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class GetJobConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("jobs")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetJobOutputContentConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetJobOutputContentConverter.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class GetJobOutputContentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class GetJobOutputContentConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("jobs")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetMigrationConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetMigrationConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class GetMigrationConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class GetMigrationConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("migrations")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetWorkRequestConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/GetWorkRequestConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class GetWorkRequestConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class GetWorkRequestConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("workRequests")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListAgentImagesConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListAgentImagesConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ListAgentImagesConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -29,7 +29,7 @@ public class ListAgentImagesConverter {
         Validate.notNull(request, "request instance is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20200720").path("agentImages");
+                client.getBaseTarget().path("/20210929").path("agentImages");
 
         if (request.getLimit() != null) {
             target =

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListAgentsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListAgentsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ListAgentsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -30,7 +30,7 @@ public class ListAgentsConverter {
         Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20200720").path("agents");
+                client.getBaseTarget().path("/20210929").path("agents");
 
         target =
                 target.queryParam(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListConnectionsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListConnectionsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ListConnectionsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -30,7 +30,7 @@ public class ListConnectionsConverter {
         Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20200720").path("connections");
+                client.getBaseTarget().path("/20210929").path("connections");
 
         target =
                 target.queryParam(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListJobOutputsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListJobOutputsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ListJobOutputsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class ListJobOutputsConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("jobs")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListJobsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListJobsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ListJobsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -30,7 +30,7 @@ public class ListJobsConverter {
         Validate.notNull(request.getMigrationId(), "migrationId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20200720").path("jobs");
+                client.getBaseTarget().path("/20210929").path("jobs");
 
         target =
                 target.queryParam(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListMigrationObjectTypesConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListMigrationObjectTypesConverter.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemigration.model.*;
+import com.oracle.bmc.databasemigration.requests.*;
+import com.oracle.bmc.databasemigration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public class ListMigrationObjectTypesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemigration.requests.ListMigrationObjectTypesRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemigration.requests.ListMigrationObjectTypesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemigration.requests.ListMigrationObjectTypesRequest request) {
+        Validate.notNull(request, "request instance is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20210929").path("migrationObjectTypes");
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemigration.responses.ListMigrationObjectTypesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemigration.responses.ListMigrationObjectTypesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemigration.responses
+                                        .ListMigrationObjectTypesResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemigration.responses
+                                            .ListMigrationObjectTypesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemigration.responses.ListMigrationObjectTypesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.databasemigration.model
+                                                                .MigrationObjectTypeSummaryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.databasemigration.model
+                                                                        .MigrationObjectTypeSummaryCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.databasemigration.model
+                                                        .MigrationObjectTypeSummaryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .ListMigrationObjectTypesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemigration.responses
+                                                        .ListMigrationObjectTypesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.migrationObjectTypeSummaryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .ListMigrationObjectTypesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListMigrationsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListMigrationsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ListMigrationsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -30,7 +30,7 @@ public class ListMigrationsConverter {
         Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20200720").path("migrations");
+                client.getBaseTarget().path("/20210929").path("migrations");
 
         target =
                 target.queryParam(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListWorkRequestErrorsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListWorkRequestErrorsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ListWorkRequestErrorsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -33,7 +33,7 @@ public class ListWorkRequestErrorsConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("workRequests")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
@@ -70,14 +70,6 @@ public class ListWorkRequestErrorsConverter {
                             "sortOrder",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
                                     request.getSortOrder().getValue()));
-        }
-
-        if (request.getDisplayName() != null) {
-            target =
-                    target.queryParam(
-                            "displayName",
-                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getDisplayName()));
         }
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListWorkRequestLogsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListWorkRequestLogsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ListWorkRequestLogsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -32,7 +32,7 @@ public class ListWorkRequestLogsConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("workRequests")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
@@ -69,14 +69,6 @@ public class ListWorkRequestLogsConverter {
                             "sortOrder",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
                                     request.getSortOrder().getValue()));
-        }
-
-        if (request.getDisplayName() != null) {
-            target =
-                    target.queryParam(
-                            "displayName",
-                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getDisplayName()));
         }
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListWorkRequestsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListWorkRequestsConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ListWorkRequestsConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class ListWorkRequestsConverter {
         Validate.notNull(request.getCompartmentId(), "compartmentId is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20200720").path("workRequests");
+                client.getBaseTarget().path("/20210929").path("workRequests");
 
         target =
                 target.queryParam(
@@ -45,6 +45,14 @@ public class ListWorkRequestsConverter {
                             "resourceId",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
                                     request.getResourceId()));
+        }
+
+        if (request.getStatus() != null) {
+            target =
+                    target.queryParam(
+                            "status",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getStatus().getValue()));
         }
 
         if (request.getLimit() != null) {
@@ -77,14 +85,6 @@ public class ListWorkRequestsConverter {
                             "sortOrder",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
                                     request.getSortOrder().getValue()));
-        }
-
-        if (request.getDisplayName() != null) {
-            target =
-                    target.queryParam(
-                            "displayName",
-                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
-                                    request.getDisplayName()));
         }
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ResumeJobConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ResumeJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class ResumeJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class ResumeJobConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("jobs")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/RetrieveSupportedPhasesConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/RetrieveSupportedPhasesConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class RetrieveSupportedPhasesConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -33,7 +33,7 @@ public class RetrieveSupportedPhasesConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("migrations")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/StartMigrationConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/StartMigrationConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class StartMigrationConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -31,7 +31,7 @@ public class StartMigrationConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("migrations")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/UpdateAgentConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/UpdateAgentConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class UpdateAgentConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -32,7 +32,7 @@ public class UpdateAgentConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("agents")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/UpdateConnectionConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/UpdateConnectionConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class UpdateConnectionConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -34,7 +34,7 @@ public class UpdateConnectionConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("connections")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/UpdateJobConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/UpdateJobConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class UpdateJobConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -32,7 +32,7 @@ public class UpdateJobConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("jobs")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/UpdateMigrationConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/UpdateMigrationConverter.java
@@ -10,7 +10,7 @@ import com.oracle.bmc.databasemigration.requests.*;
 import com.oracle.bmc.databasemigration.responses.*;
 import org.apache.commons.lang3.Validate;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public class UpdateMigrationConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
@@ -32,7 +32,7 @@ public class UpdateMigrationConverter {
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
                 client.getBaseTarget()
-                        .path("/20200720")
+                        .path("/20210929")
                         .path("migrations")
                         .path(
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdminCredentials.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdminCredentials.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Database Administrator Credentials details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AdminCredentials.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorReport.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorReport.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Pre-Migration advisor report details.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AdvisorReport.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AdvisorReport {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("reportLocationDetails")
+        private AdvisorReportLocationDetails reportLocationDetails;
+
+        public Builder reportLocationDetails(AdvisorReportLocationDetails reportLocationDetails) {
+            this.reportLocationDetails = reportLocationDetails;
+            this.__explicitlySet__.add("reportLocationDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("result")
+        private AdvisorResults result;
+
+        public Builder result(AdvisorResults result) {
+            this.result = result;
+            this.__explicitlySet__.add("result");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("numberOfFatal")
+        private Integer numberOfFatal;
+
+        public Builder numberOfFatal(Integer numberOfFatal) {
+            this.numberOfFatal = numberOfFatal;
+            this.__explicitlySet__.add("numberOfFatal");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("numberOfFatalBlockers")
+        private Integer numberOfFatalBlockers;
+
+        public Builder numberOfFatalBlockers(Integer numberOfFatalBlockers) {
+            this.numberOfFatalBlockers = numberOfFatalBlockers;
+            this.__explicitlySet__.add("numberOfFatalBlockers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("numberOfWarnings")
+        private Integer numberOfWarnings;
+
+        public Builder numberOfWarnings(Integer numberOfWarnings) {
+            this.numberOfWarnings = numberOfWarnings;
+            this.__explicitlySet__.add("numberOfWarnings");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("numberOfInformationalResults")
+        private Integer numberOfInformationalResults;
+
+        public Builder numberOfInformationalResults(Integer numberOfInformationalResults) {
+            this.numberOfInformationalResults = numberOfInformationalResults;
+            this.__explicitlySet__.add("numberOfInformationalResults");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AdvisorReport build() {
+            AdvisorReport __instance__ =
+                    new AdvisorReport(
+                            reportLocationDetails,
+                            result,
+                            numberOfFatal,
+                            numberOfFatalBlockers,
+                            numberOfWarnings,
+                            numberOfInformationalResults);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AdvisorReport o) {
+            Builder copiedBuilder =
+                    reportLocationDetails(o.getReportLocationDetails())
+                            .result(o.getResult())
+                            .numberOfFatal(o.getNumberOfFatal())
+                            .numberOfFatalBlockers(o.getNumberOfFatalBlockers())
+                            .numberOfWarnings(o.getNumberOfWarnings())
+                            .numberOfInformationalResults(o.getNumberOfInformationalResults());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("reportLocationDetails")
+    AdvisorReportLocationDetails reportLocationDetails;
+
+    /**
+     * Pre-Migration advisor result.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("result")
+    AdvisorResults result;
+
+    /**
+     * Number of Fatal results in the advisor report.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("numberOfFatal")
+    Integer numberOfFatal;
+
+    /**
+     * Number of Fatal Blocker results in the advisor report.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("numberOfFatalBlockers")
+    Integer numberOfFatalBlockers;
+
+    /**
+     * Number of Warning results in the advisor report.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("numberOfWarnings")
+    Integer numberOfWarnings;
+
+    /**
+     * Number of Informational results in the advisor report.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("numberOfInformationalResults")
+    Integer numberOfInformationalResults;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorReportBucketDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorReportBucketDetails.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Details to access Pre-Migration Advisor report in the specified Object Storage bucket, if any.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AdvisorReportBucketDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AdvisorReportBucketDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("bucketName")
+        private String bucketName;
+
+        public Builder bucketName(String bucketName) {
+            this.bucketName = bucketName;
+            this.__explicitlySet__.add("bucketName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectName")
+        private String objectName;
+
+        public Builder objectName(String objectName) {
+            this.objectName = objectName;
+            this.__explicitlySet__.add("objectName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AdvisorReportBucketDetails build() {
+            AdvisorReportBucketDetails __instance__ =
+                    new AdvisorReportBucketDetails(bucketName, namespace, objectName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AdvisorReportBucketDetails o) {
+            Builder copiedBuilder =
+                    bucketName(o.getBucketName())
+                            .namespace(o.getNamespace())
+                            .objectName(o.getObjectName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Name of the bucket containing the Pre-Migration Advisor report.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bucketName")
+    String bucketName;
+
+    /**
+     * Object Storage namespace.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    /**
+     * Pre-Migration Advisor report object name.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectName")
+    String objectName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorReportLocationDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorReportLocationDetails.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Details to access Pre-Migration Advisor report.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AdvisorReportLocationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AdvisorReportLocationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStorageDetails")
+        private AdvisorReportBucketDetails objectStorageDetails;
+
+        public Builder objectStorageDetails(AdvisorReportBucketDetails objectStorageDetails) {
+            this.objectStorageDetails = objectStorageDetails;
+            this.__explicitlySet__.add("objectStorageDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("locationInSource")
+        private String locationInSource;
+
+        public Builder locationInSource(String locationInSource) {
+            this.locationInSource = locationInSource;
+            this.__explicitlySet__.add("locationInSource");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AdvisorReportLocationDetails build() {
+            AdvisorReportLocationDetails __instance__ =
+                    new AdvisorReportLocationDetails(objectStorageDetails, locationInSource);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AdvisorReportLocationDetails o) {
+            Builder copiedBuilder =
+                    objectStorageDetails(o.getObjectStorageDetails())
+                            .locationInSource(o.getLocationInSource());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStorageDetails")
+    AdvisorReportBucketDetails objectStorageDetails;
+
+    /**
+     * Path in the Source Registered Connection where the Pre-Migration advisor report can be accessed.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("locationInSource")
+    String locationInSource;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorResults.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorResults.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Pre-Migration advisor result.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public enum AdvisorResults {
+    Fatal("FATAL"),
+    Blocker("BLOCKER"),
+    Warning("WARNING"),
+    Informational("INFORMATIONAL"),
+    Pass("PASS"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, AdvisorResults> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (AdvisorResults v : AdvisorResults.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    AdvisorResults(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static AdvisorResults create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'AdvisorResults', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AdvisorSettings.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional Pre-Migration advisor settings.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AdvisorSettings.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AdvisorSettings {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isSkipAdvisor")
+        private Boolean isSkipAdvisor;
+
+        public Builder isSkipAdvisor(Boolean isSkipAdvisor) {
+            this.isSkipAdvisor = isSkipAdvisor;
+            this.__explicitlySet__.add("isSkipAdvisor");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isIgnoreErrors")
+        private Boolean isIgnoreErrors;
+
+        public Builder isIgnoreErrors(Boolean isIgnoreErrors) {
+            this.isIgnoreErrors = isIgnoreErrors;
+            this.__explicitlySet__.add("isIgnoreErrors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AdvisorSettings build() {
+            AdvisorSettings __instance__ = new AdvisorSettings(isSkipAdvisor, isIgnoreErrors);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AdvisorSettings o) {
+            Builder copiedBuilder =
+                    isSkipAdvisor(o.getIsSkipAdvisor()).isIgnoreErrors(o.getIsIgnoreErrors());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * True to skip the Pre-Migration Advisor execution. Default is false.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSkipAdvisor")
+    Boolean isSkipAdvisor;
+
+    /**
+     * True to not interrupt migration execution due to Pre-Migration Advisor errors. Default is false.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isIgnoreErrors")
+    Boolean isIgnoreErrors;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Agent.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Agent.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * ODMS Agent Details
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Agent.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of an Agent search. Contains AgentSummary items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AgentCollection.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentImageCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentImageCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of an ODMS Agent Image search. Contains AgentImageSummary items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentImageSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentImageSummary.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Available ODMS Agent Images.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AgentSummary.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * ODMS Agent Details
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AgentSummary.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ChangeAgentCompartmentDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ChangeAgentCompartmentDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Change Agent compartment details
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ChangeConnectionCompartmentDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ChangeConnectionCompartmentDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Change Database Connection compartment details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ChangeMigrationCompartmentDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ChangeMigrationCompartmentDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Change Migration compartment details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CloneMigrationDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CloneMigrationDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details that will override an existing Migration configuration that will be cloned.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -92,6 +91,15 @@ public class CloneMigrationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("includeObjects")
+        private java.util.List<DatabaseObject> includeObjects;
+
+        public Builder includeObjects(java.util.List<DatabaseObject> includeObjects) {
+            this.includeObjects = includeObjects;
+            this.__explicitlySet__.add("includeObjects");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("vaultDetails")
         private CreateVaultDetails vaultDetails;
 
@@ -133,6 +141,7 @@ public class CloneMigrationDetails {
                             sourceContainerDatabaseConnectionId,
                             targetDatabaseConnectionId,
                             excludeObjects,
+                            includeObjects,
                             vaultDetails,
                             freeformTags,
                             definedTags);
@@ -151,6 +160,7 @@ public class CloneMigrationDetails {
                                     o.getSourceContainerDatabaseConnectionId())
                             .targetDatabaseConnectionId(o.getTargetDatabaseConnectionId())
                             .excludeObjects(o.getExcludeObjects())
+                            .includeObjects(o.getIncludeObjects())
                             .vaultDetails(o.getVaultDetails())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
@@ -211,11 +221,18 @@ public class CloneMigrationDetails {
     String targetDatabaseConnectionId;
 
     /**
-     * Database objects to exclude from migration.
+     * Database objects to exclude from migration, cannot be specified alongside 'includeObjects'
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("excludeObjects")
     java.util.List<DatabaseObject> excludeObjects;
+
+    /**
+     * Database objects to include from migration, cannot be specified alongside 'excludeObjects'
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("includeObjects")
+    java.util.List<DatabaseObject> includeObjects;
 
     @com.fasterxml.jackson.annotation.JsonProperty("vaultDetails")
     CreateVaultDetails vaultDetails;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ConnectDescriptor.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ConnectDescriptor.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Connect Descriptor details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Connection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Connection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Database Connection resource used for migrations.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Connection.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ConnectionCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ConnectionCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of a Database Connection search. Contains DatabaseConnectionSummary items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ConnectionSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ConnectionSummary.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Database Connection Summary.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAdminCredentials.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAdminCredentials.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Database Administrator Credentials details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAdvisorSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAdvisorSettings.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional Pre-Migration advisor settings.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateAdvisorSettings.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateAdvisorSettings {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isSkipAdvisor")
+        private Boolean isSkipAdvisor;
+
+        public Builder isSkipAdvisor(Boolean isSkipAdvisor) {
+            this.isSkipAdvisor = isSkipAdvisor;
+            this.__explicitlySet__.add("isSkipAdvisor");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isIgnoreErrors")
+        private Boolean isIgnoreErrors;
+
+        public Builder isIgnoreErrors(Boolean isIgnoreErrors) {
+            this.isIgnoreErrors = isIgnoreErrors;
+            this.__explicitlySet__.add("isIgnoreErrors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateAdvisorSettings build() {
+            CreateAdvisorSettings __instance__ =
+                    new CreateAdvisorSettings(isSkipAdvisor, isIgnoreErrors);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateAdvisorSettings o) {
+            Builder copiedBuilder =
+                    isSkipAdvisor(o.getIsSkipAdvisor()).isIgnoreErrors(o.getIsIgnoreErrors());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * True to skip the Pre-Migration Advisor execution. Default is false.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSkipAdvisor")
+    Boolean isSkipAdvisor;
+
+    /**
+     * True to not interrupt migration execution due to Pre-Migration Advisor errors. Default is false.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isIgnoreErrors")
+    Boolean isIgnoreErrors;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAgentDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAgentDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * ODMS Agent Details
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateConnectDescriptor.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateConnectDescriptor.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Connect Descriptor details. Required for Manual and UserManagerOci connection types.
  * If a Private Endpoint was specified for the Connection, the host should contain a valid IP address.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateConnectionDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateConnectionDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details to create a Database Connection resource.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateCurlTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateCurlTransferDetails.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional properties for Curl-based dump transfer in source or target host.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateCurlTransferDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateCurlTransferDetails extends CreateHostDumpTransferDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateCurlTransferDetails build() {
+            CreateCurlTransferDetails __instance__ = new CreateCurlTransferDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateCurlTransferDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateCurlTransferDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpParameters.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpParameters.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional parameters for Data Pump Export and Import. Refer to [Configuring Optional Initial Load Advanced Settings](https://docs.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED)
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpSettings.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional settings for Data Pump Export and Import jobs
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataTransferMediumDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataTransferMediumDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Data Transfer Medium details for the Migration. If not specified, it will default to Database Link. Only one type
  * of data transfer medium can be specified.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDatabaseLinkDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDatabaseLinkDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional details for creating a network database link from OCI database to on-premise database.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -37,18 +36,28 @@ public class CreateDatabaseLinkDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletBucket")
+        private CreateObjectStoreBucket walletBucket;
+
+        public Builder walletBucket(CreateObjectStoreBucket walletBucket) {
+            this.walletBucket = walletBucket;
+            this.__explicitlySet__.add("walletBucket");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateDatabaseLinkDetails build() {
-            CreateDatabaseLinkDetails __instance__ = new CreateDatabaseLinkDetails(name);
+            CreateDatabaseLinkDetails __instance__ =
+                    new CreateDatabaseLinkDetails(name, walletBucket);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(CreateDatabaseLinkDetails o) {
-            Builder copiedBuilder = name(o.getName());
+            Builder copiedBuilder = name(o.getName()).walletBucket(o.getWalletBucket());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -68,6 +77,9 @@ public class CreateDatabaseLinkDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletBucket")
+    CreateObjectStoreBucket walletBucket;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDirectoryObject.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDirectoryObject.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Directory object details, used to define either import or export directory objects in Data Pump Settings.
  * Import directory is required for Non-Autonomous target connections. If specified for an autonomous target, it will show an error.
  * Export directory will error if there are database link details specified.
@@ -18,7 +17,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDumpTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDumpTransferDetails.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional additional properties for dump transfer.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateDumpTransferDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateDumpTransferDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private CreateHostDumpTransferDetails source;
+
+        public Builder source(CreateHostDumpTransferDetails source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private CreateHostDumpTransferDetails target;
+
+        public Builder target(CreateHostDumpTransferDetails target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateDumpTransferDetails build() {
+            CreateDumpTransferDetails __instance__ = new CreateDumpTransferDetails(source, target);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateDumpTransferDetails o) {
+            Builder copiedBuilder = source(o.getSource()).target(o.getTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("source")
+    CreateHostDumpTransferDetails source;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    CreateHostDumpTransferDetails target;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateExtract.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateExtract.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Parameters for GoldenGate Extract processes.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = CreateExtract.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details about Oracle GoldenGate Microservices. Required for online logical migration.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateHub.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateHub.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details about Oracle GoldenGate Microservices. Required for online logical migration.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateGoldenGateSettings.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional settings for GoldenGate Microservices processes
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateHostDumpTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateHostDumpTransferDetails.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional additional properties for dump transfer in source or target host. Default kind is CURL
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind",
+    defaultImpl = CreateHostDumpTransferDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateOciCliDumpTransferDetails.class,
+        name = "OCI_CLI"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateCurlTransferDetails.class,
+        name = "CURL"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateHostDumpTransferDetails {
+
+    /**
+     * Type of dump transfer to use during migration in source or target host. Default kind is CURL
+     *
+     **/
+    public enum Kind {
+        Curl("CURL"),
+        OciCli("OCI_CLI"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Kind> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Kind v : Kind.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Kind(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Kind create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Kind: " + key);
+        }
+    };
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateMigrationDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateMigrationDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Create Migration resource parameters.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -102,6 +101,15 @@ public class CreateMigrationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dumpTransferDetails")
+        private CreateDumpTransferDetails dumpTransferDetails;
+
+        public Builder dumpTransferDetails(CreateDumpTransferDetails dumpTransferDetails) {
+            this.dumpTransferDetails = dumpTransferDetails;
+            this.__explicitlySet__.add("dumpTransferDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("datapumpSettings")
         private CreateDataPumpSettings datapumpSettings;
 
@@ -111,12 +119,30 @@ public class CreateMigrationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("advisorSettings")
+        private CreateAdvisorSettings advisorSettings;
+
+        public Builder advisorSettings(CreateAdvisorSettings advisorSettings) {
+            this.advisorSettings = advisorSettings;
+            this.__explicitlySet__.add("advisorSettings");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("excludeObjects")
         private java.util.List<DatabaseObject> excludeObjects;
 
         public Builder excludeObjects(java.util.List<DatabaseObject> excludeObjects) {
             this.excludeObjects = excludeObjects;
             this.__explicitlySet__.add("excludeObjects");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("includeObjects")
+        private java.util.List<DatabaseObject> includeObjects;
+
+        public Builder includeObjects(java.util.List<DatabaseObject> includeObjects) {
+            this.includeObjects = includeObjects;
+            this.__explicitlySet__.add("includeObjects");
             return this;
         }
 
@@ -171,8 +197,11 @@ public class CreateMigrationDetails {
                             sourceContainerDatabaseConnectionId,
                             targetDatabaseConnectionId,
                             dataTransferMediumDetails,
+                            dumpTransferDetails,
                             datapumpSettings,
+                            advisorSettings,
                             excludeObjects,
+                            includeObjects,
                             goldenGateDetails,
                             vaultDetails,
                             freeformTags,
@@ -193,8 +222,11 @@ public class CreateMigrationDetails {
                                     o.getSourceContainerDatabaseConnectionId())
                             .targetDatabaseConnectionId(o.getTargetDatabaseConnectionId())
                             .dataTransferMediumDetails(o.getDataTransferMediumDetails())
+                            .dumpTransferDetails(o.getDumpTransferDetails())
                             .datapumpSettings(o.getDatapumpSettings())
+                            .advisorSettings(o.getAdvisorSettings())
                             .excludeObjects(o.getExcludeObjects())
+                            .includeObjects(o.getIncludeObjects())
                             .goldenGateDetails(o.getGoldenGateDetails())
                             .vaultDetails(o.getVaultDetails())
                             .freeformTags(o.getFreeformTags())
@@ -265,15 +297,28 @@ public class CreateMigrationDetails {
     @com.fasterxml.jackson.annotation.JsonProperty("dataTransferMediumDetails")
     CreateDataTransferMediumDetails dataTransferMediumDetails;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("dumpTransferDetails")
+    CreateDumpTransferDetails dumpTransferDetails;
+
     @com.fasterxml.jackson.annotation.JsonProperty("datapumpSettings")
     CreateDataPumpSettings datapumpSettings;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("advisorSettings")
+    CreateAdvisorSettings advisorSettings;
+
     /**
-     * Database objects to exclude from migration.
+     * Database objects to exclude from migration, cannot be specified alongside 'includeObjects'
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("excludeObjects")
     java.util.List<DatabaseObject> excludeObjects;
+
+    /**
+     * Database objects to include from migration, cannot be specified alongside 'excludeObjects'
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("includeObjects")
+    java.util.List<DatabaseObject> includeObjects;
 
     @com.fasterxml.jackson.annotation.JsonProperty("goldenGateDetails")
     CreateGoldenGateDetails goldenGateDetails;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateObjectStoreBucket.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateObjectStoreBucket.java
@@ -5,8 +5,8 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * In lieu of a network database link, OCI Object Storage bucket will be used to store Data Pump dump files for the migration.
+ * Additionally, it can be specified alongside a database link data transfer medium.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -16,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateOciCliDumpTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateOciCliDumpTransferDetails.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional dump transfer details for OCI-CLI-based dump transfer in source or target host.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateOciCliDumpTransferDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateOciCliDumpTransferDetails extends CreateHostDumpTransferDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("ociHome")
+        private String ociHome;
+
+        public Builder ociHome(String ociHome) {
+            this.ociHome = ociHome;
+            this.__explicitlySet__.add("ociHome");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateOciCliDumpTransferDetails build() {
+            CreateOciCliDumpTransferDetails __instance__ =
+                    new CreateOciCliDumpTransferDetails(ociHome);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateOciCliDumpTransferDetails o) {
+            Builder copiedBuilder = ociHome(o.getOciHome());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateOciCliDumpTransferDetails(String ociHome) {
+        super();
+        this.ociHome = ociHome;
+    }
+
+    /**
+     * Path to the OCI CLI installation in the node.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ociHome")
+    String ociHome;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreatePrivateEndpoint.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreatePrivateEndpoint.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * OCI Private Endpoint configuration details.
  * Not required for source container database connections, it will default to the specified Source Database Connection Private Endpoint.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateReplicat.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateReplicat.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Parameters for GoldenGate Replicat processes.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = CreateReplicat.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateSshDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateSshDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details of the SSH key that will be used. Required for source database Manual and UserManagerOci connection types.
  * Not required for source container database connections.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = CreateSshDetails.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateVaultDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateVaultDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * OCI Vault details to store migration and connection credentials secrets
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CurlTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CurlTransferDetails.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional properties for Curl-based dump transfer in source or target host.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CurlTransferDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CurlTransferDetails extends HostDumpTransferDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CurlTransferDetails build() {
+            CurlTransferDetails __instance__ = new CurlTransferDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CurlTransferDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CurlTransferDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpEstimate.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpEstimate.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Estimate size of dumps that will be generated.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum DataPumpEstimate {
     Blocks("BLOCKS"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpExcludeParameters.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpExcludeParameters.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Supported Import/Export exclude parameters
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 public enum DataPumpExcludeParameters {
     Index("INDEX"),
     MaterializedView("MATERIALIZED_VIEW"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpJobMode.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpJobMode.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Data Pump job modes
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum DataPumpJobMode {
     Full("FULL"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpParameters.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpParameters.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional parameters for Data Pump Export and Import. Refer to [Configuring Optional Initial Load Advanced Settings](https://docs.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED)
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpSettings.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional settings for Data Pump Export and Import jobs
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DataPumpSettings.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpTableExistsAction.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpTableExistsAction.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * IMPORT: Specifies the action to be performed when data is loaded into a preexisting table.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum DataPumpTableExistsAction {
     Truncate("TRUNCATE"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataTransferMediumDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataTransferMediumDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Data Transfer Medium details for the Migration.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DatabaseConnectionTypes.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DatabaseConnectionTypes.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Supported database connection types
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum DatabaseConnectionTypes {
     Manual("MANUAL"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DatabaseLinkDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DatabaseLinkDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional details for creating a network database link from OCI database to on-premise database.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -37,18 +36,27 @@ public class DatabaseLinkDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletBucket")
+        private ObjectStoreBucket walletBucket;
+
+        public Builder walletBucket(ObjectStoreBucket walletBucket) {
+            this.walletBucket = walletBucket;
+            this.__explicitlySet__.add("walletBucket");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public DatabaseLinkDetails build() {
-            DatabaseLinkDetails __instance__ = new DatabaseLinkDetails(name);
+            DatabaseLinkDetails __instance__ = new DatabaseLinkDetails(name, walletBucket);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DatabaseLinkDetails o) {
-            Builder copiedBuilder = name(o.getName());
+            Builder copiedBuilder = name(o.getName()).walletBucket(o.getWalletBucket());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -68,6 +76,9 @@ public class DatabaseLinkDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletBucket")
+    ObjectStoreBucket walletBucket;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DatabaseObject.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DatabaseObject.java
@@ -5,8 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
- * Database objects to exclude from migration
+ * Database objects to include or exclude from migration
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DatabaseObject.Builder.class)
@@ -44,18 +43,28 @@ public class DatabaseObject {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private String type;
+
+        public Builder type(String type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public DatabaseObject build() {
-            DatabaseObject __instance__ = new DatabaseObject(owner, objectName);
+            DatabaseObject __instance__ = new DatabaseObject(owner, objectName, type);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(DatabaseObject o) {
-            Builder copiedBuilder = owner(o.getOwner()).objectName(o.getObjectName());
+            Builder copiedBuilder =
+                    owner(o.getOwner()).objectName(o.getObjectName()).type(o.getType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -82,6 +91,14 @@ public class DatabaseObject {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("objectName")
     String objectName;
+
+    /**
+     * Type of object to exclude.
+     * If not specified, matching owners and object names of type TABLE would be excluded.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    String type;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DirectoryObject.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DirectoryObject.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Directory object details, used to define either import or export directory objects in Data Pump Settings.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DirectoryObject.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DumpTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DumpTransferDetails.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional additional properties for dump transfer.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DumpTransferDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DumpTransferDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private HostDumpTransferDetails source;
+
+        public Builder source(HostDumpTransferDetails source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private HostDumpTransferDetails target;
+
+        public Builder target(HostDumpTransferDetails target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DumpTransferDetails build() {
+            DumpTransferDetails __instance__ = new DumpTransferDetails(source, target);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DumpTransferDetails o) {
+            Builder copiedBuilder = source(o.getSource()).target(o.getTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("source")
+    HostDumpTransferDetails source;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    HostDumpTransferDetails target;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Extract.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Extract.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Parameters for Extract processes.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Extract.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExtractPerformanceProfile.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExtractPerformanceProfile.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * GoldenGate Extract perfoemance profile
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum ExtractPerformanceProfile {
     Low("LOW"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GenerateToken.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GenerateToken.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * ODMS Agent token details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = GenerateToken.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GoldenGateDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GoldenGateDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details about Oracle GoldenGate Microservices.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GoldenGateHub.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GoldenGateHub.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details about Oracle GoldenGate Microservices.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = GoldenGateHub.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GoldenGateSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/GoldenGateSettings.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional settings for Oracle GoldenGate processes
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/HostDumpTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/HostDumpTransferDetails.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional additional properties for dump transfer in source or target host. Default kind is CURL
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind",
+    defaultImpl = HostDumpTransferDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = OciCliDumpTransferDetails.class,
+        name = "OCI_CLI"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CurlTransferDetails.class,
+        name = "CURL"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class HostDumpTransferDetails {
+
+    /**
+     * Type of dump transfer to use during migration in source or target host. Default kind is CURL
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Kind {
+        Curl("CURL"),
+        OciCli("OCI_CLI"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Kind> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Kind v : Kind.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Kind(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Kind create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Kind', returning UnknownEnumValue", key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Job.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Job.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of a Database Connection search. Contains DatabaseConnectionSummary items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Job.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of a Job search. Contains JobSummary items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JobCollection.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobLifecycleStates.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobLifecycleStates.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Possible lifecycle states.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum JobLifecycleStates {
     Accepted("ACCEPTED"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobOutputSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobOutputSummary.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Job output summary line.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JobOutputSummary.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobOutputSummaryCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobOutputSummaryCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of a Job output listing. Contains JobOutputSummary items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobPhaseStatus.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobPhaseStatus.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Job Phase status.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum JobPhaseStatus {
     Pending("PENDING"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobSummary.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Job description
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JobSummary.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobTypes.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/JobTypes.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Job type.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum JobTypes {
     Evaluation("EVALUATION"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/LifecycleStates.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/LifecycleStates.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Possible lifecycle states.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum LifecycleStates {
     Creating("CREATING"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/LogLocationBucketDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/LogLocationBucketDetails.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Details to access log file in the specified Object Storage bucket, if any.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LogLocationBucketDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LogLocationBucketDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("bucketName")
+        private String bucketName;
+
+        public Builder bucketName(String bucketName) {
+            this.bucketName = bucketName;
+            this.__explicitlySet__.add("bucketName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectName")
+        private String objectName;
+
+        public Builder objectName(String objectName) {
+            this.objectName = objectName;
+            this.__explicitlySet__.add("objectName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LogLocationBucketDetails build() {
+            LogLocationBucketDetails __instance__ =
+                    new LogLocationBucketDetails(bucketName, namespace, objectName);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LogLocationBucketDetails o) {
+            Builder copiedBuilder =
+                    bucketName(o.getBucketName())
+                            .namespace(o.getNamespace())
+                            .objectName(o.getObjectName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Name of the bucket containing the log file.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bucketName")
+    String bucketName;
+
+    /**
+     * Object Storage namespace.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    /**
+     * Log object name.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectName")
+    String objectName;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MetadataRemap.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MetadataRemap.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Defines remapping to be applied to objects as they are processed.
  * Refer to [METADATA_REMAP Procedure ](https://docs.oracle.com/en/database/oracle/oracle-database/19/arpls/DBMS_DATAPUMP.html#GUID-0FC32790-91E6-4781-87A3-229DE024CB3D)
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = MetadataRemap.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Migration.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Migration.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Migration resource
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Migration.Builder.class)
@@ -136,6 +135,15 @@ public class Migration {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dumpTransferDetails")
+        private DumpTransferDetails dumpTransferDetails;
+
+        public Builder dumpTransferDetails(DumpTransferDetails dumpTransferDetails) {
+            this.dumpTransferDetails = dumpTransferDetails;
+            this.__explicitlySet__.add("dumpTransferDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("datapumpSettings")
         private DataPumpSettings datapumpSettings;
 
@@ -145,12 +153,30 @@ public class Migration {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("advisorSettings")
+        private AdvisorSettings advisorSettings;
+
+        public Builder advisorSettings(AdvisorSettings advisorSettings) {
+            this.advisorSettings = advisorSettings;
+            this.__explicitlySet__.add("advisorSettings");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("excludeObjects")
         private java.util.List<DatabaseObject> excludeObjects;
 
         public Builder excludeObjects(java.util.List<DatabaseObject> excludeObjects) {
             this.excludeObjects = excludeObjects;
             this.__explicitlySet__.add("excludeObjects");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("includeObjects")
+        private java.util.List<DatabaseObject> includeObjects;
+
+        public Builder includeObjects(java.util.List<DatabaseObject> includeObjects) {
+            this.includeObjects = includeObjects;
+            this.__explicitlySet__.add("includeObjects");
             return this;
         }
 
@@ -200,9 +226,9 @@ public class Migration {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-        private LifecycleStates lifecycleState;
+        private MigrationLifecycleStates lifecycleState;
 
-        public Builder lifecycleState(LifecycleStates lifecycleState) {
+        public Builder lifecycleState(MigrationLifecycleStates lifecycleState) {
             this.lifecycleState = lifecycleState;
             this.__explicitlySet__.add("lifecycleState");
             return this;
@@ -263,8 +289,11 @@ public class Migration {
                             targetDatabaseConnectionId,
                             executingJobId,
                             dataTransferMediumDetails,
+                            dumpTransferDetails,
                             datapumpSettings,
+                            advisorSettings,
                             excludeObjects,
+                            includeObjects,
                             goldenGateDetails,
                             vaultDetails,
                             timeCreated,
@@ -295,8 +324,11 @@ public class Migration {
                             .targetDatabaseConnectionId(o.getTargetDatabaseConnectionId())
                             .executingJobId(o.getExecutingJobId())
                             .dataTransferMediumDetails(o.getDataTransferMediumDetails())
+                            .dumpTransferDetails(o.getDumpTransferDetails())
                             .datapumpSettings(o.getDatapumpSettings())
+                            .advisorSettings(o.getAdvisorSettings())
                             .excludeObjects(o.getExcludeObjects())
+                            .includeObjects(o.getIncludeObjects())
                             .goldenGateDetails(o.getGoldenGateDetails())
                             .vaultDetails(o.getVaultDetails())
                             .timeCreated(o.getTimeCreated())
@@ -401,15 +433,29 @@ public class Migration {
     @com.fasterxml.jackson.annotation.JsonProperty("dataTransferMediumDetails")
     DataTransferMediumDetails dataTransferMediumDetails;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("dumpTransferDetails")
+    DumpTransferDetails dumpTransferDetails;
+
     @com.fasterxml.jackson.annotation.JsonProperty("datapumpSettings")
     DataPumpSettings datapumpSettings;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("advisorSettings")
+    AdvisorSettings advisorSettings;
+
     /**
      * Database objects to exclude from migration.
+     * If 'includeObjects' are specified, only exclude object types can be specified with general wildcards (.*) for owner and objectName.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("excludeObjects")
     java.util.List<DatabaseObject> excludeObjects;
+
+    /**
+     * Database objects to include from migration.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("includeObjects")
+    java.util.List<DatabaseObject> includeObjects;
 
     @com.fasterxml.jackson.annotation.JsonProperty("goldenGateDetails")
     GoldenGateDetails goldenGateDetails;
@@ -443,7 +489,7 @@ public class Migration {
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-    LifecycleStates lifecycleState;
+    MigrationLifecycleStates lifecycleState;
 
     /**
      * Additional status related to the execution and current state of the Migration.

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of a Migration search. Contains MigrationSummary items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationJobProgressResource.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationJobProgressResource.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Progress details of a Migration Job.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationJobProgressSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationJobProgressSummary.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Summary of the progress of a Migration Job.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationLifecycleStates.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationLifecycleStates.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Possible Migration lifecycle states.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public enum MigrationLifecycleStates {
+    Creating("CREATING"),
+    Updating("UPDATING"),
+    Active("ACTIVE"),
+    InProgress("IN_PROGRESS"),
+    Accepted("ACCEPTED"),
+    Succeeded("SUCCEEDED"),
+    Canceled("CANCELED"),
+    Waiting("WAITING"),
+    NeedsAttention("NEEDS_ATTENTION"),
+    Inactive("INACTIVE"),
+    Deleting("DELETING"),
+    Deleted("DELETED"),
+    Failed("FAILED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, MigrationLifecycleStates> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (MigrationLifecycleStates v : MigrationLifecycleStates.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    MigrationLifecycleStates(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static MigrationLifecycleStates create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'MigrationLifecycleStates', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationObjectTypeSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationObjectTypeSummary.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration Object Type
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = MigrationObjectTypeSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MigrationObjectTypeSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MigrationObjectTypeSummary build() {
+            MigrationObjectTypeSummary __instance__ = new MigrationObjectTypeSummary(name);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MigrationObjectTypeSummary o) {
+            Builder copiedBuilder = name(o.getName());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Object type name
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationObjectTypeSummaryCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationObjectTypeSummaryCollection.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Results of a Migration Object Type listing. Contains MigrationObjectTypeSummary items.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = MigrationObjectTypeSummaryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MigrationObjectTypeSummaryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<MigrationObjectTypeSummary> items;
+
+        public Builder items(java.util.List<MigrationObjectTypeSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MigrationObjectTypeSummaryCollection build() {
+            MigrationObjectTypeSummaryCollection __instance__ =
+                    new MigrationObjectTypeSummaryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MigrationObjectTypeSummaryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Items in collection.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<MigrationObjectTypeSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationPhaseCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationPhaseCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of a Migration Phase search. Contains a collection of valid ODMS Job Phases.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationPhaseSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationPhaseSummary.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Migration Phase Summary of details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationStatus.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationStatus.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Possible Migration status.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum MigrationStatus {
     Ready("READY"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationSummary.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Migration resource
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = MigrationSummary.Builder.class)
@@ -145,9 +144,9 @@ public class MigrationSummary {
         }
 
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-        private LifecycleStates lifecycleState;
+        private MigrationLifecycleStates lifecycleState;
 
-        public Builder lifecycleState(LifecycleStates lifecycleState) {
+        public Builder lifecycleState(MigrationLifecycleStates lifecycleState) {
             this.lifecycleState = lifecycleState;
             this.__explicitlySet__.add("lifecycleState");
             return this;
@@ -345,7 +344,7 @@ public class MigrationSummary {
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
-    LifecycleStates lifecycleState;
+    MigrationLifecycleStates lifecycleState;
 
     /**
      * Additional status related to the execution and current state of the Migration.

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationTypes.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationTypes.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Supported Migration types.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum MigrationTypes {
     Online("ONLINE"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ObjectStoreBucket.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ObjectStoreBucket.java
@@ -5,8 +5,8 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * In lieu of a network database link, OCI Object Storage bucket will be used to store Data Pump dump files for the migration.
+ * Additionally, it can be specified alongside a database link data transfer medium.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -16,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OciCliDumpTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OciCliDumpTransferDetails.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional dump transfer details for OCI-CLI-based dump transfer in source or target host.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = OciCliDumpTransferDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class OciCliDumpTransferDetails extends HostDumpTransferDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("ociHome")
+        private String ociHome;
+
+        public Builder ociHome(String ociHome) {
+            this.ociHome = ociHome;
+            this.__explicitlySet__.add("ociHome");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public OciCliDumpTransferDetails build() {
+            OciCliDumpTransferDetails __instance__ = new OciCliDumpTransferDetails(ociHome);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(OciCliDumpTransferDetails o) {
+            Builder copiedBuilder = ociHome(o.getOciHome());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public OciCliDumpTransferDetails(String ociHome) {
+        super();
+        this.ociHome = ociHome;
+    }
+
+    /**
+     * Path to the OCI CLI installation in the node.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ociHome")
+    String ociHome;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OdmsJobPhases.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OdmsJobPhases.java
@@ -5,19 +5,21 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Possible ODMS Job Phases.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum OdmsJobPhases {
     OdmsValidateTgt("ODMS_VALIDATE_TGT"),
     OdmsValidateSrc("ODMS_VALIDATE_SRC"),
+    OdmsValidatePremigrationAdvisor("ODMS_VALIDATE_PREMIGRATION_ADVISOR"),
     OdmsValidateGgHub("ODMS_VALIDATE_GG_HUB"),
     OdmsValidateDatapumpSettings("ODMS_VALIDATE_DATAPUMP_SETTINGS"),
     OdmsValidateDatapumpSettingsSrc("ODMS_VALIDATE_DATAPUMP_SETTINGS_SRC"),
     OdmsValidateDatapumpSettingsTgt("ODMS_VALIDATE_DATAPUMP_SETTINGS_TGT"),
+    OdmsValidateDatapumpSrc("ODMS_VALIDATE_DATAPUMP_SRC"),
+    OdmsValidateDatapumpEstimateSrc("ODMS_VALIDATE_DATAPUMP_ESTIMATE_SRC"),
     OdmsValidate("ODMS_VALIDATE"),
     OdmsPrepare("ODMS_PREPARE"),
     OdmsInitialLoadExport("ODMS_INITIAL_LOAD_EXPORT"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OdmsPhaseActions.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OdmsPhaseActions.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Possible ODMS Job Phase actions.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum OdmsPhaseActions {
     Wait("WAIT"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OperationStatus.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OperationStatus.java
@@ -5,15 +5,15 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Possible operation status.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum OperationStatus {
     Accepted("ACCEPTED"),
     InProgress("IN_PROGRESS"),
+    Waiting("WAITING"),
     Failed("FAILED"),
     Succeeded("SUCCEEDED"),
     Canceling("CANCELING"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OperationTypes.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/OperationTypes.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Possible operation types.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.extern.slf4j.Slf4j
 public enum OperationTypes {
     CreateAgent("CREATE_AGENT"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ParLink.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ParLink.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Pre-Authenticated Request Link for ODMS Agent log use.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ParLink.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/PhaseExtractEntry.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/PhaseExtractEntry.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Job phase extract message.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PhaseExtractEntry.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PhaseExtractEntry {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private PhaseExtractTypes type;
+
+        public Builder type(PhaseExtractTypes type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("message")
+        private String message;
+
+        public Builder message(String message) {
+            this.message = message;
+            this.__explicitlySet__.add("message");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PhaseExtractEntry build() {
+            PhaseExtractEntry __instance__ = new PhaseExtractEntry(type, message);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PhaseExtractEntry o) {
+            Builder copiedBuilder = type(o.getType()).message(o.getMessage());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Type of extract.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    PhaseExtractTypes type;
+
+    /**
+     * Message in entry.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    String message;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/PhaseExtractTypes.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/PhaseExtractTypes.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Job Phase extract type.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public enum PhaseExtractTypes {
+    Error("ERROR"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, PhaseExtractTypes> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (PhaseExtractTypes v : PhaseExtractTypes.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    PhaseExtractTypes(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static PhaseExtractTypes create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'PhaseExtractTypes', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/PhaseStatus.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/PhaseStatus.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Job phase status details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = PhaseStatus.Builder.class)
@@ -53,6 +52,33 @@ public class PhaseStatus {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAdvisorReportAvailable")
+        private Boolean isAdvisorReportAvailable;
+
+        public Builder isAdvisorReportAvailable(Boolean isAdvisorReportAvailable) {
+            this.isAdvisorReportAvailable = isAdvisorReportAvailable;
+            this.__explicitlySet__.add("isAdvisorReportAvailable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("extract")
+        private java.util.List<PhaseExtractEntry> extract;
+
+        public Builder extract(java.util.List<PhaseExtractEntry> extract) {
+            this.extract = extract;
+            this.__explicitlySet__.add("extract");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("logLocation")
+        private LogLocationBucketDetails logLocation;
+
+        public Builder logLocation(LogLocationBucketDetails logLocation) {
+            this.logLocation = logLocation;
+            this.__explicitlySet__.add("logLocation");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("progress")
         private Integer progress;
 
@@ -66,7 +92,15 @@ public class PhaseStatus {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public PhaseStatus build() {
-            PhaseStatus __instance__ = new PhaseStatus(name, status, durationInMs, progress);
+            PhaseStatus __instance__ =
+                    new PhaseStatus(
+                            name,
+                            status,
+                            durationInMs,
+                            isAdvisorReportAvailable,
+                            extract,
+                            logLocation,
+                            progress);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -77,6 +111,9 @@ public class PhaseStatus {
                     name(o.getName())
                             .status(o.getStatus())
                             .durationInMs(o.getDurationInMs())
+                            .isAdvisorReportAvailable(o.getIsAdvisorReportAvailable())
+                            .extract(o.getExtract())
+                            .logLocation(o.getLogLocation())
                             .progress(o.getProgress());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -111,6 +148,23 @@ public class PhaseStatus {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("durationInMs")
     Integer durationInMs;
+
+    /**
+     * True if a Pre-Migration Advisor report is available for this phase. False or null if no report is available.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAdvisorReportAvailable")
+    Boolean isAdvisorReportAvailable;
+
+    /**
+     * Summary of phase status results.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("extract")
+    java.util.List<PhaseExtractEntry> extract;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("logLocation")
+    LogLocationBucketDetails logLocation;
 
     /**
      * Percent progress of job phase.

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/PrivateEndpointDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/PrivateEndpointDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * OCI Private Endpoint configuration details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Replicat.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Replicat.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Parameters for Replicat processes.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = Replicat.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ResumeJobDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ResumeJobDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Parameters to specify to resume a Migration Job.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ResumeJobDetails.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/SortOrders.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/SortOrders.java
@@ -5,11 +5,10 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Sort orders.
  *
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 public enum SortOrders {
     Asc("ASC"),
     Desc("DESC"),

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/SshDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/SshDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details of the SSH key that will be used.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = SshDetails.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/StartMigrationDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/StartMigrationDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Parameters to specify to a Migration job operation.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UnsupportedDatabaseObject.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UnsupportedDatabaseObject.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Database objects to exclude from migration
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAdminCredentials.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAdminCredentials.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Database Administrator Credentials details. An empty object would result in the removal of the stored details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAdvisorSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAdvisorSettings.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional Pre-Migration advisor settings.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateAdvisorSettings.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateAdvisorSettings {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isSkipAdvisor")
+        private Boolean isSkipAdvisor;
+
+        public Builder isSkipAdvisor(Boolean isSkipAdvisor) {
+            this.isSkipAdvisor = isSkipAdvisor;
+            this.__explicitlySet__.add("isSkipAdvisor");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isIgnoreErrors")
+        private Boolean isIgnoreErrors;
+
+        public Builder isIgnoreErrors(Boolean isIgnoreErrors) {
+            this.isIgnoreErrors = isIgnoreErrors;
+            this.__explicitlySet__.add("isIgnoreErrors");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateAdvisorSettings build() {
+            UpdateAdvisorSettings __instance__ =
+                    new UpdateAdvisorSettings(isSkipAdvisor, isIgnoreErrors);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateAdvisorSettings o) {
+            Builder copiedBuilder =
+                    isSkipAdvisor(o.getIsSkipAdvisor()).isIgnoreErrors(o.getIsIgnoreErrors());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * True to skip the Pre-Migration Advisor execution. Default is false.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isSkipAdvisor")
+    Boolean isSkipAdvisor;
+
+    /**
+     * True to not interrupt migration execution due to Pre-Migration Advisor errors. Default is false.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isIgnoreErrors")
+    Boolean isIgnoreErrors;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAgentDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAgentDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * ODMS Agent Details
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -28,15 +27,6 @@ public class UpdateAgentDetails {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
-        private String compartmentId;
-
-        public Builder compartmentId(String compartmentId) {
-            this.compartmentId = compartmentId;
-            this.__explicitlySet__.add("compartmentId");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("displayName")
         private String displayName;
 
@@ -98,13 +88,7 @@ public class UpdateAgentDetails {
         public UpdateAgentDetails build() {
             UpdateAgentDetails __instance__ =
                     new UpdateAgentDetails(
-                            compartmentId,
-                            displayName,
-                            streamId,
-                            publicKey,
-                            version,
-                            freeformTags,
-                            definedTags);
+                            displayName, streamId, publicKey, version, freeformTags, definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -112,8 +96,7 @@ public class UpdateAgentDetails {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateAgentDetails o) {
             Builder copiedBuilder =
-                    compartmentId(o.getCompartmentId())
-                            .displayName(o.getDisplayName())
+                    displayName(o.getDisplayName())
                             .streamId(o.getStreamId())
                             .publicKey(o.getPublicKey())
                             .version(o.getVersion())
@@ -131,13 +114,6 @@ public class UpdateAgentDetails {
     public static Builder builder() {
         return new Builder();
     }
-
-    /**
-     * The OCID of the compartment.
-     *
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
-    String compartmentId;
 
     /**
      * ODMS Agent name

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateConnectDescriptor.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateConnectDescriptor.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Connect Descriptor details. If a Private Endpoint was specified in the Connection, the host entry should be a valid IP address.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateConnectionDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateConnectionDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details to update in a Database Connection resource.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateCurlTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateCurlTransferDetails.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional properties for Curl-based dump transfer in source or target host.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateCurlTransferDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateCurlTransferDetails extends UpdateHostDumpTransferDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateCurlTransferDetails build() {
+            UpdateCurlTransferDetails __instance__ = new UpdateCurlTransferDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateCurlTransferDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateCurlTransferDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpParameters.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpParameters.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional parameters for Data Pump Export and Import. Refer to [Configuring Optional Initial Load Advanced Settings](https://docs-uat.us.oracle.com/en/cloud/paas/database-migration/dmsus/working-migration-resources.html#GUID-24BD3054-FDF8-48FF-8492-636C1D4B71ED)
  * If an empty object is specified, the stored Data Pump Parameter details will be removed.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpSettings.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional settings for Data Pump Export and Import jobs
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataTransferMediumDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataTransferMediumDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Data Transfer Medium details for the Migration.
  * Only one type of data transfer medium can be specified and will replace the stored Data Transfer Medium details.
  * If an empty object is specified, the stored Data Transfer Medium details will be removed.
@@ -18,7 +17,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDatabaseLinkDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDatabaseLinkDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional details for updating a network database link from OCI database to on-premise database.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -37,18 +36,28 @@ public class UpdateDatabaseLinkDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("walletBucket")
+        private UpdateObjectStoreBucket walletBucket;
+
+        public Builder walletBucket(UpdateObjectStoreBucket walletBucket) {
+            this.walletBucket = walletBucket;
+            this.__explicitlySet__.add("walletBucket");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateDatabaseLinkDetails build() {
-            UpdateDatabaseLinkDetails __instance__ = new UpdateDatabaseLinkDetails(name);
+            UpdateDatabaseLinkDetails __instance__ =
+                    new UpdateDatabaseLinkDetails(name, walletBucket);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateDatabaseLinkDetails o) {
-            Builder copiedBuilder = name(o.getName());
+            Builder copiedBuilder = name(o.getName()).walletBucket(o.getWalletBucket());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -68,6 +77,9 @@ public class UpdateDatabaseLinkDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("walletBucket")
+    UpdateObjectStoreBucket walletBucket;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDirectoryObject.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDirectoryObject.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Directory object details, used to define either import or export directory objects in Data Pump Settings.
  * Import directory is required for Non-Autonomous target connections. If specified for an autonomous target, it will show an error.
  * Export directory will error if there are database link details specified.
@@ -19,7 +18,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDumpTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDumpTransferDetails.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional additional properties for dump transfer.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateDumpTransferDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateDumpTransferDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("source")
+        private UpdateHostDumpTransferDetails source;
+
+        public Builder source(UpdateHostDumpTransferDetails source) {
+            this.source = source;
+            this.__explicitlySet__.add("source");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private UpdateHostDumpTransferDetails target;
+
+        public Builder target(UpdateHostDumpTransferDetails target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateDumpTransferDetails build() {
+            UpdateDumpTransferDetails __instance__ = new UpdateDumpTransferDetails(source, target);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateDumpTransferDetails o) {
+            Builder copiedBuilder = source(o.getSource()).target(o.getTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("source")
+    UpdateHostDumpTransferDetails source;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    UpdateHostDumpTransferDetails target;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateExtract.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateExtract.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Parameters for Extract processes.
  * If an empty object is specified, the stored Extract details will be removed.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = UpdateExtract.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details about Oracle GoldenGate Microservices. If an empty object is specified, the stored Golden Gate details will be removed.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateHub.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateHub.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details about Oracle GoldenGate Microservices.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateGoldenGateSettings.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Optional settings for Oracle GoldenGate processes
  * If an empty object is specified, the stored GoldenGate Settings details will be removed.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateHostDumpTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateHostDumpTransferDetails.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional additional properties for dump transfer in source or target host. Default kind is CURL
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind",
+    defaultImpl = UpdateHostDumpTransferDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateCurlTransferDetails.class,
+        name = "CURL"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateOciCliDumpTransferDetails.class,
+        name = "OCI_CLI"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateHostDumpTransferDetails {
+
+    /**
+     * Type of dump transfer to use during migration in source or target host. Default kind is CURL
+     *
+     **/
+    public enum Kind {
+        Curl("CURL"),
+        OciCli("OCI_CLI"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Kind> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Kind v : Kind.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Kind(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Kind create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Kind: " + key);
+        }
+    };
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateJobDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateJobDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Update Job Details
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = UpdateJobDetails.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateMigrationDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateMigrationDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Update Migration resource parameters.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -93,6 +92,15 @@ public class UpdateMigrationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dumpTransferDetails")
+        private UpdateDumpTransferDetails dumpTransferDetails;
+
+        public Builder dumpTransferDetails(UpdateDumpTransferDetails dumpTransferDetails) {
+            this.dumpTransferDetails = dumpTransferDetails;
+            this.__explicitlySet__.add("dumpTransferDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("datapumpSettings")
         private UpdateDataPumpSettings datapumpSettings;
 
@@ -102,12 +110,30 @@ public class UpdateMigrationDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("advisorSettings")
+        private UpdateAdvisorSettings advisorSettings;
+
+        public Builder advisorSettings(UpdateAdvisorSettings advisorSettings) {
+            this.advisorSettings = advisorSettings;
+            this.__explicitlySet__.add("advisorSettings");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("excludeObjects")
         private java.util.List<DatabaseObject> excludeObjects;
 
         public Builder excludeObjects(java.util.List<DatabaseObject> excludeObjects) {
             this.excludeObjects = excludeObjects;
             this.__explicitlySet__.add("excludeObjects");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("includeObjects")
+        private java.util.List<DatabaseObject> includeObjects;
+
+        public Builder includeObjects(java.util.List<DatabaseObject> includeObjects) {
+            this.includeObjects = includeObjects;
+            this.__explicitlySet__.add("includeObjects");
             return this;
         }
 
@@ -161,8 +187,11 @@ public class UpdateMigrationDetails {
                             sourceContainerDatabaseConnectionId,
                             targetDatabaseConnectionId,
                             dataTransferMediumDetails,
+                            dumpTransferDetails,
                             datapumpSettings,
+                            advisorSettings,
                             excludeObjects,
+                            includeObjects,
                             goldenGateDetails,
                             vaultDetails,
                             freeformTags,
@@ -182,8 +211,11 @@ public class UpdateMigrationDetails {
                                     o.getSourceContainerDatabaseConnectionId())
                             .targetDatabaseConnectionId(o.getTargetDatabaseConnectionId())
                             .dataTransferMediumDetails(o.getDataTransferMediumDetails())
+                            .dumpTransferDetails(o.getDumpTransferDetails())
                             .datapumpSettings(o.getDatapumpSettings())
+                            .advisorSettings(o.getAdvisorSettings())
                             .excludeObjects(o.getExcludeObjects())
+                            .includeObjects(o.getIncludeObjects())
                             .goldenGateDetails(o.getGoldenGateDetails())
                             .vaultDetails(o.getVaultDetails())
                             .freeformTags(o.getFreeformTags())
@@ -248,16 +280,30 @@ public class UpdateMigrationDetails {
     @com.fasterxml.jackson.annotation.JsonProperty("dataTransferMediumDetails")
     UpdateDataTransferMediumDetails dataTransferMediumDetails;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("dumpTransferDetails")
+    UpdateDumpTransferDetails dumpTransferDetails;
+
     @com.fasterxml.jackson.annotation.JsonProperty("datapumpSettings")
     UpdateDataPumpSettings datapumpSettings;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("advisorSettings")
+    UpdateAdvisorSettings advisorSettings;
+
     /**
-     * Database objects to exclude from migration.
+     * Database objects to exclude from migration, cannot be specified alongside 'includeObjects'.
      * If specified, the list will be replaced entirely. Empty list will remove stored excludeObjects details.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("excludeObjects")
     java.util.List<DatabaseObject> excludeObjects;
+
+    /**
+     * Database objects to include from migration, cannot be specified alongside 'excludeObjects'.
+     * If specified, the list will be replaced entirely. Empty list will remove stored includeObjects details.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("includeObjects")
+    java.util.List<DatabaseObject> includeObjects;
 
     @com.fasterxml.jackson.annotation.JsonProperty("goldenGateDetails")
     UpdateGoldenGateDetails goldenGateDetails;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateObjectStoreBucket.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateObjectStoreBucket.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * OCI Object Storage bucket details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateOciCliDumpTransferDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateOciCliDumpTransferDetails.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Optional dump transfer details for OCI-CLI-based dump transfer in source or target host.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateOciCliDumpTransferDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "kind"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateOciCliDumpTransferDetails extends UpdateHostDumpTransferDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("ociHome")
+        private String ociHome;
+
+        public Builder ociHome(String ociHome) {
+            this.ociHome = ociHome;
+            this.__explicitlySet__.add("ociHome");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateOciCliDumpTransferDetails build() {
+            UpdateOciCliDumpTransferDetails __instance__ =
+                    new UpdateOciCliDumpTransferDetails(ociHome);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateOciCliDumpTransferDetails o) {
+            Builder copiedBuilder = ociHome(o.getOciHome());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateOciCliDumpTransferDetails(String ociHome) {
+        super();
+        this.ociHome = ociHome;
+    }
+
+    /**
+     * Path to the OCI CLI installation in the node.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("ociHome")
+    String ociHome;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdatePrivateEndpoint.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdatePrivateEndpoint.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * OCI Private Endpoint configuration details.
  * An empty object would result in the removal of the stored details.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateReplicat.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateReplicat.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Parameters for Replicat processes.
  * If an empty object is specified, the stored Replicat details will be removed.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = UpdateReplicat.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateSshDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateSshDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Details of the SSH key that will be used.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = UpdateSshDetails.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateVaultDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateVaultDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * OCI Vault details to store migration and connection credentials secrets. An empty object would result in the removal of the stored details.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/VaultDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/VaultDetails.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * OCI Vault details to store migration and connection credentials secrets
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = VaultDetails.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequest.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * An asynchronous work request.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = WorkRequest.Builder.class)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of a Work Request search. Contains WorkRequestSummary items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestError.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestError.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * An error encountered while executing an operation that is tracked by a work request.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = WorkRequestError.Builder.class)
@@ -44,12 +43,12 @@ public class WorkRequestError {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("timeStamp")
-        private java.util.Date timeStamp;
+        @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+        private java.util.Date timestamp;
 
-        public Builder timeStamp(java.util.Date timeStamp) {
-            this.timeStamp = timeStamp;
-            this.__explicitlySet__.add("timeStamp");
+        public Builder timestamp(java.util.Date timestamp) {
+            this.timestamp = timestamp;
+            this.__explicitlySet__.add("timestamp");
             return this;
         }
 
@@ -57,7 +56,7 @@ public class WorkRequestError {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public WorkRequestError build() {
-            WorkRequestError __instance__ = new WorkRequestError(code, message, timeStamp);
+            WorkRequestError __instance__ = new WorkRequestError(code, message, timestamp);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -65,7 +64,7 @@ public class WorkRequestError {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(WorkRequestError o) {
             Builder copiedBuilder =
-                    code(o.getCode()).message(o.getMessage()).timeStamp(o.getTimeStamp());
+                    code(o.getCode()).message(o.getMessage()).timestamp(o.getTimestamp());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -98,8 +97,8 @@ public class WorkRequestError {
      * The time the error occured. An RFC3339 formatted datetime string.
      *
      **/
-    @com.fasterxml.jackson.annotation.JsonProperty("timeStamp")
-    java.util.Date timeStamp;
+    @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+    java.util.Date timestamp;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestErrorCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestErrorCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of a Work Request search. Contains WorkRequestError items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestLogEntry.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestLogEntry.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * A log message from executing an operation that is tracked by a work request.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
@@ -37,12 +36,12 @@ public class WorkRequestLogEntry {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("timeStamp")
-        private java.util.Date timeStamp;
+        @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+        private java.util.Date timestamp;
 
-        public Builder timeStamp(java.util.Date timeStamp) {
-            this.timeStamp = timeStamp;
-            this.__explicitlySet__.add("timeStamp");
+        public Builder timestamp(java.util.Date timestamp) {
+            this.timestamp = timestamp;
+            this.__explicitlySet__.add("timestamp");
             return this;
         }
 
@@ -50,14 +49,14 @@ public class WorkRequestLogEntry {
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public WorkRequestLogEntry build() {
-            WorkRequestLogEntry __instance__ = new WorkRequestLogEntry(message, timeStamp);
+            WorkRequestLogEntry __instance__ = new WorkRequestLogEntry(message, timestamp);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(WorkRequestLogEntry o) {
-            Builder copiedBuilder = message(o.getMessage()).timeStamp(o.getTimeStamp());
+            Builder copiedBuilder = message(o.getMessage()).timestamp(o.getTimestamp());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -82,8 +81,8 @@ public class WorkRequestLogEntry {
      * The time the log message was written. An RFC3339 formatted datetime string
      *
      **/
-    @com.fasterxml.jackson.annotation.JsonProperty("timeStamp")
-    java.util.Date timeStamp;
+    @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+    java.util.Date timestamp;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestLogEntryCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestLogEntryCollection.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * Results of a Work Request search. Contains WorkRequestLogEntry items.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestResource.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestResource.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * A resource that is created or operated on by an asynchronous operation that is tracked by
  * a work request.
  *
@@ -17,7 +16,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/WorkRequestSummary.java
@@ -5,7 +5,6 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * Note: Deprecated. Use the new resource model APIs instead.
  * A summary of the status of a work request.
  *
  * <br/>
@@ -16,7 +15,7 @@ package com.oracle.bmc.databasemigration.model;
  * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
  * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
  **/
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/AbortJobRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/AbortJobRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/AbortJobExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use AbortJobRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeAgentCompartmentRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeAgentCompartmentRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ChangeAgentCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeAgentCompartmentRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeConnectionCompartmentRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeConnectionCompartmentRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ChangeConnectionCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeConnectionCompartmentRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeMigrationCompartmentRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ChangeMigrationCompartmentRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ChangeMigrationCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeMigrationCompartmentRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/CloneMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/CloneMigrationRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/CloneMigrationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CloneMigrationRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/CreateConnectionRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/CreateConnectionRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/CreateConnectionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateConnectionRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/CreateMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/CreateMigrationRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/CreateMigrationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateMigrationRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteAgentRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteAgentRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/DeleteAgentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteAgentRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteConnectionRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteConnectionRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/DeleteConnectionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteConnectionRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteJobRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteJobRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/DeleteJobExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteJobRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/DeleteMigrationRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/DeleteMigrationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteMigrationRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/EvaluateMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/EvaluateMigrationRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/EvaluateMigrationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use EvaluateMigrationRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetAdvisorReportRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetAdvisorReportRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.requests;
+
+import com.oracle.bmc.databasemigration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/GetAdvisorReportExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetAdvisorReportRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetAdvisorReportRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the job
+     *
+     */
+    private String jobId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetAdvisorReportRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAdvisorReportRequest o) {
+            jobId(o.getJobId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetAdvisorReportRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetAdvisorReportRequest
+         */
+        public GetAdvisorReportRequest build() {
+            GetAdvisorReportRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetAgentRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetAgentRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/GetAgentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetAgentRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetConnectionRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetConnectionRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/GetConnectionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetConnectionRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetJobOutputContentRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetJobOutputContentRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/GetJobOutputContentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetJobOutputContentRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetJobRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetJobRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/GetJobExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetJobRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetMigrationRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/GetMigrationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetMigrationRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetWorkRequestRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/GetWorkRequestRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetWorkRequestRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListAgentImagesRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListAgentImagesRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListAgentImagesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListAgentImagesRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListAgentsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListAgentsRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListAgentsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListAgentsRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListConnectionsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListConnectionsRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListConnectionsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListConnectionsRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListJobOutputsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListJobOutputsRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListJobOutputsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListJobOutputsRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListJobsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListJobsRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListJobsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListJobsRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListMigrationObjectTypesRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListMigrationObjectTypesRequest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.requests;
+
+import com.oracle.bmc.databasemigration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListMigrationObjectTypesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListMigrationObjectTypesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListMigrationObjectTypesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The field to sort by. Only one sort order may be provided.
+     * Default order for name is custom based on it's usage frequency. If no value is specified name is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided.
+     * Default order for name is custom based on it's usage frequency. If no value is specified name is default.
+     *
+     **/
+    public enum SortBy {
+        Name("name"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     *
+     */
+    private com.oracle.bmc.databasemigration.model.SortOrders sortOrder;
+
+    /**
+     * The maximum number of items to return.
+     *
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListMigrationObjectTypesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListMigrationObjectTypesRequest o) {
+            opcRequestId(o.getOpcRequestId());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListMigrationObjectTypesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListMigrationObjectTypesRequest
+         */
+        public ListMigrationObjectTypesRequest build() {
+            ListMigrationObjectTypesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListMigrationsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListMigrationsRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListMigrationsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListMigrationsRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",
@@ -101,10 +101,10 @@ public class ListMigrationsRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private com.oracle.bmc.databasemigration.model.SortOrders sortOrder;
 
     /**
-     * The current state of the Database Migration Deployment.
+     * The lifecycle state of the Migration.
      *
      */
-    private com.oracle.bmc.databasemigration.model.LifecycleStates lifecycleState;
+    private com.oracle.bmc.databasemigration.model.MigrationLifecycleStates lifecycleState;
 
     /**
      * The lifecycle detailed status of the Migration.

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListWorkRequestErrorsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListWorkRequestErrorsRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkRequestErrorsRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",
@@ -39,20 +39,17 @@ public class ListWorkRequestErrorsRequest
     private String page;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending.
-     * Default order for displayName is ascending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. Default order for timestamp is descending.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending.
-     * Default order for displayName is ascending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. Default order for timestamp is descending.
      *
      **/
     public enum SortBy {
-        TimeCreated("timeCreated"),
-        DisplayName("displayName"),
+        Timestamp("timestamp"),
         ;
 
         private final String value;
@@ -87,12 +84,6 @@ public class ListWorkRequestErrorsRequest
      *
      */
     private com.oracle.bmc.databasemigration.model.SortOrders sortOrder;
-
-    /**
-     * A filter to return only resources that match the entire display name given.
-     *
-     */
-    private String displayName;
 
     /**
      * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -141,7 +132,6 @@ public class ListWorkRequestErrorsRequest
             page(o.getPage());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
-            displayName(o.getDisplayName());
             opcRequestId(o.getOpcRequestId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListWorkRequestLogsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListWorkRequestLogsRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkRequestLogsRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",
@@ -38,20 +38,17 @@ public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcReque
     private String page;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending.
-     * Default order for displayName is ascending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. Default order for timestamp is descending.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending.
-     * Default order for displayName is ascending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. Default order for timestamp is descending.
      *
      **/
     public enum SortBy {
-        TimeCreated("timeCreated"),
-        DisplayName("displayName"),
+        Timestamp("timestamp"),
         ;
 
         private final String value;
@@ -86,12 +83,6 @@ public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcReque
      *
      */
     private com.oracle.bmc.databasemigration.model.SortOrders sortOrder;
-
-    /**
-     * A filter to return only resources that match the entire display name given.
-     *
-     */
-    private String displayName;
 
     /**
      * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -140,7 +131,6 @@ public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcReque
             page(o.getPage());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
-            displayName(o.getDisplayName());
             opcRequestId(o.getOpcRequestId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListWorkRequestsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListWorkRequestsRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkRequestsRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",
@@ -32,6 +32,12 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
     private String resourceId;
 
     /**
+     * A filter to return only resources their lifecycleState matches the given OperationStatus.
+     *
+     */
+    private com.oracle.bmc.databasemigration.model.OperationStatus status;
+
+    /**
      * The maximum number of items to return.
      *
      */
@@ -44,20 +50,17 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
     private String page;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending.
-     * Default order for displayName is ascending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. Default order for timeAccepted is descending.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending.
-     * Default order for displayName is ascending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. Default order for timeAccepted is descending.
      *
      **/
     public enum SortBy {
-        TimeCreated("timeCreated"),
-        DisplayName("displayName"),
+        TimeAccepted("timeAccepted"),
         ;
 
         private final String value;
@@ -92,12 +95,6 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
      *
      */
     private com.oracle.bmc.databasemigration.model.SortOrders sortOrder;
-
-    /**
-     * A filter to return only resources that match the entire display name given.
-     *
-     */
-    private String displayName;
 
     /**
      * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
@@ -143,11 +140,11 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
         public Builder copy(ListWorkRequestsRequest o) {
             compartmentId(o.getCompartmentId());
             resourceId(o.getResourceId());
+            status(o.getStatus());
             limit(o.getLimit());
             page(o.getPage());
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
-            displayName(o.getDisplayName());
             opcRequestId(o.getOpcRequestId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ResumeJobRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ResumeJobRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ResumeJobExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ResumeJobRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/RetrieveSupportedPhasesRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/RetrieveSupportedPhasesRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/RetrieveSupportedPhasesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use RetrieveSupportedPhasesRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/StartMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/StartMigrationRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/StartMigrationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use StartMigrationRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateAgentRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateAgentRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/UpdateAgentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateAgentRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateConnectionRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateConnectionRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/UpdateConnectionExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateConnectionRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateJobRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateJobRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/UpdateJobExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateJobRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateMigrationRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/UpdateMigrationRequest.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.databasemigration.model.*;
 /**
  * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/UpdateMigrationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateMigrationRequest.
  */
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(
     builderClassName = "Builder",
     buildMethodName = "buildWithoutInvocationCallback",

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/AbortJobResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/AbortJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ChangeAgentCompartmentResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ChangeAgentCompartmentResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ChangeConnectionCompartmentResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ChangeConnectionCompartmentResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ChangeMigrationCompartmentResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ChangeMigrationCompartmentResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/CloneMigrationResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/CloneMigrationResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/CreateConnectionResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/CreateConnectionResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/CreateMigrationResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/CreateMigrationResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/DeleteAgentResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/DeleteAgentResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/DeleteConnectionResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/DeleteConnectionResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/DeleteJobResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/DeleteJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/DeleteMigrationResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/DeleteMigrationResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/EvaluateMigrationResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/EvaluateMigrationResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetAdvisorReportResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetAdvisorReportResponse.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.responses;
+
+import com.oracle.bmc.databasemigration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetAdvisorReportResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     *
+     */
+    private String etag;
+
+    /**
+     * The returned AdvisorReport instance.
+     */
+    private com.oracle.bmc.databasemigration.model.AdvisorReport advisorReport;
+
+    private GetAdvisorReportResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String etag,
+            com.oracle.bmc.databasemigration.model.AdvisorReport advisorReport) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.etag = etag;
+        this.advisorReport = advisorReport;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAdvisorReportResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            etag(o.getEtag());
+            advisorReport(o.getAdvisorReport());
+
+            return this;
+        }
+
+        public GetAdvisorReportResponse build() {
+            return new GetAdvisorReportResponse(
+                    __httpStatusCode__, opcRequestId, etag, advisorReport);
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetAgentResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetAgentResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetConnectionResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetConnectionResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetJobOutputContentResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetJobOutputContentResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetJobResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetMigrationResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetMigrationResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetWorkRequestResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/GetWorkRequestResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListAgentImagesResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListAgentImagesResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListAgentsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListAgentsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListConnectionsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListConnectionsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListJobOutputsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListJobOutputsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListJobsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListJobsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListMigrationObjectTypesResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListMigrationObjectTypesResponse.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.responses;
+
+import com.oracle.bmc.databasemigration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListMigrationObjectTypesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the {@code page} parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned MigrationObjectTypeSummaryCollection instance.
+     */
+    private com.oracle.bmc.databasemigration.model.MigrationObjectTypeSummaryCollection
+            migrationObjectTypeSummaryCollection;
+
+    private ListMigrationObjectTypesResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            com.oracle.bmc.databasemigration.model.MigrationObjectTypeSummaryCollection
+                    migrationObjectTypeSummaryCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.migrationObjectTypeSummaryCollection = migrationObjectTypeSummaryCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListMigrationObjectTypesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            migrationObjectTypeSummaryCollection(o.getMigrationObjectTypeSummaryCollection());
+
+            return this;
+        }
+
+        public ListMigrationObjectTypesResponse build() {
+            return new ListMigrationObjectTypesResponse(
+                    __httpStatusCode__,
+                    opcRequestId,
+                    opcNextPage,
+                    migrationObjectTypeSummaryCollection);
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListMigrationsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListMigrationsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListWorkRequestErrorsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListWorkRequestErrorsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListWorkRequestLogsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListWorkRequestLogsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListWorkRequestsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListWorkRequestsResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ResumeJobResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ResumeJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/RetrieveSupportedPhasesResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/RetrieveSupportedPhasesResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/StartMigrationResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/StartMigrationResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/UpdateAgentResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/UpdateAgentResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/UpdateConnectionResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/UpdateConnectionResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/UpdateJobResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/UpdateJobResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/UpdateMigrationResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/UpdateMigrationResponse.java
@@ -6,7 +6,7 @@ package com.oracle.bmc.databasemigration.responses;
 
 import com.oracle.bmc.databasemigration.model.*;
 
-@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200720")
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.6.0</version>
+        <version>2.7.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGate.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGate.java
@@ -47,6 +47,16 @@ public interface GoldenGate extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Cancels a Deployment Backup creation process.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/goldengate/CancelDeploymentBackupExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CancelDeploymentBackup API.
+     */
+    CancelDeploymentBackupResponse cancelDeploymentBackup(CancelDeploymentBackupRequest request);
+
+    /**
      * Moves the DatabaseRegistration into a different compartment within the same tenancy. When provided, If-Match is checked against ETag values of the resource.  For information about moving resources between compartments, see [Moving Resources Between Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
      *
      * @param request The request object containing the details to send
@@ -183,6 +193,17 @@ public interface GoldenGate extends AutoCloseable {
     GetDeploymentBackupResponse getDeploymentBackup(GetDeploymentBackupRequest request);
 
     /**
+     * Retrieves a deployment upgrade.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/goldengate/GetDeploymentUpgradeExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetDeploymentUpgrade API.
+     */
+    GetDeploymentUpgradeResponse getDeploymentUpgrade(GetDeploymentUpgradeRequest request);
+
+    /**
      * Retrieve the WorkRequest identified by the given OCID.
      *
      * @param request The request object containing the details to send
@@ -215,6 +236,17 @@ public interface GoldenGate extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/goldengate/ListDeploymentBackupsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDeploymentBackups API.
      */
     ListDeploymentBackupsResponse listDeploymentBackups(ListDeploymentBackupsRequest request);
+
+    /**
+     * Lists the Deployment Upgrades in a compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/goldengate/ListDeploymentUpgradesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDeploymentUpgrades API.
+     */
+    ListDeploymentUpgradesResponse listDeploymentUpgrades(ListDeploymentUpgradesRequest request);
 
     /**
      * Lists the Deployments in a compartment.

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGateAsync.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGateAsync.java
@@ -47,6 +47,22 @@ public interface GoldenGateAsync extends AutoCloseable {
     void setRegion(String regionId);
 
     /**
+     * Cancels a Deployment Backup creation process.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CancelDeploymentBackupResponse> cancelDeploymentBackup(
+            CancelDeploymentBackupRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            CancelDeploymentBackupRequest, CancelDeploymentBackupResponse>
+                    handler);
+
+    /**
      * Moves the DatabaseRegistration into a different compartment within the same tenancy. When provided, If-Match is checked against ETag values of the resource.  For information about moving resources between compartments, see [Moving Resources Between Compartments](https://docs.cloud.oracle.com/iaas/Content/Identity/Tasks/managingcompartments.htm#moveRes).
      *
      *
@@ -251,6 +267,23 @@ public interface GoldenGateAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Retrieves a deployment upgrade.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetDeploymentUpgradeResponse> getDeploymentUpgrade(
+            GetDeploymentUpgradeRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>
+                    handler);
+
+    /**
      * Retrieve the WorkRequest identified by the given OCID.
      *
      *
@@ -298,6 +331,23 @@ public interface GoldenGateAsync extends AutoCloseable {
             ListDeploymentBackupsRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ListDeploymentBackupsRequest, ListDeploymentBackupsResponse>
+                    handler);
+
+    /**
+     * Lists the Deployment Upgrades in a compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListDeploymentUpgradesResponse> listDeploymentUpgrades(
+            ListDeploymentUpgradesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListDeploymentUpgradesRequest, ListDeploymentUpgradesResponse>
                     handler);
 
     /**

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGateAsyncClient.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGateAsyncClient.java
@@ -377,6 +377,53 @@ public class GoldenGateAsyncClient implements GoldenGateAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<CancelDeploymentBackupResponse> cancelDeploymentBackup(
+            CancelDeploymentBackupRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CancelDeploymentBackupRequest, CancelDeploymentBackupResponse>
+                    handler) {
+        LOG.trace("Called async cancelDeploymentBackup");
+        final CancelDeploymentBackupRequest interceptedRequest =
+                CancelDeploymentBackupConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CancelDeploymentBackupConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, CancelDeploymentBackupResponse>
+                transformer = CancelDeploymentBackupConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        CancelDeploymentBackupRequest, CancelDeploymentBackupResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CancelDeploymentBackupRequest, CancelDeploymentBackupResponse>,
+                        java.util.concurrent.Future<CancelDeploymentBackupResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getCancelDeploymentBackupDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CancelDeploymentBackupRequest, CancelDeploymentBackupResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeDatabaseRegistrationCompartmentResponse>
             changeDatabaseRegistrationCompartment(
                     ChangeDatabaseRegistrationCompartmentRequest request,
@@ -919,6 +966,47 @@ public class GoldenGateAsyncClient implements GoldenGateAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetDeploymentUpgradeResponse> getDeploymentUpgrade(
+            GetDeploymentUpgradeRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>
+                    handler) {
+        LOG.trace("Called async getDeploymentUpgrade");
+        final GetDeploymentUpgradeRequest interceptedRequest =
+                GetDeploymentUpgradeConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetDeploymentUpgradeConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetDeploymentUpgradeResponse>
+                transformer = GetDeploymentUpgradeConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>,
+                        java.util.concurrent.Future<GetDeploymentUpgradeResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetWorkRequestResponse> getWorkRequest(
             GetWorkRequestRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -1028,6 +1116,47 @@ public class GoldenGateAsyncClient implements GoldenGateAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListDeploymentBackupsRequest, ListDeploymentBackupsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListDeploymentUpgradesResponse> listDeploymentUpgrades(
+            ListDeploymentUpgradesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListDeploymentUpgradesRequest, ListDeploymentUpgradesResponse>
+                    handler) {
+        LOG.trace("Called async listDeploymentUpgrades");
+        final ListDeploymentUpgradesRequest interceptedRequest =
+                ListDeploymentUpgradesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDeploymentUpgradesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListDeploymentUpgradesResponse>
+                transformer = ListDeploymentUpgradesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListDeploymentUpgradesRequest, ListDeploymentUpgradesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListDeploymentUpgradesRequest, ListDeploymentUpgradesResponse>,
+                        java.util.concurrent.Future<ListDeploymentUpgradesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListDeploymentUpgradesRequest, ListDeploymentUpgradesResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGateClient.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGateClient.java
@@ -452,6 +452,40 @@ public class GoldenGateClient implements GoldenGate {
     }
 
     @Override
+    public CancelDeploymentBackupResponse cancelDeploymentBackup(
+            CancelDeploymentBackupRequest request) {
+        LOG.trace("Called cancelDeploymentBackup");
+        final CancelDeploymentBackupRequest interceptedRequest =
+                CancelDeploymentBackupConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CancelDeploymentBackupConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CancelDeploymentBackupResponse>
+                transformer = CancelDeploymentBackupConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCancelDeploymentBackupDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeDatabaseRegistrationCompartmentResponse changeDatabaseRegistrationCompartment(
             ChangeDatabaseRegistrationCompartmentRequest request) {
         LOG.trace("Called changeDatabaseRegistrationCompartment");
@@ -839,6 +873,34 @@ public class GoldenGateClient implements GoldenGate {
     }
 
     @Override
+    public GetDeploymentUpgradeResponse getDeploymentUpgrade(GetDeploymentUpgradeRequest request) {
+        LOG.trace("Called getDeploymentUpgrade");
+        final GetDeploymentUpgradeRequest interceptedRequest =
+                GetDeploymentUpgradeConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetDeploymentUpgradeConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetDeploymentUpgradeResponse>
+                transformer = GetDeploymentUpgradeConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request) {
         LOG.trace("Called getWorkRequest");
         final GetWorkRequestRequest interceptedRequest =
@@ -906,6 +968,35 @@ public class GoldenGateClient implements GoldenGate {
                 ListDeploymentBackupsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListDeploymentBackupsResponse>
                 transformer = ListDeploymentBackupsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListDeploymentUpgradesResponse listDeploymentUpgrades(
+            ListDeploymentUpgradesRequest request) {
+        LOG.trace("Called listDeploymentUpgrades");
+        final ListDeploymentUpgradesRequest interceptedRequest =
+                ListDeploymentUpgradesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDeploymentUpgradesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListDeploymentUpgradesResponse>
+                transformer = ListDeploymentUpgradesConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGatePaginators.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGatePaginators.java
@@ -266,6 +266,123 @@ public class GoldenGatePaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listDeploymentUpgrades operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListDeploymentUpgradesResponse> listDeploymentUpgradesResponseIterator(
+            final ListDeploymentUpgradesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListDeploymentUpgradesRequest.Builder, ListDeploymentUpgradesRequest,
+                ListDeploymentUpgradesResponse>(
+                new com.google.common.base.Supplier<ListDeploymentUpgradesRequest.Builder>() {
+                    @Override
+                    public ListDeploymentUpgradesRequest.Builder get() {
+                        return ListDeploymentUpgradesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListDeploymentUpgradesResponse, String>() {
+                    @Override
+                    public String apply(ListDeploymentUpgradesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListDeploymentUpgradesRequest.Builder>,
+                        ListDeploymentUpgradesRequest>() {
+                    @Override
+                    public ListDeploymentUpgradesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListDeploymentUpgradesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListDeploymentUpgradesRequest, ListDeploymentUpgradesResponse>() {
+                    @Override
+                    public ListDeploymentUpgradesResponse apply(
+                            ListDeploymentUpgradesRequest request) {
+                        return client.listDeploymentUpgrades(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.goldengate.model.DeploymentUpgradeSummary} objects
+     * contained in responses from the listDeploymentUpgrades operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.goldengate.model.DeploymentUpgradeSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.goldengate.model.DeploymentUpgradeSummary>
+            listDeploymentUpgradesRecordIterator(final ListDeploymentUpgradesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListDeploymentUpgradesRequest.Builder, ListDeploymentUpgradesRequest,
+                ListDeploymentUpgradesResponse,
+                com.oracle.bmc.goldengate.model.DeploymentUpgradeSummary>(
+                new com.google.common.base.Supplier<ListDeploymentUpgradesRequest.Builder>() {
+                    @Override
+                    public ListDeploymentUpgradesRequest.Builder get() {
+                        return ListDeploymentUpgradesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListDeploymentUpgradesResponse, String>() {
+                    @Override
+                    public String apply(ListDeploymentUpgradesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListDeploymentUpgradesRequest.Builder>,
+                        ListDeploymentUpgradesRequest>() {
+                    @Override
+                    public ListDeploymentUpgradesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListDeploymentUpgradesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListDeploymentUpgradesRequest, ListDeploymentUpgradesResponse>() {
+                    @Override
+                    public ListDeploymentUpgradesResponse apply(
+                            ListDeploymentUpgradesRequest request) {
+                        return client.listDeploymentUpgrades(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListDeploymentUpgradesResponse,
+                        java.util.List<
+                                com.oracle.bmc.goldengate.model.DeploymentUpgradeSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.goldengate.model.DeploymentUpgradeSummary>
+                            apply(ListDeploymentUpgradesResponse response) {
+                        return response.getDeploymentUpgradeCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listDeployments operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGateWaiters.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/GoldenGateWaiters.java
@@ -325,6 +325,108 @@ public class GoldenGateWaiters {
     }
 
     /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>
+            forDeploymentUpgrade(
+                    GetDeploymentUpgradeRequest request,
+                    com.oracle.bmc.goldengate.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forDeploymentUpgrade(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>
+            forDeploymentUpgrade(
+                    GetDeploymentUpgradeRequest request,
+                    com.oracle.bmc.goldengate.model.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forDeploymentUpgrade(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>
+            forDeploymentUpgrade(
+                    GetDeploymentUpgradeRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.goldengate.model.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forDeploymentUpgrade(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for DeploymentUpgrade.
+    private com.oracle.bmc.waiter.Waiter<GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>
+            forDeploymentUpgrade(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetDeploymentUpgradeRequest request,
+                    final com.oracle.bmc.goldengate.model.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.goldengate.model.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetDeploymentUpgradeRequest, GetDeploymentUpgradeResponse>() {
+                            @Override
+                            public GetDeploymentUpgradeResponse apply(
+                                    GetDeploymentUpgradeRequest request) {
+                                return client.getDeploymentUpgrade(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetDeploymentUpgradeResponse>() {
+                            @Override
+                            public boolean apply(GetDeploymentUpgradeResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getDeploymentUpgrade().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.goldengate.model.LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
      * Creates a new {@link com.oracle.bmc.waiter.Waiter} using default configuration.
      *
      * @param request the request to send

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/CancelDeploymentBackupConverter.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/CancelDeploymentBackupConverter.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.goldengate.model.*;
+import com.oracle.bmc.goldengate.requests.*;
+import com.oracle.bmc.goldengate.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.extern.slf4j.Slf4j
+public class CancelDeploymentBackupConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.goldengate.requests.CancelDeploymentBackupRequest interceptRequest(
+            com.oracle.bmc.goldengate.requests.CancelDeploymentBackupRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.goldengate.requests.CancelDeploymentBackupRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDeploymentBackupId(), "deploymentBackupId must not be blank");
+        Validate.notNull(
+                request.getCancelDeploymentBackupDetails(),
+                "cancelDeploymentBackupDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200407")
+                        .path("deploymentBackups")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDeploymentBackupId()))
+                        .path("actions")
+                        .path("cancel");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.goldengate.responses.CancelDeploymentBackupResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.goldengate.responses.CancelDeploymentBackupResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.goldengate.responses
+                                        .CancelDeploymentBackupResponse>() {
+                            @Override
+                            public com.oracle.bmc.goldengate.responses
+                                            .CancelDeploymentBackupResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.goldengate.responses.CancelDeploymentBackupResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.goldengate.responses.CancelDeploymentBackupResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.goldengate.responses
+                                                        .CancelDeploymentBackupResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.goldengate.responses.CancelDeploymentBackupResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/GetDeploymentUpgradeConverter.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/GetDeploymentUpgradeConverter.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.goldengate.model.*;
+import com.oracle.bmc.goldengate.requests.*;
+import com.oracle.bmc.goldengate.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.extern.slf4j.Slf4j
+public class GetDeploymentUpgradeConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.goldengate.requests.GetDeploymentUpgradeRequest interceptRequest(
+            com.oracle.bmc.goldengate.requests.GetDeploymentUpgradeRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.goldengate.requests.GetDeploymentUpgradeRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getDeploymentUpgradeId(), "deploymentUpgradeId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200407")
+                        .path("deploymentUpgrades")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDeploymentUpgradeId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.goldengate.responses.GetDeploymentUpgradeResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.goldengate.responses.GetDeploymentUpgradeResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.goldengate.responses
+                                        .GetDeploymentUpgradeResponse>() {
+                            @Override
+                            public com.oracle.bmc.goldengate.responses.GetDeploymentUpgradeResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.goldengate.responses.GetDeploymentUpgradeResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.goldengate.model
+                                                                .DeploymentUpgrade>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.goldengate.model
+                                                                        .DeploymentUpgrade
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.goldengate.model.DeploymentUpgrade>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.goldengate.responses.GetDeploymentUpgradeResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.goldengate.responses
+                                                        .GetDeploymentUpgradeResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.deploymentUpgrade(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.goldengate.responses.GetDeploymentUpgradeResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/ListDeploymentUpgradesConverter.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/ListDeploymentUpgradesConverter.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.goldengate.model.*;
+import com.oracle.bmc.goldengate.requests.*;
+import com.oracle.bmc.goldengate.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.extern.slf4j.Slf4j
+public class ListDeploymentUpgradesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.goldengate.requests.ListDeploymentUpgradesRequest interceptRequest(
+            com.oracle.bmc.goldengate.requests.ListDeploymentUpgradesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.goldengate.requests.ListDeploymentUpgradesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20200407").path("deploymentUpgrades");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getDeploymentId() != null) {
+            target =
+                    target.queryParam(
+                            "deploymentId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDeploymentId()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.goldengate.responses.ListDeploymentUpgradesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.goldengate.responses.ListDeploymentUpgradesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.goldengate.responses
+                                        .ListDeploymentUpgradesResponse>() {
+                            @Override
+                            public com.oracle.bmc.goldengate.responses
+                                            .ListDeploymentUpgradesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.goldengate.responses.ListDeploymentUpgradesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.goldengate.model
+                                                                .DeploymentUpgradeCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.goldengate.model
+                                                                        .DeploymentUpgradeCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.goldengate.model
+                                                        .DeploymentUpgradeCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.goldengate.responses.ListDeploymentUpgradesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.goldengate.responses
+                                                        .ListDeploymentUpgradesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.deploymentUpgradeCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.goldengate.responses.ListDeploymentUpgradesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/ListDeploymentsConverter.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/ListDeploymentsConverter.java
@@ -46,12 +46,28 @@ public class ListDeploymentsConverter {
                                     request.getLifecycleState().getValue()));
         }
 
+        if (request.getLifecycleSubState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleSubState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleSubState().getValue()));
+        }
+
         if (request.getDisplayName() != null) {
             target =
                     target.queryParam(
                             "displayName",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
                                     request.getDisplayName()));
+        }
+
+        if (request.getFqdn() != null) {
+            target =
+                    target.queryParam(
+                            "fqdn",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getFqdn()));
         }
 
         if (request.getLimit() != null) {

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/ListWorkRequestsConverter.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/internal/http/ListWorkRequestsConverter.java
@@ -38,6 +38,14 @@ public class ListWorkRequestsConverter {
                         com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
                                 request.getCompartmentId()));
 
+        if (request.getResourceId() != null) {
+            target =
+                    target.queryParam(
+                            "resourceId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getResourceId()));
+        }
+
         if (request.getPage() != null) {
             target =
                     target.queryParam(

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/CancelDeploymentBackupDetails.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/CancelDeploymentBackupDetails.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.model;
+
+/**
+ * The information about the Cancel for a DeploymentBackup.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type",
+    defaultImpl = CancelDeploymentBackupDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = DefaultCancelDeploymentBackupDetails.class,
+        name = "DEFAULT"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CancelDeploymentBackupDetails {}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/CancelDeploymentBackupType.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/CancelDeploymentBackupType.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.model;
+
+/**
+ * The deployment backup cancel type.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+public enum CancelDeploymentBackupType {
+    Default("DEFAULT"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, CancelDeploymentBackupType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (CancelDeploymentBackupType v : CancelDeploymentBackupType.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    CancelDeploymentBackupType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static CancelDeploymentBackupType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid CancelDeploymentBackupType: " + key);
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DefaultCancelDeploymentBackupDetails.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DefaultCancelDeploymentBackupDetails.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.model;
+
+/**
+ * Definiton of the additional attributes for default deployment backup cancel.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DefaultCancelDeploymentBackupDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DefaultCancelDeploymentBackupDetails extends CancelDeploymentBackupDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DefaultCancelDeploymentBackupDetails build() {
+            DefaultCancelDeploymentBackupDetails __instance__ =
+                    new DefaultCancelDeploymentBackupDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DefaultCancelDeploymentBackupDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public DefaultCancelDeploymentBackupDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/Deployment.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/Deployment.java
@@ -97,6 +97,15 @@ public class Deployment {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleSubState")
+        private LifecycleSubState lifecycleSubState;
+
+        public Builder lifecycleSubState(LifecycleSubState lifecycleSubState) {
+            this.lifecycleSubState = lifecycleSubState;
+            this.__explicitlySet__.add("lifecycleSubState");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
         private String lifecycleDetails;
 
@@ -242,6 +251,15 @@ public class Deployment {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpgradeRequired")
+        private java.util.Date timeUpgradeRequired;
+
+        public Builder timeUpgradeRequired(java.util.Date timeUpgradeRequired) {
+            this.timeUpgradeRequired = timeUpgradeRequired;
+            this.__explicitlySet__.add("timeUpgradeRequired");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("deploymentType")
         private DeploymentType deploymentType;
 
@@ -274,6 +292,7 @@ public class Deployment {
                             timeCreated,
                             timeUpdated,
                             lifecycleState,
+                            lifecycleSubState,
                             lifecycleDetails,
                             freeformTags,
                             definedTags,
@@ -290,6 +309,7 @@ public class Deployment {
                             deploymentUrl,
                             systemTags,
                             isLatestVersion,
+                            timeUpgradeRequired,
                             deploymentType,
                             oggData);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -307,6 +327,7 @@ public class Deployment {
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
+                            .lifecycleSubState(o.getLifecycleSubState())
                             .lifecycleDetails(o.getLifecycleDetails())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
@@ -323,6 +344,7 @@ public class Deployment {
                             .deploymentUrl(o.getDeploymentUrl())
                             .systemTags(o.getSystemTags())
                             .isLatestVersion(o.getIsLatestVersion())
+                            .timeUpgradeRequired(o.getTimeUpgradeRequired())
                             .deploymentType(o.getDeploymentType())
                             .oggData(o.getOggData());
 
@@ -393,6 +415,13 @@ public class Deployment {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
+
+    /**
+     * Possible GGS lifecycle sub-states.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleSubState")
+    LifecycleSubState lifecycleSubState;
 
     /**
      * Describes the object's current state in detail. For example, it can be used to provide actionable information for a resource in a Failed state.
@@ -508,6 +537,13 @@ public class Deployment {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isLatestVersion")
     Boolean isLatestVersion;
+
+    /**
+     * The date the existing version in use will no longer be considered as usable and an upgrade will be required.  This date is typically 6 months after the version was released for use by GGS.  The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpgradeRequired")
+    java.util.Date timeUpgradeRequired;
 
     /**
      * The deployment type.

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentSummary.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentSummary.java
@@ -90,6 +90,15 @@ public class DeploymentSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleSubState")
+        private LifecycleSubState lifecycleSubState;
+
+        public Builder lifecycleSubState(LifecycleSubState lifecycleSubState) {
+            this.lifecycleSubState = lifecycleSubState;
+            this.__explicitlySet__.add("lifecycleSubState");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
         private String lifecycleDetails;
 
@@ -217,6 +226,15 @@ public class DeploymentSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpgradeRequired")
+        private java.util.Date timeUpgradeRequired;
+
+        public Builder timeUpgradeRequired(java.util.Date timeUpgradeRequired) {
+            this.timeUpgradeRequired = timeUpgradeRequired;
+            this.__explicitlySet__.add("timeUpgradeRequired");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("deploymentType")
         private DeploymentType deploymentType;
 
@@ -239,6 +257,7 @@ public class DeploymentSummary {
                             timeCreated,
                             timeUpdated,
                             lifecycleState,
+                            lifecycleSubState,
                             lifecycleDetails,
                             freeformTags,
                             definedTags,
@@ -253,6 +272,7 @@ public class DeploymentSummary {
                             deploymentUrl,
                             systemTags,
                             isLatestVersion,
+                            timeUpgradeRequired,
                             deploymentType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -268,6 +288,7 @@ public class DeploymentSummary {
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
+                            .lifecycleSubState(o.getLifecycleSubState())
                             .lifecycleDetails(o.getLifecycleDetails())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
@@ -282,6 +303,7 @@ public class DeploymentSummary {
                             .deploymentUrl(o.getDeploymentUrl())
                             .systemTags(o.getSystemTags())
                             .isLatestVersion(o.getIsLatestVersion())
+                            .timeUpgradeRequired(o.getTimeUpgradeRequired())
                             .deploymentType(o.getDeploymentType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -344,6 +366,13 @@ public class DeploymentSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
+
+    /**
+     * Possible GGS lifecycle sub-states.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleSubState")
+    LifecycleSubState lifecycleSubState;
 
     /**
      * Describes the object's current state in detail. For example, it can be used to provide actionable information for a resource in a Failed state.
@@ -445,6 +474,13 @@ public class DeploymentSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isLatestVersion")
     Boolean isLatestVersion;
+
+    /**
+     * The date the existing version in use will no longer be considered as usable and an upgrade will be required.  This date is typically 6 months after the version was released for use by GGS.  The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpgradeRequired")
+    java.util.Date timeUpgradeRequired;
 
     /**
      * The deployment type.

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgrade.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgrade.java
@@ -1,0 +1,368 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.model;
+
+/**
+ * A container for your OCI GoldenGate Upgrade information.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DeploymentUpgrade.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DeploymentUpgrade {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentId")
+        private String deploymentId;
+
+        public Builder deploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
+            this.__explicitlySet__.add("deploymentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentUpgradeType")
+        private DeploymentUpgradeType deploymentUpgradeType;
+
+        public Builder deploymentUpgradeType(DeploymentUpgradeType deploymentUpgradeType) {
+            this.deploymentUpgradeType = deploymentUpgradeType;
+            this.__explicitlySet__.add("deploymentUpgradeType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("oggVersion")
+        private String oggVersion;
+
+        public Builder oggVersion(String oggVersion) {
+            this.oggVersion = oggVersion;
+            this.__explicitlySet__.add("oggVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleSubState")
+        private LifecycleSubState lifecycleSubState;
+
+        public Builder lifecycleSubState(LifecycleSubState lifecycleSubState) {
+            this.lifecycleSubState = lifecycleSubState;
+            this.__explicitlySet__.add("lifecycleSubState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DeploymentUpgrade build() {
+            DeploymentUpgrade __instance__ =
+                    new DeploymentUpgrade(
+                            id,
+                            displayName,
+                            description,
+                            compartmentId,
+                            deploymentId,
+                            deploymentUpgradeType,
+                            timeStarted,
+                            timeFinished,
+                            oggVersion,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleSubState,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DeploymentUpgrade o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .compartmentId(o.getCompartmentId())
+                            .deploymentId(o.getDeploymentId())
+                            .deploymentUpgradeType(o.getDeploymentUpgradeType())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .oggVersion(o.getOggVersion())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleSubState(o.getLifecycleSubState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the deployment upgrade being referenced.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * An object's Display Name.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Metadata about this specific object.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment being referenced.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the deployment being referenced.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentId")
+    String deploymentId;
+
+    /**
+     * The type of the deployment upgrade: MANUAL or AUTOMATIC
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentUpgradeType")
+    DeploymentUpgradeType deploymentUpgradeType;
+
+    /**
+     * The date and time the request was started. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+    java.util.Date timeStarted;
+
+    /**
+     * The date and time the request was finished. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+    java.util.Date timeFinished;
+
+    /**
+     * Version of OGG
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("oggVersion")
+    String oggVersion;
+
+    /**
+     * The time the resource was created. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the resource was last updated. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * Possible lifecycle states.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Possible GGS lifecycle sub-states.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleSubState")
+    LifecycleSubState lifecycleSubState;
+
+    /**
+     * Describes the object's current state in detail. For example, it can be used to provide actionable information for a resource in a Failed state.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * A simple key-value pair that is applied without any predefined name, type, or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Tags defined for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The system tags associated with this resource, if any. The system tags are set by Oracle Cloud Infrastructure services. Each key is predefined and scoped to namespaces.  For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * Example: {@code {orcl-cloud: {free-tier-retain: true}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgradeCollection.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgradeCollection.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.model;
+
+/**
+ * A list of Deployment Upgrades.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DeploymentUpgradeCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DeploymentUpgradeCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<DeploymentUpgradeSummary> items;
+
+        public Builder items(java.util.List<DeploymentUpgradeSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DeploymentUpgradeCollection build() {
+            DeploymentUpgradeCollection __instance__ = new DeploymentUpgradeCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DeploymentUpgradeCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * An array of Deployment Upgrade summaries.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<DeploymentUpgradeSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgradeLifecycleState.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgradeLifecycleState.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.model;
+
+/**
+ * Possible deploymentUpgrade lifecycle states.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+public enum DeploymentUpgradeLifecycleState {
+    Waiting("WAITING"),
+    InProgress("IN_PROGRESS"),
+    Failed("FAILED"),
+    Succeeded("SUCCEEDED"),
+    Canceling("CANCELING"),
+    Canceled("CANCELED"),
+    NeedsAttention("NEEDS_ATTENTION"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, DeploymentUpgradeLifecycleState> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (DeploymentUpgradeLifecycleState v : DeploymentUpgradeLifecycleState.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    DeploymentUpgradeLifecycleState(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static DeploymentUpgradeLifecycleState create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid DeploymentUpgradeLifecycleState: " + key);
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgradeSummary.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgradeSummary.java
@@ -1,0 +1,368 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.model;
+
+/**
+ * Summary of the Deployment Upgrade.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DeploymentUpgradeSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DeploymentUpgradeSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("description")
+        private String description;
+
+        public Builder description(String description) {
+            this.description = description;
+            this.__explicitlySet__.add("description");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentId")
+        private String deploymentId;
+
+        public Builder deploymentId(String deploymentId) {
+            this.deploymentId = deploymentId;
+            this.__explicitlySet__.add("deploymentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("deploymentUpgradeType")
+        private DeploymentUpgradeType deploymentUpgradeType;
+
+        public Builder deploymentUpgradeType(DeploymentUpgradeType deploymentUpgradeType) {
+            this.deploymentUpgradeType = deploymentUpgradeType;
+            this.__explicitlySet__.add("deploymentUpgradeType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("oggVersion")
+        private String oggVersion;
+
+        public Builder oggVersion(String oggVersion) {
+            this.oggVersion = oggVersion;
+            this.__explicitlySet__.add("oggVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleSubState")
+        private LifecycleSubState lifecycleSubState;
+
+        public Builder lifecycleSubState(LifecycleSubState lifecycleSubState) {
+            this.lifecycleSubState = lifecycleSubState;
+            this.__explicitlySet__.add("lifecycleSubState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DeploymentUpgradeSummary build() {
+            DeploymentUpgradeSummary __instance__ =
+                    new DeploymentUpgradeSummary(
+                            id,
+                            displayName,
+                            description,
+                            compartmentId,
+                            deploymentId,
+                            deploymentUpgradeType,
+                            timeStarted,
+                            timeFinished,
+                            oggVersion,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            lifecycleSubState,
+                            lifecycleDetails,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DeploymentUpgradeSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .description(o.getDescription())
+                            .compartmentId(o.getCompartmentId())
+                            .deploymentId(o.getDeploymentId())
+                            .deploymentUpgradeType(o.getDeploymentUpgradeType())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished())
+                            .oggVersion(o.getOggVersion())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleSubState(o.getLifecycleSubState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the deployment being referenced.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * An object's Display Name.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Metadata about this specific object.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("description")
+    String description;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment being referenced.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the deployment being referenced.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentId")
+    String deploymentId;
+
+    /**
+     * The type of the deployment upgrade: MANUAL or AUTOMATIC
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("deploymentUpgradeType")
+    DeploymentUpgradeType deploymentUpgradeType;
+
+    /**
+     * The date and time the request was started. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+    java.util.Date timeStarted;
+
+    /**
+     * The date and time the request was finished. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+    java.util.Date timeFinished;
+
+    /**
+     * Version of OGG
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("oggVersion")
+    String oggVersion;
+
+    /**
+     * The time the resource was created. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the resource was last updated. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    /**
+     * Possible lifecycle states.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Possible GGS lifecycle sub-states.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleSubState")
+    LifecycleSubState lifecycleSubState;
+
+    /**
+     * Describes the object's current state in detail. For example, it can be used to provide actionable information for a resource in a Failed state.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * A simple key-value pair that is applied without any predefined name, type, or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Tags defined for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The system tags associated with this resource, if any. The system tags are set by Oracle Cloud Infrastructure services. Each key is predefined and scoped to namespaces.  For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * Example: {@code {orcl-cloud: {free-tier-retain: true}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgradeType.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/DeploymentUpgradeType.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.model;
+
+/**
+ * The deployment upgrade type.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.extern.slf4j.Slf4j
+public enum DeploymentUpgradeType {
+    Manual("MANUAL"),
+    Automatic("AUTOMATIC"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, DeploymentUpgradeType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (DeploymentUpgradeType v : DeploymentUpgradeType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    DeploymentUpgradeType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static DeploymentUpgradeType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'DeploymentUpgradeType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/LifecycleState.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/LifecycleState.java
@@ -18,6 +18,11 @@ public enum LifecycleState {
     Deleting("DELETING"),
     Deleted("DELETED"),
     Failed("FAILED"),
+    NeedsAttention("NEEDS_ATTENTION"),
+    InProgress("IN_PROGRESS"),
+    Canceling("CANCELING"),
+    Canceled("CANCELED"),
+    Succeeded("SUCCEEDED"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/LifecycleSubState.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/LifecycleSubState.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.model;
+
+/**
+ * Possible lifecycle sub-states.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.extern.slf4j.Slf4j
+public enum LifecycleSubState {
+    Recovering("RECOVERING"),
+    Starting("STARTING"),
+    Stopping("STOPPING"),
+    Moving("MOVING"),
+    Upgrading("UPGRADING"),
+    Restoring("RESTORING"),
+    BackupInProgress("BACKUP_IN_PROGRESS"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, LifecycleSubState> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (LifecycleSubState v : LifecycleSubState.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    LifecycleSubState(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static LifecycleSubState create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'LifecycleSubState', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/OggDeployment.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/OggDeployment.java
@@ -43,6 +43,15 @@ public class OggDeployment {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("oggVersion")
+        private String oggVersion;
+
+        public Builder oggVersion(String oggVersion) {
+            this.oggVersion = oggVersion;
+            this.__explicitlySet__.add("oggVersion");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("certificate")
         private String certificate;
 
@@ -57,7 +66,7 @@ public class OggDeployment {
 
         public OggDeployment build() {
             OggDeployment __instance__ =
-                    new OggDeployment(deploymentName, adminUsername, certificate);
+                    new OggDeployment(deploymentName, adminUsername, oggVersion, certificate);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -67,6 +76,7 @@ public class OggDeployment {
             Builder copiedBuilder =
                     deploymentName(o.getDeploymentName())
                             .adminUsername(o.getAdminUsername())
+                            .oggVersion(o.getOggVersion())
                             .certificate(o.getCertificate());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -94,6 +104,13 @@ public class OggDeployment {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("adminUsername")
     String adminUsername;
+
+    /**
+     * Version of OGG
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("oggVersion")
+    String oggVersion;
 
     /**
      * A PEM-encoded SSL certificate.

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/WorkRequest.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/model/WorkRequest.java
@@ -207,7 +207,7 @@ public class WorkRequest {
     java.util.Date timeStarted;
 
     /**
-     * The date and time the object was finished. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
+     * The date and time the request was finished. The format is defined by [RFC3339](https://tools.ietf.org/html/rfc3339), such as {@code 2016-08-25T21:10:29.600Z}.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/CancelDeploymentBackupRequest.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/CancelDeploymentBackupRequest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.requests;
+
+import com.oracle.bmc.goldengate.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/goldengate/CancelDeploymentBackupExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CancelDeploymentBackupRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CancelDeploymentBackupRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.goldengate.model.CancelDeploymentBackupDetails> {
+
+    /**
+     * A unique DeploymentBackup identifier.
+     *
+     */
+    private String deploymentBackupId;
+
+    /**
+     * A placeholder for any additional metadata to describe the deployment backup cancel.
+     *
+     */
+    private com.oracle.bmc.goldengate.model.CancelDeploymentBackupDetails
+            cancelDeploymentBackupDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the {@code if-match} parameter to the value of the etag from a previous GET or POST response for that resource.  The resource is updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried, in case of a timeout or server error, without risk of executing that same action again. Retry tokens expire after 24 hours, but can be invalidated before then due to conflicting operations. For example, if a resource has been deleted and purged from the system, then a retry of the original creation request is rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.goldengate.model.CancelDeploymentBackupDetails getBody$() {
+        return cancelDeploymentBackupDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CancelDeploymentBackupRequest,
+                    com.oracle.bmc.goldengate.model.CancelDeploymentBackupDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CancelDeploymentBackupRequest o) {
+            deploymentBackupId(o.getDeploymentBackupId());
+            cancelDeploymentBackupDetails(o.getCancelDeploymentBackupDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CancelDeploymentBackupRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CancelDeploymentBackupRequest
+         */
+        public CancelDeploymentBackupRequest build() {
+            CancelDeploymentBackupRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(com.oracle.bmc.goldengate.model.CancelDeploymentBackupDetails body) {
+            cancelDeploymentBackupDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/GetDeploymentUpgradeRequest.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/GetDeploymentUpgradeRequest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.requests;
+
+import com.oracle.bmc.goldengate.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/goldengate/GetDeploymentUpgradeExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetDeploymentUpgradeRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetDeploymentUpgradeRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * A unique Deployment Upgrade identifier.
+     *
+     */
+    private String deploymentUpgradeId;
+
+    /**
+     * The client request ID for tracing.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetDeploymentUpgradeRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetDeploymentUpgradeRequest o) {
+            deploymentUpgradeId(o.getDeploymentUpgradeId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetDeploymentUpgradeRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetDeploymentUpgradeRequest
+         */
+        public GetDeploymentUpgradeRequest build() {
+            GetDeploymentUpgradeRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/ListDeploymentUpgradesRequest.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/ListDeploymentUpgradesRequest.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.requests;
+
+import com.oracle.bmc.goldengate.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/goldengate/ListDeploymentUpgradesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListDeploymentUpgradesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListDeploymentUpgradesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ID of the compartment in which to list resources.
+     *
+     */
+    private String compartmentId;
+
+    /**
+     * The ID of the deployment in which to list resources.
+     *
+     */
+    private String deploymentId;
+
+    /**
+     * A filter to return only the resources that match the 'lifecycleState' given.
+     *
+     */
+    private com.oracle.bmc.goldengate.model.LifecycleState lifecycleState;
+
+    /**
+     * A filter to return only the resources that match the entire 'displayName' given.
+     *
+     */
+    private String displayName;
+
+    /**
+     * The maximum number of items to return.
+     *
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     *
+     */
+    private com.oracle.bmc.goldengate.model.SortOrder sortOrder;
+
+    /**
+     * The field to sort by. Only one sort order can be provided. Default order for 'timeCreated' is descending.  Default order for 'displayName' is ascending. If no value is specified timeCreated is the default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order can be provided. Default order for 'timeCreated' is descending.  Default order for 'displayName' is ascending. If no value is specified timeCreated is the default.
+     *
+     **/
+    public enum SortBy {
+        TimeCreated("timeCreated"),
+        DisplayName("displayName"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListDeploymentUpgradesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDeploymentUpgradesRequest o) {
+            compartmentId(o.getCompartmentId());
+            deploymentId(o.getDeploymentId());
+            lifecycleState(o.getLifecycleState());
+            displayName(o.getDisplayName());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListDeploymentUpgradesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListDeploymentUpgradesRequest
+         */
+        public ListDeploymentUpgradesRequest build() {
+            ListDeploymentUpgradesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/ListDeploymentsRequest.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/ListDeploymentsRequest.java
@@ -32,10 +32,22 @@ public class ListDeploymentsRequest extends com.oracle.bmc.requests.BmcRequest<j
     private com.oracle.bmc.goldengate.model.LifecycleState lifecycleState;
 
     /**
+     * A filter to return only the resources that match the 'lifecycleSubState' given.
+     *
+     */
+    private com.oracle.bmc.goldengate.model.LifecycleSubState lifecycleSubState;
+
+    /**
      * A filter to return only the resources that match the entire 'displayName' given.
      *
      */
     private String displayName;
+
+    /**
+     * A filter to return only the resources that match the 'fqdn' given.
+     *
+     */
+    private String fqdn;
 
     /**
      * The maximum number of items to return.
@@ -140,7 +152,9 @@ public class ListDeploymentsRequest extends com.oracle.bmc.requests.BmcRequest<j
         public Builder copy(ListDeploymentsRequest o) {
             compartmentId(o.getCompartmentId());
             lifecycleState(o.getLifecycleState());
+            lifecycleSubState(o.getLifecycleSubState());
             displayName(o.getDisplayName());
+            fqdn(o.getFqdn());
             limit(o.getLimit());
             page(o.getPage());
             sortOrder(o.getSortOrder());

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/ListWorkRequestsRequest.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/requests/ListWorkRequestsRequest.java
@@ -26,6 +26,12 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
     private String compartmentId;
 
     /**
+     * The ID of the resource in which to list resources.
+     *
+     */
+    private String resourceId;
+
+    /**
      * The client request ID for tracing.
      *
      */
@@ -79,6 +85,7 @@ public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<
          */
         public Builder copy(ListWorkRequestsRequest o) {
             compartmentId(o.getCompartmentId());
+            resourceId(o.getResourceId());
             opcRequestId(o.getOpcRequestId());
             page(o.getPage());
             limit(o.getLimit());

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/responses/CancelDeploymentBackupResponse.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/responses/CancelDeploymentBackupResponse.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.responses;
+
+import com.oracle.bmc.goldengate.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CancelDeploymentBackupResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * A unique Oracle-assigned identifier for an asynchronous request. You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * A unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please include the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    private CancelDeploymentBackupResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CancelDeploymentBackupResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public CancelDeploymentBackupResponse build() {
+            return new CancelDeploymentBackupResponse(
+                    __httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/responses/GetDeploymentUpgradeResponse.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/responses/GetDeploymentUpgradeResponse.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.responses;
+
+import com.oracle.bmc.goldengate.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetDeploymentUpgradeResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     *
+     */
+    private String etag;
+
+    /**
+     * A unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please include the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned DeploymentUpgrade instance.
+     */
+    private com.oracle.bmc.goldengate.model.DeploymentUpgrade deploymentUpgrade;
+
+    private GetDeploymentUpgradeResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.goldengate.model.DeploymentUpgrade deploymentUpgrade) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.deploymentUpgrade = deploymentUpgrade;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetDeploymentUpgradeResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            deploymentUpgrade(o.getDeploymentUpgrade());
+
+            return this;
+        }
+
+        public GetDeploymentUpgradeResponse build() {
+            return new GetDeploymentUpgradeResponse(
+                    __httpStatusCode__, etag, opcRequestId, deploymentUpgrade);
+        }
+    }
+}

--- a/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/responses/ListDeploymentUpgradesResponse.java
+++ b/bmc-goldengate/src/main/java/com/oracle/bmc/goldengate/responses/ListDeploymentUpgradesResponse.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.goldengate.responses;
+
+import com.oracle.bmc.goldengate.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200407")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListDeploymentUpgradesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * A unique Oracle-assigned identifier for the request. If you need to contact Oracle about a particular request, please include the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response, then a partial list might have been returned. Include this value as the {@code page} parameter for the subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned DeploymentUpgradeCollection instance.
+     */
+    private com.oracle.bmc.goldengate.model.DeploymentUpgradeCollection deploymentUpgradeCollection;
+
+    private ListDeploymentUpgradesResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            com.oracle.bmc.goldengate.model.DeploymentUpgradeCollection
+                    deploymentUpgradeCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.deploymentUpgradeCollection = deploymentUpgradeCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDeploymentUpgradesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            deploymentUpgradeCollection(o.getDeploymentUpgradeCollection());
+
+            return this;
+        }
+
+        public ListDeploymentUpgradesResponse build() {
+            return new ListDeploymentUpgradesResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, deploymentUpgradeCollection);
+        }
+    }
+}

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgent.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgent.java
@@ -100,6 +100,18 @@ public interface ManagementAgent extends AutoCloseable {
     DeployPluginsResponse deployPlugins(DeployPluginsRequest request);
 
     /**
+     * Get the AutoUpgradable configuration for all agents in a tenancy.
+     * The supplied compartmentId must be a tenancy root.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/managementagent/GetAutoUpgradableConfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetAutoUpgradableConfig API.
+     */
+    GetAutoUpgradableConfigResponse getAutoUpgradableConfig(GetAutoUpgradableConfigRequest request);
+
+    /**
      * Gets complete details of the inventory of a given agent id
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -232,6 +244,18 @@ public interface ManagementAgent extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/managementagent/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.
      */
     ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request);
+
+    /**
+     * Sets the AutoUpgradable configuration for all agents in a tenancy.
+     * The supplied compartmentId must be a tenancy root.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/managementagent/SetAutoUpgradableConfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SetAutoUpgradableConfig API.
+     */
+    SetAutoUpgradableConfigResponse setAutoUpgradableConfig(SetAutoUpgradableConfigRequest request);
 
     /**
      * Gets count of the inventory of agents for a given compartment id, group by, and isPluginDeployed parameters.

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentAsync.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentAsync.java
@@ -131,6 +131,24 @@ public interface ManagementAgentAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Get the AutoUpgradable configuration for all agents in a tenancy.
+     * The supplied compartmentId must be a tenancy root.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetAutoUpgradableConfigResponse> getAutoUpgradableConfig(
+            GetAutoUpgradableConfigRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetAutoUpgradableConfigRequest, GetAutoUpgradableConfigResponse>
+                    handler);
+
+    /**
      * Gets complete details of the inventory of a given agent id
      *
      * @param request The request object containing the details to send
@@ -331,6 +349,24 @@ public interface ManagementAgentAsync extends AutoCloseable {
     java.util.concurrent.Future<ListWorkRequestsResponse> listWorkRequests(
             ListWorkRequestsRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListWorkRequestsRequest, ListWorkRequestsResponse>
+                    handler);
+
+    /**
+     * Sets the AutoUpgradable configuration for all agents in a tenancy.
+     * The supplied compartmentId must be a tenancy root.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SetAutoUpgradableConfigResponse> setAutoUpgradableConfig(
+            SetAutoUpgradableConfigRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            SetAutoUpgradableConfigRequest, SetAutoUpgradableConfigResponse>
                     handler);
 
     /**

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentAsyncClient.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentAsyncClient.java
@@ -601,6 +601,47 @@ public class ManagementAgentAsyncClient implements ManagementAgentAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetAutoUpgradableConfigResponse> getAutoUpgradableConfig(
+            GetAutoUpgradableConfigRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetAutoUpgradableConfigRequest, GetAutoUpgradableConfigResponse>
+                    handler) {
+        LOG.trace("Called async getAutoUpgradableConfig");
+        final GetAutoUpgradableConfigRequest interceptedRequest =
+                GetAutoUpgradableConfigConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAutoUpgradableConfigConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetAutoUpgradableConfigResponse>
+                transformer = GetAutoUpgradableConfigConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetAutoUpgradableConfigRequest, GetAutoUpgradableConfigResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetAutoUpgradableConfigRequest, GetAutoUpgradableConfigResponse>,
+                        java.util.concurrent.Future<GetAutoUpgradableConfigResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetAutoUpgradableConfigRequest, GetAutoUpgradableConfigResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetManagementAgentResponse> getManagementAgent(
             GetManagementAgentRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -1099,6 +1140,53 @@ public class ManagementAgentAsyncClient implements ManagementAgentAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListWorkRequestsRequest, ListWorkRequestsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SetAutoUpgradableConfigResponse> setAutoUpgradableConfig(
+            SetAutoUpgradableConfigRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            SetAutoUpgradableConfigRequest, SetAutoUpgradableConfigResponse>
+                    handler) {
+        LOG.trace("Called async setAutoUpgradableConfig");
+        final SetAutoUpgradableConfigRequest interceptedRequest =
+                SetAutoUpgradableConfigConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SetAutoUpgradableConfigConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SetAutoUpgradableConfigResponse>
+                transformer = SetAutoUpgradableConfigConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SetAutoUpgradableConfigRequest, SetAutoUpgradableConfigResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SetAutoUpgradableConfigRequest, SetAutoUpgradableConfigResponse>,
+                        java.util.concurrent.Future<SetAutoUpgradableConfigResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getSetAutoUpgradableConfigDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SetAutoUpgradableConfigRequest, SetAutoUpgradableConfigResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentClient.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/ManagementAgentClient.java
@@ -612,6 +612,35 @@ public class ManagementAgentClient implements ManagementAgent {
     }
 
     @Override
+    public GetAutoUpgradableConfigResponse getAutoUpgradableConfig(
+            GetAutoUpgradableConfigRequest request) {
+        LOG.trace("Called getAutoUpgradableConfig");
+        final GetAutoUpgradableConfigRequest interceptedRequest =
+                GetAutoUpgradableConfigConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetAutoUpgradableConfigConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetAutoUpgradableConfigResponse>
+                transformer = GetAutoUpgradableConfigConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetManagementAgentResponse getManagementAgent(GetManagementAgentRequest request) {
         LOG.trace("Called getManagementAgent");
         final GetManagementAgentRequest interceptedRequest =
@@ -965,6 +994,40 @@ public class ManagementAgentClient implements ManagementAgent {
                             retryRequest,
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SetAutoUpgradableConfigResponse setAutoUpgradableConfig(
+            SetAutoUpgradableConfigRequest request) {
+        LOG.trace("Called setAutoUpgradableConfig");
+        final SetAutoUpgradableConfigRequest interceptedRequest =
+                SetAutoUpgradableConfigConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SetAutoUpgradableConfigConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, SetAutoUpgradableConfigResponse>
+                transformer = SetAutoUpgradableConfigConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getSetAutoUpgradableConfigDetails(),
+                                                retriedRequest);
                                 return transformer.apply(response);
                             });
                 });

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/GetAutoUpgradableConfigConverter.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/GetAutoUpgradableConfigConverter.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.managementagent.model.*;
+import com.oracle.bmc.managementagent.requests.*;
+import com.oracle.bmc.managementagent.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.extern.slf4j.Slf4j
+public class GetAutoUpgradableConfigConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.managementagent.requests.GetAutoUpgradableConfigRequest
+            interceptRequest(
+                    com.oracle.bmc.managementagent.requests.GetAutoUpgradableConfigRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.managementagent.requests.GetAutoUpgradableConfigRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200202")
+                        .path("managementAgents")
+                        .path("actions")
+                        .path("getAutoUpgradableConfig");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.managementagent.responses.GetAutoUpgradableConfigResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.managementagent.responses.GetAutoUpgradableConfigResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.managementagent.responses
+                                        .GetAutoUpgradableConfigResponse>() {
+                            @Override
+                            public com.oracle.bmc.managementagent.responses
+                                            .GetAutoUpgradableConfigResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.managementagent.responses.GetAutoUpgradableConfigResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.managementagent.model
+                                                                .AutoUpgradableConfig>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.managementagent.model
+                                                                        .AutoUpgradableConfig
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.managementagent.model
+                                                        .AutoUpgradableConfig>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.managementagent.responses
+                                                .GetAutoUpgradableConfigResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.managementagent.responses
+                                                        .GetAutoUpgradableConfigResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.autoUpgradableConfig(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.managementagent.responses
+                                                .GetAutoUpgradableConfigResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/ListManagementAgentImagesConverter.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/ListManagementAgentImagesConverter.java
@@ -88,6 +88,14 @@ public class ListManagementAgentImagesConverter {
                                     request.getLifecycleState().getValue()));
         }
 
+        if (request.getInstallType() != null) {
+            target =
+                    target.queryParam(
+                            "installType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstallType().getValue()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/ListManagementAgentsConverter.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/ListManagementAgentsConverter.java
@@ -106,6 +106,14 @@ public class ListManagementAgentsConverter {
                                     request.getIsCustomerDeployed()));
         }
 
+        if (request.getInstallType() != null) {
+            target =
+                    target.queryParam(
+                            "installType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstallType().getValue()));
+        }
+
         if (request.getLimit() != null) {
             target =
                     target.queryParam(

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/SetAutoUpgradableConfigConverter.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/SetAutoUpgradableConfigConverter.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.managementagent.model.*;
+import com.oracle.bmc.managementagent.requests.*;
+import com.oracle.bmc.managementagent.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.extern.slf4j.Slf4j
+public class SetAutoUpgradableConfigConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.managementagent.requests.SetAutoUpgradableConfigRequest
+            interceptRequest(
+                    com.oracle.bmc.managementagent.requests.SetAutoUpgradableConfigRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.managementagent.requests.SetAutoUpgradableConfigRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getSetAutoUpgradableConfigDetails(),
+                "setAutoUpgradableConfigDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200202")
+                        .path("managementAgents")
+                        .path("actions")
+                        .path("setAutoUpgradableConfig");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.managementagent.responses.SetAutoUpgradableConfigResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.managementagent.responses.SetAutoUpgradableConfigResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.managementagent.responses
+                                        .SetAutoUpgradableConfigResponse>() {
+                            @Override
+                            public com.oracle.bmc.managementagent.responses
+                                            .SetAutoUpgradableConfigResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.managementagent.responses.SetAutoUpgradableConfigResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.managementagent.model
+                                                                .AutoUpgradableConfig>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.managementagent.model
+                                                                        .AutoUpgradableConfig
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.managementagent.model
+                                                        .AutoUpgradableConfig>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.managementagent.responses
+                                                .SetAutoUpgradableConfigResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.managementagent.responses
+                                                        .SetAutoUpgradableConfigResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.autoUpgradableConfig(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.managementagent.responses
+                                                .SetAutoUpgradableConfigResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/SummarizeManagementAgentCountsConverter.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/internal/http/SummarizeManagementAgentCountsConverter.java
@@ -56,6 +56,14 @@ public class SummarizeManagementAgentCountsConverter {
                                     request.getHasPlugins()));
         }
 
+        if (request.getInstallType() != null) {
+            target =
+                    target.queryParam(
+                            "installType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getInstallType().getValue()));
+        }
+
         if (request.getPage() != null) {
             target =
                     target.queryParam(

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/AutoUpgradableConfig.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/AutoUpgradableConfig.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.model;
+
+/**
+ * The tenancy-level agent AutoUpgradable configuration.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AutoUpgradableConfig.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AutoUpgradableConfig {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isAgentAutoUpgradable")
+        private Boolean isAgentAutoUpgradable;
+
+        public Builder isAgentAutoUpgradable(Boolean isAgentAutoUpgradable) {
+            this.isAgentAutoUpgradable = isAgentAutoUpgradable;
+            this.__explicitlySet__.add("isAgentAutoUpgradable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AutoUpgradableConfig build() {
+            AutoUpgradableConfig __instance__ = new AutoUpgradableConfig(isAgentAutoUpgradable);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AutoUpgradableConfig o) {
+            Builder copiedBuilder = isAgentAutoUpgradable(o.getIsAgentAutoUpgradable());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * true if the agents can be upgraded automatically; false if they must be upgraded manually.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAgentAutoUpgradable")
+    Boolean isAgentAutoUpgradable;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/InstallTypes.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/InstallTypes.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.model;
+
+/**
+ * Supported install types.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.extern.slf4j.Slf4j
+public enum InstallTypes {
+    Agent("AGENT"),
+    Gateway("GATEWAY"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, InstallTypes> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (InstallTypes v : InstallTypes.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    InstallTypes(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static InstallTypes create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'InstallTypes', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgent.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgent.java
@@ -87,6 +87,15 @@ public class ManagementAgent {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceArtifactVersion")
+        private String resourceArtifactVersion;
+
+        public Builder resourceArtifactVersion(String resourceArtifactVersion) {
+            this.resourceArtifactVersion = resourceArtifactVersion;
+            this.__explicitlySet__.add("resourceArtifactVersion");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("host")
         private String host;
 
@@ -204,6 +213,15 @@ public class ManagementAgent {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("installType")
+        private InstallTypes installType;
+
+        public Builder installType(InstallTypes installType) {
+            this.installType = installType;
+            this.__explicitlySet__.add("installType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -236,6 +254,7 @@ public class ManagementAgent {
                             platformName,
                             platformVersion,
                             version,
+                            resourceArtifactVersion,
                             host,
                             hostId,
                             installPath,
@@ -249,6 +268,7 @@ public class ManagementAgent {
                             lifecycleState,
                             lifecycleDetails,
                             isCustomerDeployed,
+                            installType,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -265,6 +285,7 @@ public class ManagementAgent {
                             .platformName(o.getPlatformName())
                             .platformVersion(o.getPlatformVersion())
                             .version(o.getVersion())
+                            .resourceArtifactVersion(o.getResourceArtifactVersion())
                             .host(o.getHost())
                             .hostId(o.getHostId())
                             .installPath(o.getInstallPath())
@@ -278,6 +299,7 @@ public class ManagementAgent {
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
                             .isCustomerDeployed(o.getIsCustomerDeployed())
+                            .installType(o.getInstallType())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -336,6 +358,17 @@ public class ManagementAgent {
     String version;
 
     /**
+     * Version of the deployment artifact instantiated by this Management Agent.
+     * The format for Standalone resourceMode is YYMMDD.HHMM, and the format for other modes
+     * (whose artifacts are based upon Standalone but can advance independently)
+     * is YYMMDD.HHMM.VVVVVVVVVVVV.
+     * VVVVVVVVVVVV is always a numeric value between 000000000000 and 999999999999
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceArtifactVersion")
+    String resourceArtifactVersion;
+
+    /**
      * Management Agent host machine name
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("host")
@@ -366,7 +399,7 @@ public class ManagementAgent {
     String compartmentId;
 
     /**
-     * true if the agent can be upgraded automatically; false if it must be upgraded manually.
+     * true if the agent can be upgraded automatically; false if it must be upgraded manually. This flag is derived from the tenancy level auto upgrade preference.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isAgentAutoUpgradable")
     Boolean isAgentAutoUpgradable;
@@ -412,6 +445,12 @@ public class ManagementAgent {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isCustomerDeployed")
     Boolean isCustomerDeployed;
+
+    /**
+     * The install type, either AGENT or GATEWAY
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("installType")
+    InstallTypes installType;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgentAggregationDimensions.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgentAggregationDimensions.java
@@ -62,13 +62,22 @@ public class ManagementAgentAggregationDimensions {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("installType")
+        private InstallTypes installType;
+
+        public Builder installType(InstallTypes installType) {
+            this.installType = installType;
+            this.__explicitlySet__.add("installType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ManagementAgentAggregationDimensions build() {
             ManagementAgentAggregationDimensions __instance__ =
                     new ManagementAgentAggregationDimensions(
-                            availabilityStatus, platformType, version, hasPlugins);
+                            availabilityStatus, platformType, version, hasPlugins, installType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -79,7 +88,8 @@ public class ManagementAgentAggregationDimensions {
                     availabilityStatus(o.getAvailabilityStatus())
                             .platformType(o.getPlatformType())
                             .version(o.getVersion())
-                            .hasPlugins(o.getHasPlugins());
+                            .hasPlugins(o.getHasPlugins())
+                            .installType(o.getInstallType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -116,6 +126,12 @@ public class ManagementAgentAggregationDimensions {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("hasPlugins")
     Boolean hasPlugins;
+
+    /**
+     * The install type, either AGENT or GATEWAY
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("installType")
+    InstallTypes installType;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgentPluginAggregationDimensions.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgentPluginAggregationDimensions.java
@@ -35,19 +35,29 @@ public class ManagementAgentPluginAggregationDimensions {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("pluginDisplayName")
+        private String pluginDisplayName;
+
+        public Builder pluginDisplayName(String pluginDisplayName) {
+            this.pluginDisplayName = pluginDisplayName;
+            this.__explicitlySet__.add("pluginDisplayName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ManagementAgentPluginAggregationDimensions build() {
             ManagementAgentPluginAggregationDimensions __instance__ =
-                    new ManagementAgentPluginAggregationDimensions(pluginName);
+                    new ManagementAgentPluginAggregationDimensions(pluginName, pluginDisplayName);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ManagementAgentPluginAggregationDimensions o) {
-            Builder copiedBuilder = pluginName(o.getPluginName());
+            Builder copiedBuilder =
+                    pluginName(o.getPluginName()).pluginDisplayName(o.getPluginDisplayName());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -66,6 +76,12 @@ public class ManagementAgentPluginAggregationDimensions {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("pluginName")
     String pluginName;
+
+    /**
+     * Management Agent Plugin Display Name
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("pluginDisplayName")
+    String pluginDisplayName;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgentSummary.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/ManagementAgentSummary.java
@@ -89,6 +89,15 @@ public class ManagementAgentSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceArtifactVersion")
+        private String resourceArtifactVersion;
+
+        public Builder resourceArtifactVersion(String resourceArtifactVersion) {
+            this.resourceArtifactVersion = resourceArtifactVersion;
+            this.__explicitlySet__.add("resourceArtifactVersion");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isAgentAutoUpgradable")
         private Boolean isAgentAutoUpgradable;
 
@@ -197,6 +206,15 @@ public class ManagementAgentSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("installType")
+        private InstallTypes installType;
+
+        public Builder installType(InstallTypes installType) {
+            this.installType = installType;
+            this.__explicitlySet__.add("installType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -229,6 +247,7 @@ public class ManagementAgentSummary {
                             platformName,
                             platformVersion,
                             version,
+                            resourceArtifactVersion,
                             isAgentAutoUpgradable,
                             timeCreated,
                             timeUpdated,
@@ -241,6 +260,7 @@ public class ManagementAgentSummary {
                             lifecycleState,
                             lifecycleDetails,
                             isCustomerDeployed,
+                            installType,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -257,6 +277,7 @@ public class ManagementAgentSummary {
                             .platformName(o.getPlatformName())
                             .platformVersion(o.getPlatformVersion())
                             .version(o.getVersion())
+                            .resourceArtifactVersion(o.getResourceArtifactVersion())
                             .isAgentAutoUpgradable(o.getIsAgentAutoUpgradable())
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
@@ -269,6 +290,7 @@ public class ManagementAgentSummary {
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
                             .isCustomerDeployed(o.getIsCustomerDeployed())
+                            .installType(o.getInstallType())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -327,7 +349,18 @@ public class ManagementAgentSummary {
     String version;
 
     /**
-     * true if the agent can be upgraded automatically; false if it must be upgraded manually.
+     * Version of the deployment artifact instantiated by this Management Agent.
+     * The format for Standalone resourceMode is YYMMDD.HHMM, and the format for other modes
+     * (whose artifacts are based upon Standalone but can advance independently)
+     * is YYMMDD.HHMM.VVVVVVVVVVVV.
+     * VVVVVVVVVVVV is always a numeric value between 000000000000 and 999999999999
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceArtifactVersion")
+    String resourceArtifactVersion;
+
+    /**
+     * true if the agent can be upgraded automatically; false if it must be upgraded manually. This flag is derived from the tenancy level auto upgrade preference.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isAgentAutoUpgradable")
     Boolean isAgentAutoUpgradable;
@@ -397,6 +430,12 @@ public class ManagementAgentSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isCustomerDeployed")
     Boolean isCustomerDeployed;
+
+    /**
+     * The install type, either AGENT or GATEWAY
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("installType")
+    InstallTypes installType;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/SetAutoUpgradableConfigDetails.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/SetAutoUpgradableConfigDetails.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.model;
+
+/**
+ * Details for configuring tenancy-level agent AutoUpgradable configuration.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = SetAutoUpgradableConfigDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class SetAutoUpgradableConfigDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isAgentAutoUpgradable")
+        private Boolean isAgentAutoUpgradable;
+
+        public Builder isAgentAutoUpgradable(Boolean isAgentAutoUpgradable) {
+            this.isAgentAutoUpgradable = isAgentAutoUpgradable;
+            this.__explicitlySet__.add("isAgentAutoUpgradable");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public SetAutoUpgradableConfigDetails build() {
+            SetAutoUpgradableConfigDetails __instance__ =
+                    new SetAutoUpgradableConfigDetails(compartmentId, isAgentAutoUpgradable);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(SetAutoUpgradableConfigDetails o) {
+            Builder copiedBuilder =
+                    compartmentId(o.getCompartmentId())
+                            .isAgentAutoUpgradable(o.getIsAgentAutoUpgradable());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Tenancy identifier i.e, Root compartment identifier
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * true if the agents can be upgraded automatically; false if they must be upgraded manually.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAgentAutoUpgradable")
+    Boolean isAgentAutoUpgradable;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/UpdateManagementAgentDetails.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/model/UpdateManagementAgentDetails.java
@@ -26,15 +26,6 @@ public class UpdateManagementAgentDetails {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
-        @com.fasterxml.jackson.annotation.JsonProperty("isAgentAutoUpgradable")
-        private Boolean isAgentAutoUpgradable;
-
-        public Builder isAgentAutoUpgradable(Boolean isAgentAutoUpgradable) {
-            this.isAgentAutoUpgradable = isAgentAutoUpgradable;
-            this.__explicitlySet__.add("isAgentAutoUpgradable");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("displayName")
         private String displayName;
 
@@ -68,8 +59,7 @@ public class UpdateManagementAgentDetails {
 
         public UpdateManagementAgentDetails build() {
             UpdateManagementAgentDetails __instance__ =
-                    new UpdateManagementAgentDetails(
-                            isAgentAutoUpgradable, displayName, freeformTags, definedTags);
+                    new UpdateManagementAgentDetails(displayName, freeformTags, definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -77,8 +67,7 @@ public class UpdateManagementAgentDetails {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateManagementAgentDetails o) {
             Builder copiedBuilder =
-                    isAgentAutoUpgradable(o.getIsAgentAutoUpgradable())
-                            .displayName(o.getDisplayName())
+                    displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -93,12 +82,6 @@ public class UpdateManagementAgentDetails {
     public static Builder builder() {
         return new Builder();
     }
-
-    /**
-     * Setting of this flag is no longer supported.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("isAgentAutoUpgradable")
-    Boolean isAgentAutoUpgradable;
 
     /**
      * New displayName of Agent.

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/GetAutoUpgradableConfigRequest.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/GetAutoUpgradableConfigRequest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.requests;
+
+import com.oracle.bmc.managementagent.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/managementagent/GetAutoUpgradableConfigExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetAutoUpgradableConfigRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetAutoUpgradableConfigRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the compartment to which a request will be scoped.
+     */
+    private String compartmentId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetAutoUpgradableConfigRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAutoUpgradableConfigRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetAutoUpgradableConfigRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetAutoUpgradableConfigRequest
+         */
+        public GetAutoUpgradableConfigRequest build() {
+            GetAutoUpgradableConfigRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/ListManagementAgentImagesRequest.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/ListManagementAgentImagesRequest.java
@@ -142,6 +142,11 @@ public class ListManagementAgentImagesRequest
      */
     private com.oracle.bmc.managementagent.model.LifecycleStates lifecycleState;
 
+    /**
+     * A filter to return either agents or gateway types depending upon install type selected by user. By default both install type will be returned.
+     */
+    private com.oracle.bmc.managementagent.model.InstallTypes installType;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListManagementAgentImagesRequest, java.lang.Void> {
@@ -186,6 +191,7 @@ public class ListManagementAgentImagesRequest
             sortBy(o.getSortBy());
             name(o.getName());
             lifecycleState(o.getLifecycleState());
+            installType(o.getInstallType());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/ListManagementAgentsRequest.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/ListManagementAgentsRequest.java
@@ -66,6 +66,11 @@ public class ListManagementAgentsRequest
     private Boolean isCustomerDeployed;
 
     /**
+     * A filter to return either agents or gateway types depending upon install type selected by user. By default both install type will be returned.
+     */
+    private com.oracle.bmc.managementagent.model.InstallTypes installType;
+
+    /**
      * The maximum number of items to return.
      */
     private Integer limit;
@@ -270,6 +275,7 @@ public class ListManagementAgentsRequest
             hostId(o.getHostId());
             platformType(o.getPlatformType());
             isCustomerDeployed(o.getIsCustomerDeployed());
+            installType(o.getInstallType());
             limit(o.getLimit());
             page(o.getPage());
             sortOrder(o.getSortOrder());

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/SetAutoUpgradableConfigRequest.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/SetAutoUpgradableConfigRequest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.requests;
+
+import com.oracle.bmc.managementagent.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/managementagent/SetAutoUpgradableConfigExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SetAutoUpgradableConfigRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SetAutoUpgradableConfigRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.managementagent.model.SetAutoUpgradableConfigDetails> {
+
+    /**
+     * Details of the AutoUpgradable configuration for agents of the tenancy.
+     */
+    private com.oracle.bmc.managementagent.model.SetAutoUpgradableConfigDetails
+            setAutoUpgradableConfigDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.managementagent.model.SetAutoUpgradableConfigDetails getBody$() {
+        return setAutoUpgradableConfigDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SetAutoUpgradableConfigRequest,
+                    com.oracle.bmc.managementagent.model.SetAutoUpgradableConfigDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SetAutoUpgradableConfigRequest o) {
+            setAutoUpgradableConfigDetails(o.getSetAutoUpgradableConfigDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SetAutoUpgradableConfigRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SetAutoUpgradableConfigRequest
+         */
+        public SetAutoUpgradableConfigRequest build() {
+            SetAutoUpgradableConfigRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.managementagent.model.SetAutoUpgradableConfigDetails body) {
+            setAutoUpgradableConfigDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/SummarizeManagementAgentCountsRequest.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/requests/SummarizeManagementAgentCountsRequest.java
@@ -36,6 +36,11 @@ public class SummarizeManagementAgentCountsRequest
     private Boolean hasPlugins;
 
     /**
+     * A filter to return either agents or gateway types depending upon install type selected by user. By default both install type will be returned.
+     */
+    private com.oracle.bmc.managementagent.model.InstallTypes installType;
+
+    /**
      * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
      */
     private String page;
@@ -105,6 +110,7 @@ public class SummarizeManagementAgentCountsRequest
             compartmentId(o.getCompartmentId());
             groupBy(o.getGroupBy());
             hasPlugins(o.getHasPlugins());
+            installType(o.getInstallType());
             page(o.getPage());
             opcRequestId(o.getOpcRequestId());
             invocationCallback(o.getInvocationCallback());

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/responses/GetAutoUpgradableConfigResponse.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/responses/GetAutoUpgradableConfigResponse.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.responses;
+
+import com.oracle.bmc.managementagent.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetAutoUpgradableConfigResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned AutoUpgradableConfig instance.
+     */
+    private com.oracle.bmc.managementagent.model.AutoUpgradableConfig autoUpgradableConfig;
+
+    private GetAutoUpgradableConfigResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            com.oracle.bmc.managementagent.model.AutoUpgradableConfig autoUpgradableConfig) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.autoUpgradableConfig = autoUpgradableConfig;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetAutoUpgradableConfigResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            autoUpgradableConfig(o.getAutoUpgradableConfig());
+
+            return this;
+        }
+
+        public GetAutoUpgradableConfigResponse build() {
+            return new GetAutoUpgradableConfigResponse(
+                    __httpStatusCode__, opcRequestId, autoUpgradableConfig);
+        }
+    }
+}

--- a/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/responses/SetAutoUpgradableConfigResponse.java
+++ b/bmc-managementagent/src/main/java/com/oracle/bmc/managementagent/responses/SetAutoUpgradableConfigResponse.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.managementagent.responses;
+
+import com.oracle.bmc.managementagent.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200202")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SetAutoUpgradableConfigResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned AutoUpgradableConfig instance.
+     */
+    private com.oracle.bmc.managementagent.model.AutoUpgradableConfig autoUpgradableConfig;
+
+    private SetAutoUpgradableConfigResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            com.oracle.bmc.managementagent.model.AutoUpgradableConfig autoUpgradableConfig) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.autoUpgradableConfig = autoUpgradableConfig;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SetAutoUpgradableConfigResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            autoUpgradableConfig(o.getAutoUpgradableConfig());
+
+            return this;
+        }
+
+        public SetAutoUpgradableConfigResponse build() {
+            return new SetAutoUpgradableConfigResponse(
+                    __httpStatusCode__, opcRequestId, autoUpgradableConfig);
+        }
+    }
+}

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/Backup.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/Backup.java
@@ -417,12 +417,14 @@ public class Backup {
     @com.fasterxml.jackson.annotation.JsonProperty("backupType")
     BackupType backupType;
     /**
-     * If the backup was created automatically, or by a manual request.
+     * Indicates how the backup was created: manually, automatic, or by an Operator.
+     *
      **/
     @lombok.extern.slf4j.Slf4j
     public enum CreationType {
         Manual("MANUAL"),
         Automatic("AUTOMATIC"),
+        Operator("OPERATOR"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this
@@ -463,7 +465,8 @@ public class Backup {
         }
     };
     /**
-     * If the backup was created automatically, or by a manual request.
+     * Indicates how the backup was created: manually, automatic, or by an Operator.
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("creationType")
     CreationType creationType;

--- a/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ConfigurationVariables.java
+++ b/bmc-mysql/src/main/java/com/oracle/bmc/mysql/model/ConfigurationVariables.java
@@ -163,6 +163,33 @@ public class ConfigurationVariables {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("binlogRowMetadata")
+        private BinlogRowMetadata binlogRowMetadata;
+
+        public Builder binlogRowMetadata(BinlogRowMetadata binlogRowMetadata) {
+            this.binlogRowMetadata = binlogRowMetadata;
+            this.__explicitlySet__.add("binlogRowMetadata");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("binlogRowValueOptions")
+        private String binlogRowValueOptions;
+
+        public Builder binlogRowValueOptions(String binlogRowValueOptions) {
+            this.binlogRowValueOptions = binlogRowValueOptions;
+            this.__explicitlySet__.add("binlogRowValueOptions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("binlogTransactionCompression")
+        private Boolean binlogTransactionCompression;
+
+        public Builder binlogTransactionCompression(Boolean binlogTransactionCompression) {
+            this.binlogTransactionCompression = binlogTransactionCompression;
+            this.__explicitlySet__.add("binlogTransactionCompression");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("innodbBufferPoolSize")
         private Long innodbBufferPoolSize;
 
@@ -513,6 +540,9 @@ public class ConfigurationVariables {
                             sqlRequirePrimaryKey,
                             sqlWarnings,
                             binlogExpireLogsSeconds,
+                            binlogRowMetadata,
+                            binlogRowValueOptions,
+                            binlogTransactionCompression,
                             innodbBufferPoolSize,
                             innodbFtResultCacheLimit,
                             maxConnections,
@@ -571,6 +601,9 @@ public class ConfigurationVariables {
                             .sqlRequirePrimaryKey(o.getSqlRequirePrimaryKey())
                             .sqlWarnings(o.getSqlWarnings())
                             .binlogExpireLogsSeconds(o.getBinlogExpireLogsSeconds())
+                            .binlogRowMetadata(o.getBinlogRowMetadata())
+                            .binlogRowValueOptions(o.getBinlogRowValueOptions())
+                            .binlogTransactionCompression(o.getBinlogTransactionCompression())
                             .innodbBufferPoolSize(o.getInnodbBufferPoolSize())
                             .innodbFtResultCacheLimit(o.getInnodbFtResultCacheLimit())
                             .maxConnections(o.getMaxConnections())
@@ -959,10 +992,83 @@ public class ConfigurationVariables {
     Boolean sqlWarnings;
 
     /**
-     * ("binlog_expire_logs_seconds") DEPRECATED -- variable should not be settable and will be ignored
+     * Sets the binary log expiration period in seconds.
+     * binlogExpireLogsSeconds corresponds to the MySQL binary logging system variable [binlog_expire_logs_seconds](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds).
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("binlogExpireLogsSeconds")
     Integer binlogExpireLogsSeconds;
+    /**
+     * Configures the amount of table metadata added to the binary log when using row-based logging.
+     * binlogRowMetadata corresponds to the MySQL binary logging system variable [binlog_row_metadata](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_row_metadata).
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum BinlogRowMetadata {
+        Full("FULL"),
+        Minimal("MINIMAL"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, BinlogRowMetadata> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (BinlogRowMetadata v : BinlogRowMetadata.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        BinlogRowMetadata(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static BinlogRowMetadata create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'BinlogRowMetadata', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Configures the amount of table metadata added to the binary log when using row-based logging.
+     * binlogRowMetadata corresponds to the MySQL binary logging system variable [binlog_row_metadata](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_row_metadata).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("binlogRowMetadata")
+    BinlogRowMetadata binlogRowMetadata;
+
+    /**
+     * When set to PARTIAL_JSON, this enables use of a space-efficient binary log format for updates that modify only a small portion of a JSON document.
+     * binlogRowValueOptions corresponds to the MySQL binary logging system variable [binlog_row_value_options](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_row_value_options).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("binlogRowValueOptions")
+    String binlogRowValueOptions;
+
+    /**
+     * Enables compression for transactions that are written to binary log files on this server.
+     * binlogTransactionCompression corresponds to the MySQL binary logging system variable [binlog_transaction_compression](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_transaction_compression).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("binlogTransactionCompression")
+    Boolean binlogTransactionCompression;
 
     /**
      * ("innodb_buffer_pool_size")

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.6.0</version>
+  <version>2.7.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for configuring Binlog variables in the MySQL Database service

- Support new response value "OPERATOR" for backup creationType in list and get MDS backup API in the MySQL Database service

- Support for SetAutoUpgradableConfig and GetAutoUpgradableConfig operations in Management Agent Cloud service

- Support for additional installType filter for List Management Agents, Images and Count API operations in Management Agent Cloud service

- Support for list and read DeploymentUpgrade, cancel and restore DeploymentBackup in the Golden Gate service

- Support for non-autonomous databases targets, executing Pre-Migration advisor, uploading Datapump logs into Object Storage bucket, and filtering Database Objects in the Database Migration service

- Support for calling Oracle Cloud Infrastructure services in the ap-ibaraki-1 region



### Breaking changes

- Return type of method `public com.oracle.bmc.databasemigration.model.LifecycleStates getLifecycleState()` has been changed to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in the Database Migration service

- Method `public java.lang.String getCompartmentId()` has been removed from model `com.oracle.bmc.databasemigration.model.UpdateAgentDetails` in the Database Migration service

- Method `public java.util.Date getTimeStamp()` has been removed from the model `com.oracle.bmc.databasemigration.model.WorkRequestError` in the Database Migration service

- Method `public java.util.Date getTimeStamp()` has been removed from the model `com.oracle.bmc.databasemigration.model.WorkRequestLogEntry` in the Database Migration service

- Return type of method `public com.oracle.bmc.databasemigration.model.LifecycleStates getLifecycleState()` has been changed to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in `com.oracle.bmc.databasemigration.requests.ListMigrationsRequest` in the Database Migration service

- Method `public java.lang.String getDisplayName()` has been removed from `com.oracle.bmc.databasemigration.requests.ListWorkRequestErrorsRequest` in the Database Migration service

- Removed field `DisplayName` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestErrorsRequest$SortBy` in the Database Migration service

- Removed field `TimeCreated` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestErrorsRequest$SortBy` in the Database Migration service

- Method `public java.lang.String getDisplayName()` has been removed from `com.oracle.bmc.databasemigration.requests.ListWorkRequestLogsRequest` in the Database Migration service

- Removed field `DisplayName` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestLogsRequest$SortBy` in the Database Migration service

- Removed field `TimeCreated` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestLogsRequest$SortBy` in the Database Migration service

- Method `public java.lang.String getDisplayName()` has been removed from `com.oracle.bmc.databasemigration.requests.ListWorkRequestsRequest` in the Database Migration service

- Removed field `DisplayName` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestsRequest$SortBy` in the Database Migration service

- Removed field `TimeCreated` from `com.oracle.bmc.databasemigration.requests.ListWorkRequestsRequest$SortBy` in the Database Migration service

- Parameter 2 of `public com.oracle.bmc.waiter.Waiter forMigration(com.oracle.bmc.databasemigration.requests.GetMigrationRequest, com.oracle.bmc.databasemigration.model.LifecycleStates[])` has changed its type to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates[]` in `com.oracle.bmc.databasemigration.DatabaseMigrationWaiters` in the Database Migration service

- Parameter 2 of `public com.oracle.bmc.waiter.Waiter forMigration(com.oracle.bmc.databasemigration.requests.GetMigrationRequest, com.oracle.bmc.databasemigration.model.LifecycleStates, com.oracle.bmc.waiter.TerminationStrategy, com.oracle.bmc.waiter.DelayStrategy)` has changed its type to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in `com.oracle.bmc.databasemigration.DatabaseMigrationWaiters` in the Database Migration service

- Parameter 4 of `public com.oracle.bmc.waiter.Waiter forMigration(com.oracle.bmc.databasemigration.requests.GetMigrationRequest, com.oracle.bmc.waiter.TerminationStrategy, com.oracle.bmc.waiter.DelayStrategy, com.oracle.bmc.databasemigration.model.LifecycleStates[])` has changed its type to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates[]` in `com.oracle.bmc.databasemigration.DatabaseMigrationWaiters` in the Database Migration service

- Return type of method `public com.oracle.bmc.databasemigration.model.LifecycleStates getLifecycleState()` has been changed to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in the model `com.oracle.bmc.databasemigration.model.Migration` in the Database Migration service

- Return type of method `public com.oracle.bmc.databasemigration.model.LifecycleStates getLifecycleState()` has been changed to `com.oracle.bmc.databasemigration.model.MigrationLifecycleStates` in the model `com.oracle.bmc.databasemigration.model.MigrationSummary` in the Database Migration service

- Method `public java.lang.Boolean getIsAgentAutoUpgradable()` has been removed from `com.oracle.bmc.managementagent.model.UpdateManagementAgentDetails` in the Management Agent Cloud service