### PR TITLE
Releasing version 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.7.2 - 2021-10-19
+### Added
+- Support for creating database systems from backups with database software images in the Database service
+- Support for optionally providing a SID prefix during Exadata database creation in the Database service
+- Support for node subsetting on VM clusters in the Database service
+- Support for non-CDB to PDB conversion in the Database service
+- Support for default homepages, unprocessed data buckets, and parsing geostats in the Logging Analytics service
+
 ## 2.7.1 - 2021-10-12
 ### Added
 - Support for the Data Labeling Service
-- Support for the Web Application Firewall service
 - Support for querying and setting Application Performance Monitoring configurations in the Application Performance Monitoring service
 - Support for the run-once monitor feature and network data collection in the Application Performance Monitoring service
 - Support for Oracle Enterprise Manager bridges, source auto-association, source event types mapping, and partitioning and searching data by LogSet in the Logging Analytics service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,528 +19,528 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeComputeCapacityReservationCompartmentResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ChangeComputeCapacityReservationCompartmentResponse.java
@@ -9,7 +9,7 @@ import com.oracle.bmc.core.model.*;
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
 @lombok.Builder(builderClassName = "Builder")
 @lombok.ToString(callSuper = true)
-@lombok.EqualsAndHashCode
+@lombok.EqualsAndHashCode(callSuper = true)
 @lombok.Getter
 public class ChangeComputeCapacityReservationCompartmentResponse
         extends com.oracle.bmc.responses.BmcResponse {

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
@@ -71,6 +71,18 @@ public interface Database extends AutoCloseable {
             AddStorageCapacityExadataInfrastructureRequest request);
 
     /**
+     * Add Virtual Machines to the VM cluster. Applies to Exadata Cloud@Customer instances only.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/AddVirtualMachineToVmClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use AddVirtualMachineToVmCluster API.
+     */
+    AddVirtualMachineToVmClusterResponse addVirtualMachineToVmCluster(
+            AddVirtualMachineToVmClusterRequest request);
+
+    /**
      * Initiates a data refresh for an Autonomous Database refreshable clone. Data is refreshed from the source database to the point of a specified timestamp.
      *
      * @param request The request object containing the details to send
@@ -329,6 +341,17 @@ public interface Database extends AutoCloseable {
      */
     ConfigureAutonomousDatabaseVaultKeyResponse configureAutonomousDatabaseVaultKey(
             ConfigureAutonomousDatabaseVaultKeyRequest request);
+
+    /**
+     * Converts a non-container database to a pluggable database.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ConvertToPdbExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ConvertToPdb API.
+     */
+    ConvertToPdbResponse convertToPdb(ConvertToPdbRequest request);
 
     /**
      * Creates an Autonomous Container Database in the specified Autonomous Exadata Infrastructure.
@@ -1448,6 +1471,17 @@ public interface Database extends AutoCloseable {
     GetDbNodeResponse getDbNode(GetDbNodeRequest request);
 
     /**
+     * Gets information about the Exadata Db server.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/GetDbServerExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetDbServer API.
+     */
+    GetDbServerResponse getDbServer(GetDbServerRequest request);
+
+    /**
      * Gets information about the specified DB system.
      * <p>
      **Note:** Deprecated for Exadata Cloud Service systems. Use the [new resource model APIs](https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/exaflexsystem.htm#exaflexsystem_topic-resource_model) instead.
@@ -1608,6 +1642,18 @@ public interface Database extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/GetMaintenanceRunExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetMaintenanceRun API.
      */
     GetMaintenanceRunResponse getMaintenanceRun(GetMaintenanceRunRequest request);
+
+    /**
+     * Gets the details of operations performed to convert the specified database from non-container (non-CDB) to pluggable (PDB).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/GetPdbConversionHistoryEntryExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPdbConversionHistoryEntry API.
+     */
+    GetPdbConversionHistoryEntryResponse getPdbConversionHistoryEntry(
+            GetPdbConversionHistoryEntryRequest request);
 
     /**
      * Gets information about the specified pluggable database.
@@ -2037,6 +2083,17 @@ public interface Database extends AutoCloseable {
     ListDbNodesResponse listDbNodes(ListDbNodesRequest request);
 
     /**
+     * Lists the Exadata DB servers in the ExadataInfrastructureId and specified compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListDbServersExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListDbServers API.
+     */
+    ListDbServersResponse listDbServers(ListDbServersRequest request);
+
+    /**
      * Gets the history of the patch actions performed on the specified DB system.
      *
      * @param request The request object containing the details to send
@@ -2197,6 +2254,18 @@ public interface Database extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListMaintenanceRunsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListMaintenanceRuns API.
      */
     ListMaintenanceRunsResponse listMaintenanceRuns(ListMaintenanceRunsRequest request);
+
+    /**
+     * Gets the pluggable database conversion history for a specified database in a bare metal or virtual machine DB system.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListPdbConversionHistoryEntriesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListPdbConversionHistoryEntries API.
+     */
+    ListPdbConversionHistoryEntriesResponse listPdbConversionHistoryEntries(
+            ListPdbConversionHistoryEntriesRequest request);
 
     /**
      * Gets a list of the pluggable databases in a database or compartment. You must provide either a `databaseId` or `compartmentId` value.
@@ -2372,6 +2441,18 @@ public interface Database extends AutoCloseable {
      */
     RemoteClonePluggableDatabaseResponse remoteClonePluggableDatabase(
             RemoteClonePluggableDatabaseRequest request);
+
+    /**
+     * Remove Virtual Machines from the VM cluster. Applies to Exadata Cloud@Customer instances only.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/RemoveVirtualMachineFromVmClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RemoveVirtualMachineFromVmCluster API.
+     */
+    RemoveVirtualMachineFromVmClusterResponse removeVirtualMachineFromVmCluster(
+            RemoveVirtualMachineFromVmClusterRequest request);
 
     /**
      * Rolling restarts the specified Autonomous Container Database.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
@@ -85,6 +85,24 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Add Virtual Machines to the VM cluster. Applies to Exadata Cloud@Customer instances only.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<AddVirtualMachineToVmClusterResponse> addVirtualMachineToVmCluster(
+            AddVirtualMachineToVmClusterRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            AddVirtualMachineToVmClusterRequest,
+                            AddVirtualMachineToVmClusterResponse>
+                    handler);
+
+    /**
      * Initiates a data refresh for an Autonomous Database refreshable clone. Data is refreshed from the source database to the point of a specified timestamp.
      *
      *
@@ -464,6 +482,22 @@ public interface DatabaseAsync extends AutoCloseable {
                                     ConfigureAutonomousDatabaseVaultKeyRequest,
                                     ConfigureAutonomousDatabaseVaultKeyResponse>
                             handler);
+
+    /**
+     * Converts a non-container database to a pluggable database.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ConvertToPdbResponse> convertToPdb(
+            ConvertToPdbRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ConvertToPdbRequest, ConvertToPdbResponse>
+                    handler);
 
     /**
      * Creates an Autonomous Container Database in the specified Autonomous Exadata Infrastructure.
@@ -2123,6 +2157,21 @@ public interface DatabaseAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetDbNodeRequest, GetDbNodeResponse> handler);
 
     /**
+     * Gets information about the Exadata Db server.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetDbServerResponse> getDbServer(
+            GetDbServerRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetDbServerRequest, GetDbServerResponse> handler);
+
+    /**
      * Gets information about the specified DB system.
      * <p>
      **Note:** Deprecated for Exadata Cloud Service systems. Use the [new resource model APIs](https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/exaflexsystem.htm#exaflexsystem_topic-resource_model) instead.
@@ -2356,6 +2405,24 @@ public interface DatabaseAsync extends AutoCloseable {
             GetMaintenanceRunRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             GetMaintenanceRunRequest, GetMaintenanceRunResponse>
+                    handler);
+
+    /**
+     * Gets the details of operations performed to convert the specified database from non-container (non-CDB) to pluggable (PDB).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetPdbConversionHistoryEntryResponse> getPdbConversionHistoryEntry(
+            GetPdbConversionHistoryEntryRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetPdbConversionHistoryEntryRequest,
+                            GetPdbConversionHistoryEntryResponse>
                     handler);
 
     /**
@@ -3001,6 +3068,22 @@ public interface DatabaseAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListDbNodesRequest, ListDbNodesResponse> handler);
 
     /**
+     * Lists the Exadata DB servers in the ExadataInfrastructureId and specified compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListDbServersResponse> listDbServers(
+            ListDbServersRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListDbServersRequest, ListDbServersResponse>
+                    handler);
+
+    /**
      * Gets the history of the patch actions performed on the specified DB system.
      *
      *
@@ -3245,6 +3328,25 @@ public interface DatabaseAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<
                             ListMaintenanceRunsRequest, ListMaintenanceRunsResponse>
                     handler);
+
+    /**
+     * Gets the pluggable database conversion history for a specified database in a bare metal or virtual machine DB system.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListPdbConversionHistoryEntriesResponse>
+            listPdbConversionHistoryEntries(
+                    ListPdbConversionHistoryEntriesRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    ListPdbConversionHistoryEntriesRequest,
+                                    ListPdbConversionHistoryEntriesResponse>
+                            handler);
 
     /**
      * Gets a list of the pluggable databases in a database or compartment. You must provide either a `databaseId` or `compartmentId` value.
@@ -3511,6 +3613,25 @@ public interface DatabaseAsync extends AutoCloseable {
                             RemoteClonePluggableDatabaseRequest,
                             RemoteClonePluggableDatabaseResponse>
                     handler);
+
+    /**
+     * Remove Virtual Machines from the VM cluster. Applies to Exadata Cloud@Customer instances only.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RemoveVirtualMachineFromVmClusterResponse>
+            removeVirtualMachineFromVmCluster(
+                    RemoveVirtualMachineFromVmClusterRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    RemoveVirtualMachineFromVmClusterRequest,
+                                    RemoveVirtualMachineFromVmClusterResponse>
+                            handler);
 
     /**
      * Rolling restarts the specified Autonomous Container Database.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -476,6 +476,56 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<AddVirtualMachineToVmClusterResponse>
+            addVirtualMachineToVmCluster(
+                    AddVirtualMachineToVmClusterRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    AddVirtualMachineToVmClusterRequest,
+                                    AddVirtualMachineToVmClusterResponse>
+                            handler) {
+        LOG.trace("Called async addVirtualMachineToVmCluster");
+        final AddVirtualMachineToVmClusterRequest interceptedRequest =
+                AddVirtualMachineToVmClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddVirtualMachineToVmClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, AddVirtualMachineToVmClusterResponse>
+                transformer = AddVirtualMachineToVmClusterConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        AddVirtualMachineToVmClusterRequest, AddVirtualMachineToVmClusterResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                AddVirtualMachineToVmClusterRequest,
+                                AddVirtualMachineToVmClusterResponse>,
+                        java.util.concurrent.Future<AddVirtualMachineToVmClusterResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getAddVirtualMachineToVmClusterDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    AddVirtualMachineToVmClusterRequest, AddVirtualMachineToVmClusterResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<AutonomousDatabaseManualRefreshResponse>
             autonomousDatabaseManualRefresh(
                     AutonomousDatabaseManualRefreshRequest request,
@@ -1462,6 +1512,49 @@ public class DatabaseAsyncClient implements DatabaseAsync {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ConfigureAutonomousDatabaseVaultKeyRequest,
                     ConfigureAutonomousDatabaseVaultKeyResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ConvertToPdbResponse> convertToPdb(
+            ConvertToPdbRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ConvertToPdbRequest, ConvertToPdbResponse>
+                    handler) {
+        LOG.trace("Called async convertToPdb");
+        final ConvertToPdbRequest interceptedRequest =
+                ConvertToPdbConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ConvertToPdbConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ConvertToPdbResponse>
+                transformer = ConvertToPdbConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ConvertToPdbRequest, ConvertToPdbResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ConvertToPdbRequest, ConvertToPdbResponse>,
+                        java.util.concurrent.Future<ConvertToPdbResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getConvertToPdbDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ConvertToPdbRequest, ConvertToPdbResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -5736,6 +5829,44 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetDbServerResponse> getDbServer(
+            GetDbServerRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetDbServerRequest, GetDbServerResponse>
+                    handler) {
+        LOG.trace("Called async getDbServer");
+        final GetDbServerRequest interceptedRequest =
+                GetDbServerConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetDbServerConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetDbServerResponse>
+                transformer = GetDbServerConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetDbServerRequest, GetDbServerResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetDbServerRequest, GetDbServerResponse>,
+                        java.util.concurrent.Future<GetDbServerResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetDbServerRequest, GetDbServerResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetDbSystemResponse> getDbSystem(
             GetDbSystemRequest request,
             final com.oracle.bmc.responses.AsyncHandler<GetDbSystemRequest, GetDbSystemResponse>
@@ -6266,6 +6397,50 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetMaintenanceRunRequest, GetMaintenanceRunResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetPdbConversionHistoryEntryResponse>
+            getPdbConversionHistoryEntry(
+                    GetPdbConversionHistoryEntryRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    GetPdbConversionHistoryEntryRequest,
+                                    GetPdbConversionHistoryEntryResponse>
+                            handler) {
+        LOG.trace("Called async getPdbConversionHistoryEntry");
+        final GetPdbConversionHistoryEntryRequest interceptedRequest =
+                GetPdbConversionHistoryEntryConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPdbConversionHistoryEntryConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetPdbConversionHistoryEntryResponse>
+                transformer = GetPdbConversionHistoryEntryConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetPdbConversionHistoryEntryRequest, GetPdbConversionHistoryEntryResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetPdbConversionHistoryEntryRequest,
+                                GetPdbConversionHistoryEntryResponse>,
+                        java.util.concurrent.Future<GetPdbConversionHistoryEntryResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetPdbConversionHistoryEntryRequest, GetPdbConversionHistoryEntryResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -7834,6 +8009,44 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListDbServersResponse> listDbServers(
+            ListDbServersRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<ListDbServersRequest, ListDbServersResponse>
+                    handler) {
+        LOG.trace("Called async listDbServers");
+        final ListDbServersRequest interceptedRequest =
+                ListDbServersConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDbServersConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListDbServersResponse>
+                transformer = ListDbServersConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListDbServersRequest, ListDbServersResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListDbServersRequest, ListDbServersResponse>,
+                        java.util.concurrent.Future<ListDbServersResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListDbServersRequest, ListDbServersResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListDbSystemPatchHistoryEntriesResponse>
             listDbSystemPatchHistoryEntries(
                     ListDbSystemPatchHistoryEntriesRequest request,
@@ -8406,6 +8619,52 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListMaintenanceRunsRequest, ListMaintenanceRunsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListPdbConversionHistoryEntriesResponse>
+            listPdbConversionHistoryEntries(
+                    ListPdbConversionHistoryEntriesRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ListPdbConversionHistoryEntriesRequest,
+                                    ListPdbConversionHistoryEntriesResponse>
+                            handler) {
+        LOG.trace("Called async listPdbConversionHistoryEntries");
+        final ListPdbConversionHistoryEntriesRequest interceptedRequest =
+                ListPdbConversionHistoryEntriesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPdbConversionHistoryEntriesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListPdbConversionHistoryEntriesResponse>
+                transformer = ListPdbConversionHistoryEntriesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListPdbConversionHistoryEntriesRequest,
+                        ListPdbConversionHistoryEntriesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListPdbConversionHistoryEntriesRequest,
+                                ListPdbConversionHistoryEntriesResponse>,
+                        java.util.concurrent.Future<ListPdbConversionHistoryEntriesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListPdbConversionHistoryEntriesRequest,
+                    ListPdbConversionHistoryEntriesResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -9094,6 +9353,58 @@ public class DatabaseAsyncClient implements DatabaseAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     RemoteClonePluggableDatabaseRequest, RemoteClonePluggableDatabaseResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<RemoveVirtualMachineFromVmClusterResponse>
+            removeVirtualMachineFromVmCluster(
+                    RemoveVirtualMachineFromVmClusterRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    RemoveVirtualMachineFromVmClusterRequest,
+                                    RemoveVirtualMachineFromVmClusterResponse>
+                            handler) {
+        LOG.trace("Called async removeVirtualMachineFromVmCluster");
+        final RemoveVirtualMachineFromVmClusterRequest interceptedRequest =
+                RemoveVirtualMachineFromVmClusterConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveVirtualMachineFromVmClusterConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RemoveVirtualMachineFromVmClusterResponse>
+                transformer = RemoveVirtualMachineFromVmClusterConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        RemoveVirtualMachineFromVmClusterRequest,
+                        RemoveVirtualMachineFromVmClusterResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RemoveVirtualMachineFromVmClusterRequest,
+                                RemoveVirtualMachineFromVmClusterResponse>,
+                        java.util.concurrent.Future<RemoveVirtualMachineFromVmClusterResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getRemoveVirtualMachineFromVmClusterDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RemoveVirtualMachineFromVmClusterRequest,
+                    RemoveVirtualMachineFromVmClusterResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -523,6 +523,42 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public AddVirtualMachineToVmClusterResponse addVirtualMachineToVmCluster(
+            AddVirtualMachineToVmClusterRequest request) {
+        LOG.trace("Called addVirtualMachineToVmCluster");
+        final AddVirtualMachineToVmClusterRequest interceptedRequest =
+                AddVirtualMachineToVmClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddVirtualMachineToVmClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, AddVirtualMachineToVmClusterResponse>
+                transformer = AddVirtualMachineToVmClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getAddVirtualMachineToVmClusterDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public AutonomousDatabaseManualRefreshResponse autonomousDatabaseManualRefresh(
             AutonomousDatabaseManualRefreshRequest request) {
         LOG.trace("Called autonomousDatabaseManualRefresh");
@@ -1215,6 +1251,38 @@ public class DatabaseClient implements Database {
                                                 ib,
                                                 retriedRequest
                                                         .getConfigureAutonomousDatabaseVaultKeyDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ConvertToPdbResponse convertToPdb(ConvertToPdbRequest request) {
+        LOG.trace("Called convertToPdb");
+        final ConvertToPdbRequest interceptedRequest =
+                ConvertToPdbConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ConvertToPdbConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ConvertToPdbResponse>
+                transformer = ConvertToPdbConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getConvertToPdbDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });
@@ -4256,6 +4324,34 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public GetDbServerResponse getDbServer(GetDbServerRequest request) {
+        LOG.trace("Called getDbServer");
+        final GetDbServerRequest interceptedRequest =
+                GetDbServerConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetDbServerConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetDbServerResponse>
+                transformer = GetDbServerConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetDbSystemResponse getDbSystem(GetDbSystemRequest request) {
         LOG.trace("Called getDbSystem");
         final GetDbSystemRequest interceptedRequest =
@@ -4613,6 +4709,36 @@ public class DatabaseClient implements Database {
                 GetMaintenanceRunConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetMaintenanceRunResponse>
                 transformer = GetMaintenanceRunConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetPdbConversionHistoryEntryResponse getPdbConversionHistoryEntry(
+            GetPdbConversionHistoryEntryRequest request) {
+        LOG.trace("Called getPdbConversionHistoryEntry");
+        final GetPdbConversionHistoryEntryRequest interceptedRequest =
+                GetPdbConversionHistoryEntryConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPdbConversionHistoryEntryConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetPdbConversionHistoryEntryResponse>
+                transformer = GetPdbConversionHistoryEntryConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -5710,6 +5836,34 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public ListDbServersResponse listDbServers(ListDbServersRequest request) {
+        LOG.trace("Called listDbServers");
+        final ListDbServersRequest interceptedRequest =
+                ListDbServersConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListDbServersConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListDbServersResponse>
+                transformer = ListDbServersConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListDbSystemPatchHistoryEntriesResponse listDbSystemPatchHistoryEntries(
             ListDbSystemPatchHistoryEntriesRequest request) {
         LOG.trace("Called listDbSystemPatchHistoryEntries");
@@ -6094,6 +6248,36 @@ public class DatabaseClient implements Database {
                 ListMaintenanceRunsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListMaintenanceRunsResponse>
                 transformer = ListMaintenanceRunsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListPdbConversionHistoryEntriesResponse listPdbConversionHistoryEntries(
+            ListPdbConversionHistoryEntriesRequest request) {
+        LOG.trace("Called listPdbConversionHistoryEntries");
+        final ListPdbConversionHistoryEntriesRequest interceptedRequest =
+                ListPdbConversionHistoryEntriesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListPdbConversionHistoryEntriesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListPdbConversionHistoryEntriesResponse>
+                transformer = ListPdbConversionHistoryEntriesConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -6588,6 +6772,42 @@ public class DatabaseClient implements Database {
                                                 ib,
                                                 retriedRequest
                                                         .getRemoteClonePluggableDatabaseDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public RemoveVirtualMachineFromVmClusterResponse removeVirtualMachineFromVmCluster(
+            RemoveVirtualMachineFromVmClusterRequest request) {
+        LOG.trace("Called removeVirtualMachineFromVmCluster");
+        final RemoveVirtualMachineFromVmClusterRequest interceptedRequest =
+                RemoveVirtualMachineFromVmClusterConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveVirtualMachineFromVmClusterConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RemoveVirtualMachineFromVmClusterResponse>
+                transformer = RemoveVirtualMachineFromVmClusterConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getRemoveVirtualMachineFromVmClusterDetails(),
                                                 retriedRequest);
                                 return transformer.apply(response);
                             });

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabasePaginators.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabasePaginators.java
@@ -3193,6 +3193,116 @@ public class DatabasePaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listDbServers operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListDbServersResponse> listDbServersResponseIterator(
+            final ListDbServersRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListDbServersRequest.Builder, ListDbServersRequest, ListDbServersResponse>(
+                new com.google.common.base.Supplier<ListDbServersRequest.Builder>() {
+                    @Override
+                    public ListDbServersRequest.Builder get() {
+                        return ListDbServersRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListDbServersResponse, String>() {
+                    @Override
+                    public String apply(ListDbServersResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListDbServersRequest.Builder>,
+                        ListDbServersRequest>() {
+                    @Override
+                    public ListDbServersRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListDbServersRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListDbServersRequest, ListDbServersResponse>() {
+                    @Override
+                    public ListDbServersResponse apply(ListDbServersRequest request) {
+                        return client.listDbServers(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.DbServerSummary} objects
+     * contained in responses from the listDbServers operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.DbServerSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.DbServerSummary> listDbServersRecordIterator(
+            final ListDbServersRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListDbServersRequest.Builder, ListDbServersRequest, ListDbServersResponse,
+                com.oracle.bmc.database.model.DbServerSummary>(
+                new com.google.common.base.Supplier<ListDbServersRequest.Builder>() {
+                    @Override
+                    public ListDbServersRequest.Builder get() {
+                        return ListDbServersRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListDbServersResponse, String>() {
+                    @Override
+                    public String apply(ListDbServersResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListDbServersRequest.Builder>,
+                        ListDbServersRequest>() {
+                    @Override
+                    public ListDbServersRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListDbServersRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<ListDbServersRequest, ListDbServersResponse>() {
+                    @Override
+                    public ListDbServersResponse apply(ListDbServersRequest request) {
+                        return client.listDbServers(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListDbServersResponse,
+                        java.util.List<com.oracle.bmc.database.model.DbServerSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.database.model.DbServerSummary> apply(
+                            ListDbServersResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listDbSystemPatchHistoryEntries operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -4833,6 +4943,132 @@ public class DatabasePaginators {
                     @Override
                     public java.util.List<com.oracle.bmc.database.model.MaintenanceRunSummary>
                             apply(ListMaintenanceRunsResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listPdbConversionHistoryEntries operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListPdbConversionHistoryEntriesResponse>
+            listPdbConversionHistoryEntriesResponseIterator(
+                    final ListPdbConversionHistoryEntriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListPdbConversionHistoryEntriesRequest.Builder,
+                ListPdbConversionHistoryEntriesRequest, ListPdbConversionHistoryEntriesResponse>(
+                new com.google.common.base.Supplier<
+                        ListPdbConversionHistoryEntriesRequest.Builder>() {
+                    @Override
+                    public ListPdbConversionHistoryEntriesRequest.Builder get() {
+                        return ListPdbConversionHistoryEntriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPdbConversionHistoryEntriesResponse, String>() {
+                    @Override
+                    public String apply(ListPdbConversionHistoryEntriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPdbConversionHistoryEntriesRequest.Builder>,
+                        ListPdbConversionHistoryEntriesRequest>() {
+                    @Override
+                    public ListPdbConversionHistoryEntriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPdbConversionHistoryEntriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPdbConversionHistoryEntriesRequest,
+                        ListPdbConversionHistoryEntriesResponse>() {
+                    @Override
+                    public ListPdbConversionHistoryEntriesResponse apply(
+                            ListPdbConversionHistoryEntriesRequest request) {
+                        return client.listPdbConversionHistoryEntries(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary} objects
+     * contained in responses from the listPdbConversionHistoryEntries operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary>
+            listPdbConversionHistoryEntriesRecordIterator(
+                    final ListPdbConversionHistoryEntriesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListPdbConversionHistoryEntriesRequest.Builder,
+                ListPdbConversionHistoryEntriesRequest, ListPdbConversionHistoryEntriesResponse,
+                com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary>(
+                new com.google.common.base.Supplier<
+                        ListPdbConversionHistoryEntriesRequest.Builder>() {
+                    @Override
+                    public ListPdbConversionHistoryEntriesRequest.Builder get() {
+                        return ListPdbConversionHistoryEntriesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPdbConversionHistoryEntriesResponse, String>() {
+                    @Override
+                    public String apply(ListPdbConversionHistoryEntriesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListPdbConversionHistoryEntriesRequest.Builder>,
+                        ListPdbConversionHistoryEntriesRequest>() {
+                    @Override
+                    public ListPdbConversionHistoryEntriesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListPdbConversionHistoryEntriesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPdbConversionHistoryEntriesRequest,
+                        ListPdbConversionHistoryEntriesResponse>() {
+                    @Override
+                    public ListPdbConversionHistoryEntriesResponse apply(
+                            ListPdbConversionHistoryEntriesRequest request) {
+                        return client.listPdbConversionHistoryEntries(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListPdbConversionHistoryEntriesResponse,
+                        java.util.List<
+                                com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary>
+                            apply(ListPdbConversionHistoryEntriesResponse response) {
                         return response.getItems();
                     }
                 });

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
@@ -164,6 +164,65 @@ public class DatabaseWaiters {
      * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
+                    AddVirtualMachineToVmClusterRequest, AddVirtualMachineToVmClusterResponse>
+            forAddVirtualMachineToVmCluster(AddVirtualMachineToVmClusterRequest request) {
+        return forAddVirtualMachineToVmCluster(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    AddVirtualMachineToVmClusterRequest, AddVirtualMachineToVmClusterResponse>
+            forAddVirtualMachineToVmCluster(
+                    AddVirtualMachineToVmClusterRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<AddVirtualMachineToVmClusterResponse>() {
+                    @Override
+                    public AddVirtualMachineToVmClusterResponse call() throws Exception {
+                        final AddVirtualMachineToVmClusterResponse response =
+                                client.addVirtualMachineToVmCluster(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
                     AutonomousDatabaseManualRefreshRequest, AutonomousDatabaseManualRefreshResponse>
             forAutonomousDatabaseManualRefresh(AutonomousDatabaseManualRefreshRequest request) {
         return forAutonomousDatabaseManualRefresh(
@@ -1315,6 +1374,61 @@ public class DatabaseWaiters {
                     public ConfigureAutonomousDatabaseVaultKeyResponse call() throws Exception {
                         final ConfigureAutonomousDatabaseVaultKeyResponse response =
                                 client.configureAutonomousDatabaseVaultKey(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<ConvertToPdbRequest, ConvertToPdbResponse> forConvertToPdb(
+            ConvertToPdbRequest request) {
+        return forConvertToPdb(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<ConvertToPdbRequest, ConvertToPdbResponse> forConvertToPdb(
+            ConvertToPdbRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<ConvertToPdbResponse>() {
+                    @Override
+                    public ConvertToPdbResponse call() throws Exception {
+                        final ConvertToPdbResponse response = client.convertToPdb(request);
 
                         final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
                                 getWorkRequestRequest =
@@ -6828,6 +6942,103 @@ public class DatabaseWaiters {
      * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
      * @return a new {@code Waiter} instance
      */
+    public com.oracle.bmc.waiter.Waiter<GetDbServerRequest, GetDbServerResponse> forDbServer(
+            GetDbServerRequest request,
+            com.oracle.bmc.database.model.DbServer.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forDbServer(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetDbServerRequest, GetDbServerResponse> forDbServer(
+            GetDbServerRequest request,
+            com.oracle.bmc.database.model.DbServer.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forDbServer(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetDbServerRequest, GetDbServerResponse> forDbServer(
+            GetDbServerRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.database.model.DbServer.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forDbServer(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for DbServer.
+    private com.oracle.bmc.waiter.Waiter<GetDbServerRequest, GetDbServerResponse> forDbServer(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetDbServerRequest request,
+            final com.oracle.bmc.database.model.DbServer.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.database.model.DbServer.LifecycleState> targetStatesSet =
+                new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetDbServerRequest, GetDbServerResponse>() {
+                            @Override
+                            public GetDbServerResponse apply(GetDbServerRequest request) {
+                                return client.getDbServer(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetDbServerResponse>() {
+                            @Override
+                            public boolean apply(GetDbServerResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getDbServer().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.database.model.DbServer.LifecycleState.Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
     public com.oracle.bmc.waiter.Waiter<GetDbSystemRequest, GetDbSystemResponse> forDbSystem(
             GetDbSystemRequest request,
             com.oracle.bmc.database.model.DbSystem.LifecycleState... targetStates) {
@@ -7789,6 +8000,118 @@ public class DatabaseWaiters {
                         targetStatesSet.contains(
                                 com.oracle.bmc.database.model.MaintenanceRun.LifecycleState
                                         .Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetPdbConversionHistoryEntryRequest, GetPdbConversionHistoryEntryResponse>
+            forPdbConversionHistoryEntry(
+                    GetPdbConversionHistoryEntryRequest request,
+                    com.oracle.bmc.database.model.PdbConversionHistoryEntry.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forPdbConversionHistoryEntry(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetPdbConversionHistoryEntryRequest, GetPdbConversionHistoryEntryResponse>
+            forPdbConversionHistoryEntry(
+                    GetPdbConversionHistoryEntryRequest request,
+                    com.oracle.bmc.database.model.PdbConversionHistoryEntry.LifecycleState
+                            targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forPdbConversionHistoryEntry(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    GetPdbConversionHistoryEntryRequest, GetPdbConversionHistoryEntryResponse>
+            forPdbConversionHistoryEntry(
+                    GetPdbConversionHistoryEntryRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.database.model.PdbConversionHistoryEntry.LifecycleState...
+                            targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forPdbConversionHistoryEntry(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for PdbConversionHistoryEntry.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetPdbConversionHistoryEntryRequest, GetPdbConversionHistoryEntryResponse>
+            forPdbConversionHistoryEntry(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetPdbConversionHistoryEntryRequest request,
+                    final com.oracle.bmc.database.model.PdbConversionHistoryEntry.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.database.model.PdbConversionHistoryEntry.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetPdbConversionHistoryEntryRequest,
+                                GetPdbConversionHistoryEntryResponse>() {
+                            @Override
+                            public GetPdbConversionHistoryEntryResponse apply(
+                                    GetPdbConversionHistoryEntryRequest request) {
+                                return client.getPdbConversionHistoryEntry(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<
+                                GetPdbConversionHistoryEntryResponse>() {
+                            @Override
+                            public boolean apply(GetPdbConversionHistoryEntryResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getPdbConversionHistoryEntry()
+                                                .getLifecycleState());
+                            }
+                        },
+                        false),
                 request);
     }
 
@@ -8898,6 +9221,67 @@ public class DatabaseWaiters {
                     public RemoteClonePluggableDatabaseResponse call() throws Exception {
                         final RemoteClonePluggableDatabaseResponse response =
                                 client.remoteClonePluggableDatabase(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    RemoveVirtualMachineFromVmClusterRequest,
+                    RemoveVirtualMachineFromVmClusterResponse>
+            forRemoveVirtualMachineFromVmCluster(RemoveVirtualMachineFromVmClusterRequest request) {
+        return forRemoveVirtualMachineFromVmCluster(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    RemoveVirtualMachineFromVmClusterRequest,
+                    RemoveVirtualMachineFromVmClusterResponse>
+            forRemoveVirtualMachineFromVmCluster(
+                    RemoveVirtualMachineFromVmClusterRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<RemoveVirtualMachineFromVmClusterResponse>() {
+                    @Override
+                    public RemoveVirtualMachineFromVmClusterResponse call() throws Exception {
+                        final RemoveVirtualMachineFromVmClusterResponse response =
+                                client.removeVirtualMachineFromVmCluster(request);
 
                         final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
                                 getWorkRequestRequest =

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/AddVirtualMachineToVmClusterConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/AddVirtualMachineToVmClusterConverter.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class AddVirtualMachineToVmClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.AddVirtualMachineToVmClusterRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests.AddVirtualMachineToVmClusterRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.AddVirtualMachineToVmClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getAddVirtualMachineToVmClusterDetails(),
+                "addVirtualMachineToVmClusterDetails is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()))
+                        .path("actions")
+                        .path("addVirtualMachine");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.AddVirtualMachineToVmClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.AddVirtualMachineToVmClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .AddVirtualMachineToVmClusterResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .AddVirtualMachineToVmClusterResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.AddVirtualMachineToVmClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.database.model.VmCluster>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.database.model.VmCluster
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.database.model.VmCluster>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .AddVirtualMachineToVmClusterResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .AddVirtualMachineToVmClusterResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.vmCluster(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .AddVirtualMachineToVmClusterResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ConvertToPdbConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ConvertToPdbConverter.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ConvertToPdbConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.ConvertToPdbRequest interceptRequest(
+            com.oracle.bmc.database.requests.ConvertToPdbRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ConvertToPdbRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDatabaseId(), "databaseId must not be blank");
+        Validate.notNull(request.getConvertToPdbDetails(), "convertToPdbDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("databases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDatabaseId()))
+                        .path("actions")
+                        .path("convertToPdb");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.ConvertToPdbResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.ConvertToPdbResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses.ConvertToPdbResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses.ConvertToPdbResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ConvertToPdbResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.database.model.Database>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.database.model.Database
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.database.model.Database>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses.ConvertToPdbResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ConvertToPdbResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.database(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses.ConvertToPdbResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetDbServerConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetDbServerConverter.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetDbServerConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.GetDbServerRequest interceptRequest(
+            com.oracle.bmc.database.requests.GetDbServerRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.GetDbServerRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId is required");
+        Validate.notBlank(request.getDbServerId(), "dbServerId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("dbServers")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDbServerId()));
+
+        target =
+                target.queryParam(
+                        "exadataInfrastructureId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getExadataInfrastructureId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.GetDbServerResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.GetDbServerResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses.GetDbServerResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses.GetDbServerResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.GetDbServerResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.database.model.DbServer>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.database.model.DbServer
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.database.model.DbServer>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses.GetDbServerResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .GetDbServerResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.dbServer(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses.GetDbServerResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetPdbConversionHistoryEntryConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/GetPdbConversionHistoryEntryConverter.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetPdbConversionHistoryEntryConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.GetPdbConversionHistoryEntryRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests.GetPdbConversionHistoryEntryRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.GetPdbConversionHistoryEntryRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDatabaseId(), "databaseId must not be blank");
+        Validate.notBlank(
+                request.getPdbConversionHistoryEntryId(),
+                "pdbConversionHistoryEntryId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("databases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDatabaseId()))
+                        .path("pdbConversionHistoryEntries")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getPdbConversionHistoryEntryId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.GetPdbConversionHistoryEntryResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.GetPdbConversionHistoryEntryResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .GetPdbConversionHistoryEntryResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .GetPdbConversionHistoryEntryResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.GetPdbConversionHistoryEntryResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.database.model
+                                                                .PdbConversionHistoryEntry>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.database.model
+                                                                        .PdbConversionHistoryEntry
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.database.model
+                                                        .PdbConversionHistoryEntry>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .GetPdbConversionHistoryEntryResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .GetPdbConversionHistoryEntryResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.pdbConversionHistoryEntry(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .GetPdbConversionHistoryEntryResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbNodesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbNodesConverter.java
@@ -94,6 +94,14 @@ public class ListDbNodesConverter {
                                     request.getLifecycleState().getValue()));
         }
 
+        if (request.getDbServerId() != null) {
+            target =
+                    target.queryParam(
+                            "dbServerId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDbServerId()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbServersConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListDbServersConverter.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListDbServersConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.ListDbServersRequest interceptRequest(
+            com.oracle.bmc.database.requests.ListDbServersRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ListDbServersRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+        Validate.notNull(
+                request.getExadataInfrastructureId(), "exadataInfrastructureId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("dbServers");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        target =
+                target.queryParam(
+                        "exadataInfrastructureId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getExadataInfrastructureId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.ListDbServersResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.ListDbServersResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses.ListDbServersResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses.ListDbServersResponse apply(
+                                    javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ListDbServersResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                com.oracle.bmc.database.model
+                                                                        .DbServerSummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        com.oracle.bmc.database
+                                                                                .model
+                                                                                .DbServerSummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        com.oracle.bmc.database.model
+                                                                .DbServerSummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses.ListDbServersResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ListDbServersResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses.ListDbServersResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListPdbConversionHistoryEntriesConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ListPdbConversionHistoryEntriesConverter.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListPdbConversionHistoryEntriesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.ListPdbConversionHistoryEntriesRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests.ListPdbConversionHistoryEntriesRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ListPdbConversionHistoryEntriesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getDatabaseId(), "databaseId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("databases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getDatabaseId()))
+                        .path("pdbConversionHistoryEntries");
+
+        if (request.getPdbConversionAction() != null) {
+            target =
+                    target.queryParam(
+                            "pdbConversionAction",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPdbConversionAction().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.ListPdbConversionHistoryEntriesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.ListPdbConversionHistoryEntriesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .ListPdbConversionHistoryEntriesResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .ListPdbConversionHistoryEntriesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ListPdbConversionHistoryEntriesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                com.oracle.bmc.database.model
+                                                                        .PdbConversionHistoryEntrySummary>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        com.oracle.bmc.database
+                                                                                .model
+                                                                                .PdbConversionHistoryEntrySummary>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        com.oracle.bmc.database.model
+                                                                .PdbConversionHistoryEntrySummary>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .ListPdbConversionHistoryEntriesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ListPdbConversionHistoryEntriesResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .ListPdbConversionHistoryEntriesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/RemoveVirtualMachineFromVmClusterConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/RemoveVirtualMachineFromVmClusterConverter.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class RemoveVirtualMachineFromVmClusterConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.RemoveVirtualMachineFromVmClusterRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests.RemoveVirtualMachineFromVmClusterRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.RemoveVirtualMachineFromVmClusterRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getRemoveVirtualMachineFromVmClusterDetails(),
+                "removeVirtualMachineFromVmClusterDetails is required");
+        Validate.notBlank(request.getVmClusterId(), "vmClusterId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("vmClusters")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVmClusterId()))
+                        .path("actions")
+                        .path("removeVirtualMachine");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.RemoveVirtualMachineFromVmClusterResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.RemoveVirtualMachineFromVmClusterResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .RemoveVirtualMachineFromVmClusterResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .RemoveVirtualMachineFromVmClusterResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.RemoveVirtualMachineFromVmClusterResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.database.model.VmCluster>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.database.model.VmCluster
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.database.model.VmCluster>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .RemoveVirtualMachineFromVmClusterResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .RemoveVirtualMachineFromVmClusterResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.vmCluster(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .RemoveVirtualMachineFromVmClusterResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AddVirtualMachineToVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AddVirtualMachineToVmClusterDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of adding Virtual Machines to the VM Cluster. Applies to Exadata Cloud@Customer instances only.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = AddVirtualMachineToVmClusterDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AddVirtualMachineToVmClusterDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+        private java.util.List<DbServerDetails> dbServers;
+
+        public Builder dbServers(java.util.List<DbServerDetails> dbServers) {
+            this.dbServers = dbServers;
+            this.__explicitlySet__.add("dbServers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AddVirtualMachineToVmClusterDetails build() {
+            AddVirtualMachineToVmClusterDetails __instance__ =
+                    new AddVirtualMachineToVmClusterDetails(dbServers);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AddVirtualMachineToVmClusterDetails o) {
+            Builder copiedBuilder = dbServers(o.getDbServers());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The list of Exacc DB servers for the cluster to be added.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+    java.util.List<DbServerDetails> dbServers;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ConvertToPdbDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ConvertToPdbDetails.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details for converting a non-container database to pluggable database.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ConvertToPdbDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ConvertToPdbDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("action")
+        private Action action;
+
+        public Builder action(Action action) {
+            this.action = action;
+            this.__explicitlySet__.add("action");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("convertToPdbTargetDetails")
+        private ConvertToPdbTargetBase convertToPdbTargetDetails;
+
+        public Builder convertToPdbTargetDetails(ConvertToPdbTargetBase convertToPdbTargetDetails) {
+            this.convertToPdbTargetDetails = convertToPdbTargetDetails;
+            this.__explicitlySet__.add("convertToPdbTargetDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ConvertToPdbDetails build() {
+            ConvertToPdbDetails __instance__ =
+                    new ConvertToPdbDetails(action, convertToPdbTargetDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ConvertToPdbDetails o) {
+            Builder copiedBuilder =
+                    action(o.getAction())
+                            .convertToPdbTargetDetails(o.getConvertToPdbTargetDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The operations used to convert a non-container database to a pluggable database.
+     * - Use {@code PRECHECK} to run a pre-check operation on non-container database prior to converting it into a pluggable database.
+     * - Use {@code CONVERT} to convert a non-container database into a pluggable database.
+     * - Use {@code SYNC} if the non-container database was manually converted into a pluggable database using the dbcli command-line utility. Databases may need to be converted manually if the CONVERT action fails when converting a non-container database using the API.
+     * - Use {@code SYNC_ROLLBACK} if the conversion of a non-container database into a pluggable database was manually rolled back using the dbcli command line utility. Conversions may need to be manually rolled back if the CONVERT action fails when converting a non-container database using the API.
+     *
+     **/
+    public enum Action {
+        Precheck("PRECHECK"),
+        Convert("CONVERT"),
+        Sync("SYNC"),
+        SyncRollback("SYNC_ROLLBACK"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Action> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Action v : Action.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Action(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Action create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Action: " + key);
+        }
+    };
+    /**
+     * The operations used to convert a non-container database to a pluggable database.
+     * - Use {@code PRECHECK} to run a pre-check operation on non-container database prior to converting it into a pluggable database.
+     * - Use {@code CONVERT} to convert a non-container database into a pluggable database.
+     * - Use {@code SYNC} if the non-container database was manually converted into a pluggable database using the dbcli command-line utility. Databases may need to be converted manually if the CONVERT action fails when converting a non-container database using the API.
+     * - Use {@code SYNC_ROLLBACK} if the conversion of a non-container database into a pluggable database was manually rolled back using the dbcli command line utility. Conversions may need to be manually rolled back if the CONVERT action fails when converting a non-container database using the API.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("action")
+    Action action;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("convertToPdbTargetDetails")
+    ConvertToPdbTargetBase convertToPdbTargetDetails;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ConvertToPdbTargetBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ConvertToPdbTargetBase.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the container database in which the converted pluggable database will be located.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "target",
+    defaultImpl = ConvertToPdbTargetBase.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = PdbConversionToNewDatabaseDetails.class,
+        name = "NEW_DATABASE"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class ConvertToPdbTargetBase {
+
+    /**
+     * The target container database of the pluggable database created by the database conversion operation. Currently, the database conversion operation only supports creating the pluggable database in a new container database.
+     *  - Use {@code NEW_DATABASE} to specify that the pluggable database be created within a new container database in the same database home.
+     *
+     **/
+    public enum Target {
+        NewDatabase("NEW_DATABASE"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Target> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Target v : Target.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Target(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Target create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Target: " + key);
+        }
+    };
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationDetails.java
@@ -185,4 +185,18 @@ public class CreateDataGuardAssociationDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("transportType")
     TransportType transportType;
+
+    /**
+     * Specifies the {@code DB_UNIQUE_NAME} of the peer database to be created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerDbUniqueName")
+    String peerDbUniqueName;
+
+    /**
+     * Specifies a prefix for the {@code Oracle SID} of the database to be created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("peerSidPrefix")
+    String peerSidPrefix;
 }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingDbSystemDetails.java
@@ -72,6 +72,24 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("peerDbUniqueName")
+        private String peerDbUniqueName;
+
+        public Builder peerDbUniqueName(String peerDbUniqueName) {
+            this.peerDbUniqueName = peerDbUniqueName;
+            this.__explicitlySet__.add("peerDbUniqueName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerSidPrefix")
+        private String peerSidPrefix;
+
+        public Builder peerSidPrefix(String peerSidPrefix) {
+            this.peerSidPrefix = peerSidPrefix;
+            this.__explicitlySet__.add("peerSidPrefix");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("peerDbSystemId")
         private String peerDbSystemId;
 
@@ -100,6 +118,8 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
                             databaseAdminPassword,
                             protectionMode,
                             transportType,
+                            peerDbUniqueName,
+                            peerSidPrefix,
                             peerDbSystemId,
                             peerDbHomeId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -113,6 +133,8 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
                             .databaseAdminPassword(o.getDatabaseAdminPassword())
                             .protectionMode(o.getProtectionMode())
                             .transportType(o.getTransportType())
+                            .peerDbUniqueName(o.getPeerDbUniqueName())
+                            .peerSidPrefix(o.getPeerSidPrefix())
                             .peerDbSystemId(o.getPeerDbSystemId())
                             .peerDbHomeId(o.getPeerDbHomeId());
 
@@ -134,9 +156,17 @@ public class CreateDataGuardAssociationToExistingDbSystemDetails
             String databaseAdminPassword,
             ProtectionMode protectionMode,
             TransportType transportType,
+            String peerDbUniqueName,
+            String peerSidPrefix,
             String peerDbSystemId,
             String peerDbHomeId) {
-        super(databaseSoftwareImageId, databaseAdminPassword, protectionMode, transportType);
+        super(
+                databaseSoftwareImageId,
+                databaseAdminPassword,
+                protectionMode,
+                transportType,
+                peerDbUniqueName,
+                peerSidPrefix);
         this.peerDbSystemId = peerDbSystemId;
         this.peerDbHomeId = peerDbHomeId;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationToExistingVmClusterDetails.java
@@ -70,6 +70,24 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("peerDbUniqueName")
+        private String peerDbUniqueName;
+
+        public Builder peerDbUniqueName(String peerDbUniqueName) {
+            this.peerDbUniqueName = peerDbUniqueName;
+            this.__explicitlySet__.add("peerDbUniqueName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerSidPrefix")
+        private String peerSidPrefix;
+
+        public Builder peerSidPrefix(String peerSidPrefix) {
+            this.peerSidPrefix = peerSidPrefix;
+            this.__explicitlySet__.add("peerSidPrefix");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("peerVmClusterId")
         private String peerVmClusterId;
 
@@ -98,6 +116,8 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
                             databaseAdminPassword,
                             protectionMode,
                             transportType,
+                            peerDbUniqueName,
+                            peerSidPrefix,
                             peerVmClusterId,
                             peerDbHomeId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -111,6 +131,8 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
                             .databaseAdminPassword(o.getDatabaseAdminPassword())
                             .protectionMode(o.getProtectionMode())
                             .transportType(o.getTransportType())
+                            .peerDbUniqueName(o.getPeerDbUniqueName())
+                            .peerSidPrefix(o.getPeerSidPrefix())
                             .peerVmClusterId(o.getPeerVmClusterId())
                             .peerDbHomeId(o.getPeerDbHomeId());
 
@@ -132,9 +154,17 @@ public class CreateDataGuardAssociationToExistingVmClusterDetails
             String databaseAdminPassword,
             ProtectionMode protectionMode,
             TransportType transportType,
+            String peerDbUniqueName,
+            String peerSidPrefix,
             String peerVmClusterId,
             String peerDbHomeId) {
-        super(databaseSoftwareImageId, databaseAdminPassword, protectionMode, transportType);
+        super(
+                databaseSoftwareImageId,
+                databaseAdminPassword,
+                protectionMode,
+                transportType,
+                peerDbUniqueName,
+                peerSidPrefix);
         this.peerVmClusterId = peerVmClusterId;
         this.peerDbHomeId = peerDbHomeId;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationWithNewDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDataGuardAssociationWithNewDbSystemDetails.java
@@ -72,6 +72,24 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("peerDbUniqueName")
+        private String peerDbUniqueName;
+
+        public Builder peerDbUniqueName(String peerDbUniqueName) {
+            this.peerDbUniqueName = peerDbUniqueName;
+            this.__explicitlySet__.add("peerDbUniqueName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("peerSidPrefix")
+        private String peerSidPrefix;
+
+        public Builder peerSidPrefix(String peerSidPrefix) {
+            this.peerSidPrefix = peerSidPrefix;
+            this.__explicitlySet__.add("peerSidPrefix");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("displayName")
         private String displayName;
 
@@ -145,6 +163,8 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
                             databaseAdminPassword,
                             protectionMode,
                             transportType,
+                            peerDbUniqueName,
+                            peerSidPrefix,
                             displayName,
                             availabilityDomain,
                             shape,
@@ -163,6 +183,8 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
                             .databaseAdminPassword(o.getDatabaseAdminPassword())
                             .protectionMode(o.getProtectionMode())
                             .transportType(o.getTransportType())
+                            .peerDbUniqueName(o.getPeerDbUniqueName())
+                            .peerSidPrefix(o.getPeerSidPrefix())
                             .displayName(o.getDisplayName())
                             .availabilityDomain(o.getAvailabilityDomain())
                             .shape(o.getShape())
@@ -189,6 +211,8 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
             String databaseAdminPassword,
             ProtectionMode protectionMode,
             TransportType transportType,
+            String peerDbUniqueName,
+            String peerSidPrefix,
             String displayName,
             String availabilityDomain,
             String shape,
@@ -196,7 +220,13 @@ public class CreateDataGuardAssociationWithNewDbSystemDetails
             java.util.List<String> nsgIds,
             java.util.List<String> backupNetworkNsgIds,
             String hostname) {
-        super(databaseSoftwareImageId, databaseAdminPassword, protectionMode, transportType);
+        super(
+                databaseSoftwareImageId,
+                databaseAdminPassword,
+                protectionMode,
+                transportType,
+                peerDbUniqueName,
+                peerSidPrefix);
         this.displayName = displayName;
         this.availabilityDomain = availabilityDomain;
         this.shape = shape;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
@@ -138,6 +138,15 @@ public class CreateDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("sidPrefix")
+        private String sidPrefix;
+
+        public Builder sidPrefix(String sidPrefix) {
+            this.sidPrefix = sidPrefix;
+            this.__explicitlySet__.add("sidPrefix");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -155,7 +164,8 @@ public class CreateDatabaseDetails {
                             dbWorkload,
                             dbBackupConfig,
                             freeformTags,
-                            definedTags);
+                            definedTags,
+                            sidPrefix);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -174,7 +184,8 @@ public class CreateDatabaseDetails {
                             .dbWorkload(o.getDbWorkload())
                             .dbBackupConfig(o.getDbBackupConfig())
                             .freeformTags(o.getFreeformTags())
-                            .definedTags(o.getDefinedTags());
+                            .definedTags(o.getDefinedTags())
+                            .sidPrefix(o.getSidPrefix());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -301,6 +312,13 @@ public class CreateDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Specifies a prefix for the {@code Oracle SID} of the database to be created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sidPrefix")
+    String sidPrefix;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseFromBackupDetails.java
@@ -71,13 +71,27 @@ public class CreateDatabaseFromBackupDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("sidPrefix")
+        private String sidPrefix;
+
+        public Builder sidPrefix(String sidPrefix) {
+            this.sidPrefix = sidPrefix;
+            this.__explicitlySet__.add("sidPrefix");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateDatabaseFromBackupDetails build() {
             CreateDatabaseFromBackupDetails __instance__ =
                     new CreateDatabaseFromBackupDetails(
-                            backupId, backupTDEPassword, adminPassword, dbUniqueName, dbName);
+                            backupId,
+                            backupTDEPassword,
+                            adminPassword,
+                            dbUniqueName,
+                            dbName,
+                            sidPrefix);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -89,7 +103,8 @@ public class CreateDatabaseFromBackupDetails {
                             .backupTDEPassword(o.getBackupTDEPassword())
                             .adminPassword(o.getAdminPassword())
                             .dbUniqueName(o.getDbUniqueName())
-                            .dbName(o.getDbName());
+                            .dbName(o.getDbName())
+                            .sidPrefix(o.getSidPrefix());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -132,6 +147,13 @@ public class CreateDatabaseFromBackupDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dbName")
     String dbName;
+
+    /**
+     * Specifies a prefix for the {@code Oracle SID} of the database to be created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sidPrefix")
+    String sidPrefix;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDbHomeFromBackupDetails.java
@@ -38,6 +38,15 @@ public class CreateDbHomeFromBackupDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("databaseSoftwareImageId")
+        private String databaseSoftwareImageId;
+
+        public Builder databaseSoftwareImageId(String databaseSoftwareImageId) {
+            this.databaseSoftwareImageId = databaseSoftwareImageId;
+            this.__explicitlySet__.add("databaseSoftwareImageId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("database")
         private CreateDatabaseFromBackupDetails database;
 
@@ -72,7 +81,11 @@ public class CreateDbHomeFromBackupDetails {
         public CreateDbHomeFromBackupDetails build() {
             CreateDbHomeFromBackupDetails __instance__ =
                     new CreateDbHomeFromBackupDetails(
-                            displayName, database, freeformTags, definedTags);
+                            displayName,
+                            databaseSoftwareImageId,
+                            database,
+                            freeformTags,
+                            definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -81,6 +94,7 @@ public class CreateDbHomeFromBackupDetails {
         public Builder copy(CreateDbHomeFromBackupDetails o) {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
+                            .databaseSoftwareImageId(o.getDatabaseSoftwareImageId())
                             .database(o.getDatabase())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
@@ -102,6 +116,12 @@ public class CreateDbHomeFromBackupDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("displayName")
     String displayName;
+
+    /**
+     * The database software image [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the image to be used to restore a database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("databaseSoftwareImageId")
+    String databaseSoftwareImageId;
 
     @com.fasterxml.jackson.annotation.JsonProperty("database")
     CreateDatabaseFromBackupDetails database;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateVmClusterDetails.java
@@ -154,6 +154,15 @@ public class CreateVmClusterDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+        private java.util.List<String> dbServers;
+
+        public Builder dbServers(java.util.List<String> dbServers) {
+            this.dbServers = dbServers;
+            this.__explicitlySet__.add("dbServers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -193,6 +202,7 @@ public class CreateVmClusterDetails {
                             isLocalBackupEnabled,
                             timeZone,
                             giVersion,
+                            dbServers,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -216,6 +226,7 @@ public class CreateVmClusterDetails {
                             .isLocalBackupEnabled(o.getIsLocalBackupEnabled())
                             .timeZone(o.getTimeZone())
                             .giVersion(o.getGiVersion())
+                            .dbServers(o.getDbServers())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -352,6 +363,12 @@ public class CreateVmClusterDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("giVersion")
     String giVersion;
+
+    /**
+     * The list of Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+    java.util.List<String> dbServers;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/Database.java
@@ -225,6 +225,15 @@ public class Database {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCdb")
+        private Boolean isCdb;
+
+        public Builder isCdb(Boolean isCdb) {
+            this.isCdb = isCdb;
+            this.__explicitlySet__.add("isCdb");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
         private CloudDatabaseManagementConfig databaseManagementConfig;
 
@@ -232,6 +241,15 @@ public class Database {
                 CloudDatabaseManagementConfig databaseManagementConfig) {
             this.databaseManagementConfig = databaseManagementConfig;
             this.__explicitlySet__.add("databaseManagementConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sidPrefix")
+        private String sidPrefix;
+
+        public Builder sidPrefix(String sidPrefix) {
+            this.sidPrefix = sidPrefix;
+            this.__explicitlySet__.add("sidPrefix");
             return this;
         }
 
@@ -263,7 +281,9 @@ public class Database {
                             kmsKeyId,
                             sourceDatabasePointInTimeRecoveryTimestamp,
                             databaseSoftwareImageId,
-                            databaseManagementConfig);
+                            isCdb,
+                            databaseManagementConfig,
+                            sidPrefix);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -294,7 +314,9 @@ public class Database {
                             .sourceDatabasePointInTimeRecoveryTimestamp(
                                     o.getSourceDatabasePointInTimeRecoveryTimestamp())
                             .databaseSoftwareImageId(o.getDatabaseSoftwareImageId())
-                            .databaseManagementConfig(o.getDatabaseManagementConfig());
+                            .isCdb(o.getIsCdb())
+                            .databaseManagementConfig(o.getDatabaseManagementConfig())
+                            .sidPrefix(o.getSidPrefix());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -390,6 +412,7 @@ public class Database {
         Updating("UPDATING"),
         BackupInProgress("BACKUP_IN_PROGRESS"),
         Upgrading("UPGRADING"),
+        Converting("CONVERTING"),
         Terminating("TERMINATING"),
         Terminated("TERMINATED"),
         RestoreFailed("RESTORE_FAILED"),
@@ -496,8 +519,21 @@ public class Database {
     @com.fasterxml.jackson.annotation.JsonProperty("databaseSoftwareImageId")
     String databaseSoftwareImageId;
 
+    /**
+     * True if the database is a container database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCdb")
+    Boolean isCdb;
+
     @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
     CloudDatabaseManagementConfig databaseManagementConfig;
+
+    /**
+     * Specifies a prefix for the {@code Oracle SID} of the database to be created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sidPrefix")
+    String sidPrefix;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSummary.java
@@ -230,6 +230,15 @@ public class DatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCdb")
+        private Boolean isCdb;
+
+        public Builder isCdb(Boolean isCdb) {
+            this.isCdb = isCdb;
+            this.__explicitlySet__.add("isCdb");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
         private CloudDatabaseManagementConfig databaseManagementConfig;
 
@@ -237,6 +246,15 @@ public class DatabaseSummary {
                 CloudDatabaseManagementConfig databaseManagementConfig) {
             this.databaseManagementConfig = databaseManagementConfig;
             this.__explicitlySet__.add("databaseManagementConfig");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sidPrefix")
+        private String sidPrefix;
+
+        public Builder sidPrefix(String sidPrefix) {
+            this.sidPrefix = sidPrefix;
+            this.__explicitlySet__.add("sidPrefix");
             return this;
         }
 
@@ -268,7 +286,9 @@ public class DatabaseSummary {
                             kmsKeyId,
                             sourceDatabasePointInTimeRecoveryTimestamp,
                             databaseSoftwareImageId,
-                            databaseManagementConfig);
+                            isCdb,
+                            databaseManagementConfig,
+                            sidPrefix);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -299,7 +319,9 @@ public class DatabaseSummary {
                             .sourceDatabasePointInTimeRecoveryTimestamp(
                                     o.getSourceDatabasePointInTimeRecoveryTimestamp())
                             .databaseSoftwareImageId(o.getDatabaseSoftwareImageId())
-                            .databaseManagementConfig(o.getDatabaseManagementConfig());
+                            .isCdb(o.getIsCdb())
+                            .databaseManagementConfig(o.getDatabaseManagementConfig())
+                            .sidPrefix(o.getSidPrefix());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -395,6 +417,7 @@ public class DatabaseSummary {
         Updating("UPDATING"),
         BackupInProgress("BACKUP_IN_PROGRESS"),
         Upgrading("UPGRADING"),
+        Converting("CONVERTING"),
         Terminating("TERMINATING"),
         Terminated("TERMINATED"),
         RestoreFailed("RESTORE_FAILED"),
@@ -501,8 +524,21 @@ public class DatabaseSummary {
     @com.fasterxml.jackson.annotation.JsonProperty("databaseSoftwareImageId")
     String databaseSoftwareImageId;
 
+    /**
+     * True if the database is a container database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCdb")
+    Boolean isCdb;
+
     @com.fasterxml.jackson.annotation.JsonProperty("databaseManagementConfig")
     CloudDatabaseManagementConfig databaseManagementConfig;
+
+    /**
+     * Specifies a prefix for the {@code Oracle SID} of the database to be created.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sidPrefix")
+    String sidPrefix;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNode.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNode.java
@@ -177,6 +177,42 @@ public class DbNode {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+        private Integer cpuCoreCount;
+
+        public Builder cpuCoreCount(Integer cpuCoreCount) {
+            this.cpuCoreCount = cpuCoreCount;
+            this.__explicitlySet__.add("cpuCoreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServerId")
+        private String dbServerId;
+
+        public Builder dbServerId(String dbServerId) {
+            this.dbServerId = dbServerId;
+            this.__explicitlySet__.add("dbServerId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -199,7 +235,11 @@ public class DbNode {
                             maintenanceType,
                             timeMaintenanceWindowStart,
                             timeMaintenanceWindowEnd,
-                            additionalDetails);
+                            additionalDetails,
+                            cpuCoreCount,
+                            memorySizeInGBs,
+                            dbNodeStorageSizeInGBs,
+                            dbServerId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -223,7 +263,11 @@ public class DbNode {
                             .maintenanceType(o.getMaintenanceType())
                             .timeMaintenanceWindowStart(o.getTimeMaintenanceWindowStart())
                             .timeMaintenanceWindowEnd(o.getTimeMaintenanceWindowEnd())
-                            .additionalDetails(o.getAdditionalDetails());
+                            .additionalDetails(o.getAdditionalDetails())
+                            .cpuCoreCount(o.getCpuCoreCount())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .dbServerId(o.getDbServerId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -447,6 +491,30 @@ public class DbNode {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
     String additionalDetails;
+
+    /**
+     * The number of CPU cores enabled on the Db node.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+    Integer cpuCoreCount;
+
+    /**
+     * The allocated memory in GBs on the Db node.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The allocated local node storage in GBs on the Db node.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server associated with the database node.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServerId")
+    String dbServerId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNodeSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbNodeSummary.java
@@ -182,6 +182,42 @@ public class DbNodeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+        private Integer cpuCoreCount;
+
+        public Builder cpuCoreCount(Integer cpuCoreCount) {
+            this.cpuCoreCount = cpuCoreCount;
+            this.__explicitlySet__.add("cpuCoreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServerId")
+        private String dbServerId;
+
+        public Builder dbServerId(String dbServerId) {
+            this.dbServerId = dbServerId;
+            this.__explicitlySet__.add("dbServerId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -204,7 +240,11 @@ public class DbNodeSummary {
                             maintenanceType,
                             timeMaintenanceWindowStart,
                             timeMaintenanceWindowEnd,
-                            additionalDetails);
+                            additionalDetails,
+                            cpuCoreCount,
+                            memorySizeInGBs,
+                            dbNodeStorageSizeInGBs,
+                            dbServerId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -228,7 +268,11 @@ public class DbNodeSummary {
                             .maintenanceType(o.getMaintenanceType())
                             .timeMaintenanceWindowStart(o.getTimeMaintenanceWindowStart())
                             .timeMaintenanceWindowEnd(o.getTimeMaintenanceWindowEnd())
-                            .additionalDetails(o.getAdditionalDetails());
+                            .additionalDetails(o.getAdditionalDetails())
+                            .cpuCoreCount(o.getCpuCoreCount())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .dbServerId(o.getDbServerId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -452,6 +496,30 @@ public class DbNodeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
     String additionalDetails;
+
+    /**
+     * The number of CPU cores enabled on the Db node.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+    Integer cpuCoreCount;
+
+    /**
+     * The allocated memory in GBs on the Db node.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The allocated local node storage in GBs on the Db node.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server associated with the database node.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServerId")
+    String dbServerId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServer.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServer.java
@@ -1,0 +1,403 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the Exacc Db server resource. Applies to Exadata Cloud@Customer instances only.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DbServer.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DbServer {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+        private String exadataInfrastructureId;
+
+        public Builder exadataInfrastructureId(String exadataInfrastructureId) {
+            this.exadataInfrastructureId = exadataInfrastructureId;
+            this.__explicitlySet__.add("exadataInfrastructureId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+        private Integer cpuCoreCount;
+
+        public Builder cpuCoreCount(Integer cpuCoreCount) {
+            this.cpuCoreCount = cpuCoreCount;
+            this.__explicitlySet__.add("cpuCoreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterIds")
+        private java.util.List<String> vmClusterIds;
+
+        public Builder vmClusterIds(java.util.List<String> vmClusterIds) {
+            this.vmClusterIds = vmClusterIds;
+            this.__explicitlySet__.add("vmClusterIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeIds")
+        private java.util.List<String> dbNodeIds;
+
+        public Builder dbNodeIds(java.util.List<String> dbNodeIds) {
+            this.dbNodeIds = dbNodeIds;
+            this.__explicitlySet__.add("dbNodeIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxCpuCount")
+        private Integer maxCpuCount;
+
+        public Builder maxCpuCount(Integer maxCpuCount) {
+            this.maxCpuCount = maxCpuCount;
+            this.__explicitlySet__.add("maxCpuCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxMemoryInGBs")
+        private Integer maxMemoryInGBs;
+
+        public Builder maxMemoryInGBs(Integer maxMemoryInGBs) {
+            this.maxMemoryInGBs = maxMemoryInGBs;
+            this.__explicitlySet__.add("maxMemoryInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxDbNodeStorageInGBs")
+        private Integer maxDbNodeStorageInGBs;
+
+        public Builder maxDbNodeStorageInGBs(Integer maxDbNodeStorageInGBs) {
+            this.maxDbNodeStorageInGBs = maxDbNodeStorageInGBs;
+            this.__explicitlySet__.add("maxDbNodeStorageInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DbServer build() {
+            DbServer __instance__ =
+                    new DbServer(
+                            id,
+                            displayName,
+                            compartmentId,
+                            exadataInfrastructureId,
+                            cpuCoreCount,
+                            memorySizeInGBs,
+                            dbNodeStorageSizeInGBs,
+                            vmClusterIds,
+                            dbNodeIds,
+                            lifecycleState,
+                            lifecycleDetails,
+                            maxCpuCount,
+                            maxMemoryInGBs,
+                            maxDbNodeStorageInGBs,
+                            timeCreated,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DbServer o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .exadataInfrastructureId(o.getExadataInfrastructureId())
+                            .cpuCoreCount(o.getCpuCoreCount())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .vmClusterIds(o.getVmClusterIds())
+                            .dbNodeIds(o.getDbNodeIds())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .maxCpuCount(o.getMaxCpuCount())
+                            .maxMemoryInGBs(o.getMaxMemoryInGBs())
+                            .maxDbNodeStorageInGBs(o.getMaxDbNodeStorageInGBs())
+                            .timeCreated(o.getTimeCreated())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The user-friendly name for the Db server. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+    String exadataInfrastructureId;
+
+    /**
+     * The number of CPU cores enabled on the Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+    Integer cpuCoreCount;
+
+    /**
+     * The allocated memory in GBs on the Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The allocated local node storage in GBs on the Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM Clusters associated with the Db server.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterIds")
+    java.util.List<String> vmClusterIds;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Db nodes associated with the Db server.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeIds")
+    java.util.List<String> dbNodeIds;
+    /**
+     * The current state of the Db server.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Available("AVAILABLE"),
+        Unavailable("UNAVAILABLE"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        MaintenanceInProgress("MAINTENANCE_IN_PROGRESS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Additional information about the current lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The total number of CPU cores available.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxCpuCount")
+    Integer maxCpuCount;
+
+    /**
+     * The total memory available in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxMemoryInGBs")
+    Integer maxMemoryInGBs;
+
+    /**
+     * The total local node storage available in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxDbNodeStorageInGBs")
+    Integer maxDbNodeStorageInGBs;
+
+    /**
+     * The date and time that the Db Server was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: {@code {"Department": "Finance"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServerDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServerDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the Exacc Db server. Applies to Exadata Cloud@Customer instances only.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DbServerDetails.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DbServerDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServerId")
+        private String dbServerId;
+
+        public Builder dbServerId(String dbServerId) {
+            this.dbServerId = dbServerId;
+            this.__explicitlySet__.add("dbServerId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DbServerDetails build() {
+            DbServerDetails __instance__ = new DbServerDetails(dbServerId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DbServerDetails o) {
+            Builder copiedBuilder = dbServerId(o.getDbServerId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of Exacc Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServerId")
+    String dbServerId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServerSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServerSummary.java
@@ -1,0 +1,403 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the Exadata Cloud@Customer Db server.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DbServerSummary.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DbServerSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+        private String exadataInfrastructureId;
+
+        public Builder exadataInfrastructureId(String exadataInfrastructureId) {
+            this.exadataInfrastructureId = exadataInfrastructureId;
+            this.__explicitlySet__.add("exadataInfrastructureId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+        private Integer cpuCoreCount;
+
+        public Builder cpuCoreCount(Integer cpuCoreCount) {
+            this.cpuCoreCount = cpuCoreCount;
+            this.__explicitlySet__.add("cpuCoreCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+        private Integer memorySizeInGBs;
+
+        public Builder memorySizeInGBs(Integer memorySizeInGBs) {
+            this.memorySizeInGBs = memorySizeInGBs;
+            this.__explicitlySet__.add("memorySizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+        private Integer dbNodeStorageSizeInGBs;
+
+        public Builder dbNodeStorageSizeInGBs(Integer dbNodeStorageSizeInGBs) {
+            this.dbNodeStorageSizeInGBs = dbNodeStorageSizeInGBs;
+            this.__explicitlySet__.add("dbNodeStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vmClusterIds")
+        private java.util.List<String> vmClusterIds;
+
+        public Builder vmClusterIds(java.util.List<String> vmClusterIds) {
+            this.vmClusterIds = vmClusterIds;
+            this.__explicitlySet__.add("vmClusterIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbNodeIds")
+        private java.util.List<String> dbNodeIds;
+
+        public Builder dbNodeIds(java.util.List<String> dbNodeIds) {
+            this.dbNodeIds = dbNodeIds;
+            this.__explicitlySet__.add("dbNodeIds");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxCpuCount")
+        private Integer maxCpuCount;
+
+        public Builder maxCpuCount(Integer maxCpuCount) {
+            this.maxCpuCount = maxCpuCount;
+            this.__explicitlySet__.add("maxCpuCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxMemoryInGBs")
+        private Integer maxMemoryInGBs;
+
+        public Builder maxMemoryInGBs(Integer maxMemoryInGBs) {
+            this.maxMemoryInGBs = maxMemoryInGBs;
+            this.__explicitlySet__.add("maxMemoryInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("maxDbNodeStorageInGBs")
+        private Integer maxDbNodeStorageInGBs;
+
+        public Builder maxDbNodeStorageInGBs(Integer maxDbNodeStorageInGBs) {
+            this.maxDbNodeStorageInGBs = maxDbNodeStorageInGBs;
+            this.__explicitlySet__.add("maxDbNodeStorageInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DbServerSummary build() {
+            DbServerSummary __instance__ =
+                    new DbServerSummary(
+                            id,
+                            displayName,
+                            compartmentId,
+                            exadataInfrastructureId,
+                            cpuCoreCount,
+                            memorySizeInGBs,
+                            dbNodeStorageSizeInGBs,
+                            vmClusterIds,
+                            dbNodeIds,
+                            lifecycleState,
+                            lifecycleDetails,
+                            maxCpuCount,
+                            maxMemoryInGBs,
+                            maxDbNodeStorageInGBs,
+                            timeCreated,
+                            freeformTags,
+                            definedTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DbServerSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .exadataInfrastructureId(o.getExadataInfrastructureId())
+                            .cpuCoreCount(o.getCpuCoreCount())
+                            .memorySizeInGBs(o.getMemorySizeInGBs())
+                            .dbNodeStorageSizeInGBs(o.getDbNodeStorageSizeInGBs())
+                            .vmClusterIds(o.getVmClusterIds())
+                            .dbNodeIds(o.getDbNodeIds())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .maxCpuCount(o.getMaxCpuCount())
+                            .maxMemoryInGBs(o.getMaxMemoryInGBs())
+                            .maxDbNodeStorageInGBs(o.getMaxDbNodeStorageInGBs())
+                            .timeCreated(o.getTimeCreated())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The user-friendly name for the Db server. The name does not need to be unique.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the compartment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("exadataInfrastructureId")
+    String exadataInfrastructureId;
+
+    /**
+     * The number of CPU cores enabled on the Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cpuCoreCount")
+    Integer cpuCoreCount;
+
+    /**
+     * The allocated memory in GBs on the Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memorySizeInGBs")
+    Integer memorySizeInGBs;
+
+    /**
+     * The allocated local node storage in GBs on the Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeStorageSizeInGBs")
+    Integer dbNodeStorageSizeInGBs;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the VM Clusters associated with the Db server.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vmClusterIds")
+    java.util.List<String> vmClusterIds;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Db nodes associated with the Db server.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbNodeIds")
+    java.util.List<String> dbNodeIds;
+    /**
+     * The current state of the Db server.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Available("AVAILABLE"),
+        Unavailable("UNAVAILABLE"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        MaintenanceInProgress("MAINTENANCE_IN_PROGRESS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Additional information about the current lifecycle state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The total number of CPU cores available.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxCpuCount")
+    Integer maxCpuCount;
+
+    /**
+     * The total memory available in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxMemoryInGBs")
+    Integer maxMemoryInGBs;
+
+    /**
+     * The total local node storage available in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("maxDbNodeStorageInGBs")
+    Integer maxDbNodeStorageInGBs;
+
+    /**
+     * The date and time that the Db Server was created.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: {@code {"Department": "Finance"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For more information, see [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/PdbConversionHistoryEntry.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/PdbConversionHistoryEntry.java
@@ -1,0 +1,397 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of operations performed to convert a non-container database to pluggable database.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PdbConversionHistoryEntry.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PdbConversionHistoryEntry {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("action")
+        private Action action;
+
+        public Builder action(Action action) {
+            this.action = action;
+            this.__explicitlySet__.add("action");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private Target target;
+
+        public Builder target(Target target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceDatabaseId")
+        private String sourceDatabaseId;
+
+        public Builder sourceDatabaseId(String sourceDatabaseId) {
+            this.sourceDatabaseId = sourceDatabaseId;
+            this.__explicitlySet__.add("sourceDatabaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetDatabaseId")
+        private String targetDatabaseId;
+
+        public Builder targetDatabaseId(String targetDatabaseId) {
+            this.targetDatabaseId = targetDatabaseId;
+            this.__explicitlySet__.add("targetDatabaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cdbName")
+        private String cdbName;
+
+        public Builder cdbName(String cdbName) {
+            this.cdbName = cdbName;
+            this.__explicitlySet__.add("cdbName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeEnded")
+        private java.util.Date timeEnded;
+
+        public Builder timeEnded(java.util.Date timeEnded) {
+            this.timeEnded = timeEnded;
+            this.__explicitlySet__.add("timeEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("additionalCdbParams")
+        private String additionalCdbParams;
+
+        public Builder additionalCdbParams(String additionalCdbParams) {
+            this.additionalCdbParams = additionalCdbParams;
+            this.__explicitlySet__.add("additionalCdbParams");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PdbConversionHistoryEntry build() {
+            PdbConversionHistoryEntry __instance__ =
+                    new PdbConversionHistoryEntry(
+                            id,
+                            action,
+                            target,
+                            sourceDatabaseId,
+                            targetDatabaseId,
+                            cdbName,
+                            lifecycleState,
+                            lifecycleDetails,
+                            timeStarted,
+                            timeEnded,
+                            additionalCdbParams);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PdbConversionHistoryEntry o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .action(o.getAction())
+                            .target(o.getTarget())
+                            .sourceDatabaseId(o.getSourceDatabaseId())
+                            .targetDatabaseId(o.getTargetDatabaseId())
+                            .cdbName(o.getCdbName())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .timeStarted(o.getTimeStarted())
+                            .timeEnded(o.getTimeEnded())
+                            .additionalCdbParams(o.getAdditionalCdbParams());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database conversion history.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+    /**
+     * The operations used to convert a non-container database to a pluggable database.
+     * - Use {@code PRECHECK} to run a pre-check operation on non-container database prior to converting it into a pluggable database.
+     * - Use {@code CONVERT} to convert a non-container database into a pluggable database.
+     * - Use {@code SYNC} if the non-container database was manually converted into a pluggable database using the dbcli command-line utility. Databases may need to be converted manually if the CONVERT action fails when converting a non-container database using the API.
+     * - Use {@code SYNC_ROLLBACK} if the conversion of a non-container database into a pluggable database was manually rolled back using the dbcli command line utility. Conversions may need to be manually rolled back if the CONVERT action fails when converting a non-container database using the API.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Action {
+        Precheck("PRECHECK"),
+        Convert("CONVERT"),
+        Sync("SYNC"),
+        SyncRollback("SYNC_ROLLBACK"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Action> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Action v : Action.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Action(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Action create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Action', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The operations used to convert a non-container database to a pluggable database.
+     * - Use {@code PRECHECK} to run a pre-check operation on non-container database prior to converting it into a pluggable database.
+     * - Use {@code CONVERT} to convert a non-container database into a pluggable database.
+     * - Use {@code SYNC} if the non-container database was manually converted into a pluggable database using the dbcli command-line utility. Databases may need to be converted manually if the CONVERT action fails when converting a non-container database using the API.
+     * - Use {@code SYNC_ROLLBACK} if the conversion of a non-container database into a pluggable database was manually rolled back using the dbcli command line utility. Conversions may need to be manually rolled back if the CONVERT action fails when converting a non-container database using the API.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("action")
+    Action action;
+    /**
+     * The target container database of the pluggable database created by the database conversion operation. Currently, the database conversion operation only supports creating the pluggable database in a new container database.
+     *  - Use {@code NEW_DATABASE} to specify that the pluggable database be created within a new container database in the same database home.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Target {
+        NewDatabase("NEW_DATABASE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Target> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Target v : Target.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Target(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Target create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Target', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The target container database of the pluggable database created by the database conversion operation. Currently, the database conversion operation only supports creating the pluggable database in a new container database.
+     *  - Use {@code NEW_DATABASE} to specify that the pluggable database be created within a new container database in the same database home.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    Target target;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceDatabaseId")
+    String sourceDatabaseId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetDatabaseId")
+    String targetDatabaseId;
+
+    /**
+     * The database name. The name must begin with an alphabetic character and can contain a maximum of 8 alphanumeric characters. Special characters are not permitted. The database name must be unique in the tenancy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cdbName")
+    String cdbName;
+    /**
+     * Status of an operation performed during the conversion of a non-container database to a pluggable database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Succeeded("SUCCEEDED"),
+        Failed("FAILED"),
+        InProgress("IN_PROGRESS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Status of an operation performed during the conversion of a non-container database to a pluggable database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Additional information about the current lifecycle state for the conversion operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The date and time when the database conversion operation started.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+    java.util.Date timeStarted;
+
+    /**
+     * The date and time when the database conversion operation ended.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeEnded")
+    java.util.Date timeEnded;
+
+    /**
+     * Additional container database parameter.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("additionalCdbParams")
+    String additionalCdbParams;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/PdbConversionHistoryEntrySummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/PdbConversionHistoryEntrySummary.java
@@ -1,0 +1,397 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of operations performed to convert a non-container database to pluggable database.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PdbConversionHistoryEntrySummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PdbConversionHistoryEntrySummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("action")
+        private Action action;
+
+        public Builder action(Action action) {
+            this.action = action;
+            this.__explicitlySet__.add("action");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("target")
+        private Target target;
+
+        public Builder target(Target target) {
+            this.target = target;
+            this.__explicitlySet__.add("target");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceDatabaseId")
+        private String sourceDatabaseId;
+
+        public Builder sourceDatabaseId(String sourceDatabaseId) {
+            this.sourceDatabaseId = sourceDatabaseId;
+            this.__explicitlySet__.add("sourceDatabaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetDatabaseId")
+        private String targetDatabaseId;
+
+        public Builder targetDatabaseId(String targetDatabaseId) {
+            this.targetDatabaseId = targetDatabaseId;
+            this.__explicitlySet__.add("targetDatabaseId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cdbName")
+        private String cdbName;
+
+        public Builder cdbName(String cdbName) {
+            this.cdbName = cdbName;
+            this.__explicitlySet__.add("cdbName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private String lifecycleDetails;
+
+        public Builder lifecycleDetails(String lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeEnded")
+        private java.util.Date timeEnded;
+
+        public Builder timeEnded(java.util.Date timeEnded) {
+            this.timeEnded = timeEnded;
+            this.__explicitlySet__.add("timeEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("additionalCdbParams")
+        private String additionalCdbParams;
+
+        public Builder additionalCdbParams(String additionalCdbParams) {
+            this.additionalCdbParams = additionalCdbParams;
+            this.__explicitlySet__.add("additionalCdbParams");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PdbConversionHistoryEntrySummary build() {
+            PdbConversionHistoryEntrySummary __instance__ =
+                    new PdbConversionHistoryEntrySummary(
+                            id,
+                            action,
+                            target,
+                            sourceDatabaseId,
+                            targetDatabaseId,
+                            cdbName,
+                            lifecycleState,
+                            lifecycleDetails,
+                            timeStarted,
+                            timeEnded,
+                            additionalCdbParams);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PdbConversionHistoryEntrySummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .action(o.getAction())
+                            .target(o.getTarget())
+                            .sourceDatabaseId(o.getSourceDatabaseId())
+                            .targetDatabaseId(o.getTargetDatabaseId())
+                            .cdbName(o.getCdbName())
+                            .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
+                            .timeStarted(o.getTimeStarted())
+                            .timeEnded(o.getTimeEnded())
+                            .additionalCdbParams(o.getAdditionalCdbParams());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database conversion history.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+    /**
+     * The operations used to convert a non-container database to a pluggable database.
+     * - Use {@code PRECHECK} to run a pre-check operation on non-container database prior to converting it into a pluggable database.
+     * - Use {@code CONVERT} to convert a non-container database into a pluggable database.
+     * - Use {@code SYNC} if the non-container database was manually converted into a pluggable database using the dbcli command-line utility. Databases may need to be converted manually if the CONVERT action fails when converting a non-container database using the API.
+     * - Use {@code SYNC_ROLLBACK} if the conversion of a non-container database into a pluggable database was manually rolled back using the dbcli command line utility. Conversions may need to be manually rolled back if the CONVERT action fails when converting a non-container database using the API.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Action {
+        Precheck("PRECHECK"),
+        Convert("CONVERT"),
+        Sync("SYNC"),
+        SyncRollback("SYNC_ROLLBACK"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Action> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Action v : Action.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Action(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Action create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Action', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The operations used to convert a non-container database to a pluggable database.
+     * - Use {@code PRECHECK} to run a pre-check operation on non-container database prior to converting it into a pluggable database.
+     * - Use {@code CONVERT} to convert a non-container database into a pluggable database.
+     * - Use {@code SYNC} if the non-container database was manually converted into a pluggable database using the dbcli command-line utility. Databases may need to be converted manually if the CONVERT action fails when converting a non-container database using the API.
+     * - Use {@code SYNC_ROLLBACK} if the conversion of a non-container database into a pluggable database was manually rolled back using the dbcli command line utility. Conversions may need to be manually rolled back if the CONVERT action fails when converting a non-container database using the API.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("action")
+    Action action;
+    /**
+     * The target container database of the pluggable database created by the database conversion operation. Currently, the database conversion operation only supports creating the pluggable database in a new container database.
+     *  - Use {@code NEW_DATABASE} to specify that the pluggable database be created within a new container database in the same database home.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Target {
+        NewDatabase("NEW_DATABASE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Target> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Target v : Target.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Target(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Target create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Target', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The target container database of the pluggable database created by the database conversion operation. Currently, the database conversion operation only supports creating the pluggable database in a new container database.
+     *  - Use {@code NEW_DATABASE} to specify that the pluggable database be created within a new container database in the same database home.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("target")
+    Target target;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceDatabaseId")
+    String sourceDatabaseId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetDatabaseId")
+    String targetDatabaseId;
+
+    /**
+     * The database name. The name must begin with an alphabetic character and can contain a maximum of 8 alphanumeric characters. Special characters are not permitted. The database name must be unique in the tenancy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cdbName")
+    String cdbName;
+    /**
+     * Status of an operation performed during the conversion of a non-container database to a pluggable database.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Succeeded("SUCCEEDED"),
+        Failed("FAILED"),
+        InProgress("IN_PROGRESS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Status of an operation performed during the conversion of a non-container database to a pluggable database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * Additional information about the current lifecycle state for the conversion operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    String lifecycleDetails;
+
+    /**
+     * The date and time when the database conversion operation started.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+    java.util.Date timeStarted;
+
+    /**
+     * The date and time when the database conversion operation ended.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeEnded")
+    java.util.Date timeEnded;
+
+    /**
+     * Additional container database parameter.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("additionalCdbParams")
+    String additionalCdbParams;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/PdbConversionToNewDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/PdbConversionToNewDatabaseDetails.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of the new container database in which the converted pluggable database will be located.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = PdbConversionToNewDatabaseDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "target"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class PdbConversionToNewDatabaseDetails extends ConvertToPdbTargetBase {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("cdbName")
+        private String cdbName;
+
+        public Builder cdbName(String cdbName) {
+            this.cdbName = cdbName;
+            this.__explicitlySet__.add("cdbName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cdbAdminPassword")
+        private String cdbAdminPassword;
+
+        public Builder cdbAdminPassword(String cdbAdminPassword) {
+            this.cdbAdminPassword = cdbAdminPassword;
+            this.__explicitlySet__.add("cdbAdminPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("pdbAdminPassword")
+        private String pdbAdminPassword;
+
+        public Builder pdbAdminPassword(String pdbAdminPassword) {
+            this.pdbAdminPassword = pdbAdminPassword;
+            this.__explicitlySet__.add("pdbAdminPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("cdbTdeWalletPassword")
+        private String cdbTdeWalletPassword;
+
+        public Builder cdbTdeWalletPassword(String cdbTdeWalletPassword) {
+            this.cdbTdeWalletPassword = cdbTdeWalletPassword;
+            this.__explicitlySet__.add("cdbTdeWalletPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nonCdbTdeWalletPassword")
+        private String nonCdbTdeWalletPassword;
+
+        public Builder nonCdbTdeWalletPassword(String nonCdbTdeWalletPassword) {
+            this.nonCdbTdeWalletPassword = nonCdbTdeWalletPassword;
+            this.__explicitlySet__.add("nonCdbTdeWalletPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("additionalCdbParams")
+        private String additionalCdbParams;
+
+        public Builder additionalCdbParams(String additionalCdbParams) {
+            this.additionalCdbParams = additionalCdbParams;
+            this.__explicitlySet__.add("additionalCdbParams");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public PdbConversionToNewDatabaseDetails build() {
+            PdbConversionToNewDatabaseDetails __instance__ =
+                    new PdbConversionToNewDatabaseDetails(
+                            cdbName,
+                            cdbAdminPassword,
+                            pdbAdminPassword,
+                            cdbTdeWalletPassword,
+                            nonCdbTdeWalletPassword,
+                            additionalCdbParams);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(PdbConversionToNewDatabaseDetails o) {
+            Builder copiedBuilder =
+                    cdbName(o.getCdbName())
+                            .cdbAdminPassword(o.getCdbAdminPassword())
+                            .pdbAdminPassword(o.getPdbAdminPassword())
+                            .cdbTdeWalletPassword(o.getCdbTdeWalletPassword())
+                            .nonCdbTdeWalletPassword(o.getNonCdbTdeWalletPassword())
+                            .additionalCdbParams(o.getAdditionalCdbParams());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public PdbConversionToNewDatabaseDetails(
+            String cdbName,
+            String cdbAdminPassword,
+            String pdbAdminPassword,
+            String cdbTdeWalletPassword,
+            String nonCdbTdeWalletPassword,
+            String additionalCdbParams) {
+        super();
+        this.cdbName = cdbName;
+        this.cdbAdminPassword = cdbAdminPassword;
+        this.pdbAdminPassword = pdbAdminPassword;
+        this.cdbTdeWalletPassword = cdbTdeWalletPassword;
+        this.nonCdbTdeWalletPassword = nonCdbTdeWalletPassword;
+        this.additionalCdbParams = additionalCdbParams;
+    }
+
+    /**
+     * The database name. The name must begin with an alphabetic character and can contain a maximum of 8 alphanumeric characters. Special characters are not permitted. The database name must be unique in the tenancy.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cdbName")
+    String cdbName;
+
+    /**
+     * A strong password for SYS, SYSTEM, and the plugbable database ADMIN user of the container database after conversion. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numeric, and two special characters. The special characters must be _, \\#, or -.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cdbAdminPassword")
+    String cdbAdminPassword;
+
+    /**
+     * A strong password for plugbable database ADMIN user of the container database after conversion. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numeric, and two special characters. The special characters must be _, \\#, or -.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("pdbAdminPassword")
+    String pdbAdminPassword;
+
+    /**
+     * The password to open the TDE wallet of the container database after conversion. The password must be at least nine characters and contain at least two uppercase, two lowercase, two numeric, and two special characters. The special characters must be _, \\#, or -.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("cdbTdeWalletPassword")
+    String cdbTdeWalletPassword;
+
+    /**
+     * The existing TDE wallet password of the non-container database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nonCdbTdeWalletPassword")
+    String nonCdbTdeWalletPassword;
+
+    /**
+     * Additional container database parameters.
+     * Example: "_pdb_name_case_sensitive=true"
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("additionalCdbParams")
+    String additionalCdbParams;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/RemoveVirtualMachineFromVmClusterDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/RemoveVirtualMachineFromVmClusterDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * Details of removing Virtual Machines from the VM Cluster. Applies to Exadata Cloud@Customer instances only.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RemoveVirtualMachineFromVmClusterDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RemoveVirtualMachineFromVmClusterDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+        private java.util.List<DbServerDetails> dbServers;
+
+        public Builder dbServers(java.util.List<DbServerDetails> dbServers) {
+            this.dbServers = dbServers;
+            this.__explicitlySet__.add("dbServers");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RemoveVirtualMachineFromVmClusterDetails build() {
+            RemoveVirtualMachineFromVmClusterDetails __instance__ =
+                    new RemoveVirtualMachineFromVmClusterDetails(dbServers);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RemoveVirtualMachineFromVmClusterDetails o) {
+            Builder copiedBuilder = dbServers(o.getDbServers());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The list of Exacc DB servers for the cluster to be removed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+    java.util.List<DbServerDetails> dbServers;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmCluster.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmCluster.java
@@ -214,6 +214,15 @@ public class VmCluster {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+        private java.util.List<String> dbServers;
+
+        public Builder dbServers(java.util.List<String> dbServers) {
+            this.dbServers = dbServers;
+            this.__explicitlySet__.add("dbServers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -260,6 +269,7 @@ public class VmCluster {
                             systemVersion,
                             sshPublicKeys,
                             licenseModel,
+                            dbServers,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -290,6 +300,7 @@ public class VmCluster {
                             .systemVersion(o.getSystemVersion())
                             .sshPublicKeys(o.getSshPublicKeys())
                             .licenseModel(o.getLicenseModel())
+                            .dbServers(o.getDbServers())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -530,6 +541,12 @@ public class VmCluster {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
     LicenseModel licenseModel;
+
+    /**
+     * The list of Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+    java.util.List<String> dbServers;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/VmClusterSummary.java
@@ -214,6 +214,15 @@ public class VmClusterSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+        private java.util.List<String> dbServers;
+
+        public Builder dbServers(java.util.List<String> dbServers) {
+            this.dbServers = dbServers;
+            this.__explicitlySet__.add("dbServers");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -260,6 +269,7 @@ public class VmClusterSummary {
                             systemVersion,
                             sshPublicKeys,
                             licenseModel,
+                            dbServers,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -290,6 +300,7 @@ public class VmClusterSummary {
                             .systemVersion(o.getSystemVersion())
                             .sshPublicKeys(o.getSshPublicKeys())
                             .licenseModel(o.getLicenseModel())
+                            .dbServers(o.getDbServers())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -530,6 +541,12 @@ public class VmClusterSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("licenseModel")
     LicenseModel licenseModel;
+
+    /**
+     * The list of Db server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServers")
+    java.util.List<String> dbServers;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/AddVirtualMachineToVmClusterRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/AddVirtualMachineToVmClusterRequest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/AddVirtualMachineToVmClusterExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use AddVirtualMachineToVmClusterRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class AddVirtualMachineToVmClusterRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.database.model.AddVirtualMachineToVmClusterDetails> {
+
+    /**
+     * Request to add Virtual Machines to the VM cluster.
+     */
+    private com.oracle.bmc.database.model.AddVirtualMachineToVmClusterDetails
+            addVirtualMachineToVmClusterDetails;
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the {@code if-match}
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.database.model.AddVirtualMachineToVmClusterDetails getBody$() {
+        return addVirtualMachineToVmClusterDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    AddVirtualMachineToVmClusterRequest,
+                    com.oracle.bmc.database.model.AddVirtualMachineToVmClusterDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddVirtualMachineToVmClusterRequest o) {
+            addVirtualMachineToVmClusterDetails(o.getAddVirtualMachineToVmClusterDetails());
+            vmClusterId(o.getVmClusterId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of AddVirtualMachineToVmClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of AddVirtualMachineToVmClusterRequest
+         */
+        public AddVirtualMachineToVmClusterRequest build() {
+            AddVirtualMachineToVmClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.database.model.AddVirtualMachineToVmClusterDetails body) {
+            addVirtualMachineToVmClusterDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ConvertToPdbRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ConvertToPdbRequest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ConvertToPdbExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ConvertToPdbRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ConvertToPdbRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.database.model.ConvertToPdbDetails> {
+
+    /**
+     * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String databaseId;
+
+    /**
+     * Request to convert a non-container database to a pluggable database.
+     *
+     */
+    private com.oracle.bmc.database.model.ConvertToPdbDetails convertToPdbDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the {@code if-match}
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.database.model.ConvertToPdbDetails getBody$() {
+        return convertToPdbDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ConvertToPdbRequest, com.oracle.bmc.database.model.ConvertToPdbDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ConvertToPdbRequest o) {
+            databaseId(o.getDatabaseId());
+            convertToPdbDetails(o.getConvertToPdbDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ConvertToPdbRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ConvertToPdbRequest
+         */
+        public ConvertToPdbRequest build() {
+            ConvertToPdbRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(com.oracle.bmc.database.model.ConvertToPdbDetails body) {
+            convertToPdbDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetDbServerRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetDbServerRequest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/GetDbServerExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetDbServerRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetDbServerRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the ExadataInfrastructure.
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The DB server [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String dbServerId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetDbServerRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetDbServerRequest o) {
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            dbServerId(o.getDbServerId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetDbServerRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetDbServerRequest
+         */
+        public GetDbServerRequest build() {
+            GetDbServerRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetPdbConversionHistoryEntryRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/GetPdbConversionHistoryEntryRequest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/GetPdbConversionHistoryEntryExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetPdbConversionHistoryEntryRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetPdbConversionHistoryEntryRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String databaseId;
+
+    /**
+     * The database conversion history [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String pdbConversionHistoryEntryId;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetPdbConversionHistoryEntryRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPdbConversionHistoryEntryRequest o) {
+            databaseId(o.getDatabaseId());
+            pdbConversionHistoryEntryId(o.getPdbConversionHistoryEntryId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetPdbConversionHistoryEntryRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetPdbConversionHistoryEntryRequest
+         */
+        public GetPdbConversionHistoryEntryRequest build() {
+            GetPdbConversionHistoryEntryRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbNodesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbNodesRequest.java
@@ -128,6 +128,11 @@ public class ListDbNodesRequest extends com.oracle.bmc.requests.BmcRequest<java.
      */
     private com.oracle.bmc.database.model.DbNodeSummary.LifecycleState lifecycleState;
 
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Exacc Db server.
+     */
+    private String dbServerId;
+
     public static class Builder
             implements com.oracle.bmc.requests.BmcRequest.Builder<
                     ListDbNodesRequest, java.lang.Void> {
@@ -171,6 +176,7 @@ public class ListDbNodesRequest extends com.oracle.bmc.requests.BmcRequest<java.
             sortBy(o.getSortBy());
             sortOrder(o.getSortOrder());
             lifecycleState(o.getLifecycleState());
+            dbServerId(o.getDbServerId());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbServersRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListDbServersRequest.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListDbServersExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListDbServersRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListDbServersRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The compartment [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String compartmentId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the ExadataInfrastructure.
+     */
+    private String exadataInfrastructureId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either ascending ({@code ASC}) or descending ({@code DESC}).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending ({@code ASC}) or descending ({@code DESC}).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Sort by TIMECREATED.  Default order for TIMECREATED is descending.
+     */
+    private SortBy sortBy;
+
+    /**
+     * Sort by TIMECREATED.  Default order for TIMECREATED is descending.
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * A filter to return only resources that match the given lifecycle state exactly.
+     */
+    private com.oracle.bmc.database.model.DbServerSummary.LifecycleState lifecycleState;
+
+    /**
+     * A filter to return only resources that match the entire display name given. The match is not case sensitive.
+     */
+    private String displayName;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListDbServersRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDbServersRequest o) {
+            compartmentId(o.getCompartmentId());
+            exadataInfrastructureId(o.getExadataInfrastructureId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            sortBy(o.getSortBy());
+            lifecycleState(o.getLifecycleState());
+            displayName(o.getDisplayName());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListDbServersRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListDbServersRequest
+         */
+        public ListDbServersRequest build() {
+            ListDbServersRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListPdbConversionHistoryEntriesRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ListPdbConversionHistoryEntriesRequest.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ListPdbConversionHistoryEntriesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListPdbConversionHistoryEntriesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListPdbConversionHistoryEntriesRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String databaseId;
+
+    /**
+     * A filter to return only the pluggable database conversion history entries that match the specified conversion action. For example, you can use this filter to return only entries for the precheck operation.
+     */
+    private com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary.Action
+            pdbConversionAction;
+
+    /**
+     * A filter to return only the pluggable database conversion history entries that match the specified lifecycle state. For example, you can use this filter to return only entries in the "failed" lifecycle state.
+     */
+    private com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary.LifecycleState
+            lifecycleState;
+
+    /**
+     * The field to sort by. You can provide one sort order ({@code sortOrder}). The default order for {@code TIMECREATED} is ascending.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order ({@code sortOrder}). The default order for {@code TIMECREATED} is ascending.
+     *
+     **/
+    public enum SortBy {
+        Timestarted("TIMESTARTED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending ({@code ASC}) or descending ({@code DESC}).
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending ({@code ASC}) or descending ({@code DESC}).
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The maximum number of items to return per page.
+     */
+    private Integer limit;
+
+    /**
+     * The pagination token to continue listing from.
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListPdbConversionHistoryEntriesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPdbConversionHistoryEntriesRequest o) {
+            databaseId(o.getDatabaseId());
+            pdbConversionAction(o.getPdbConversionAction());
+            lifecycleState(o.getLifecycleState());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            opcRequestId(o.getOpcRequestId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListPdbConversionHistoryEntriesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListPdbConversionHistoryEntriesRequest
+         */
+        public ListPdbConversionHistoryEntriesRequest build() {
+            ListPdbConversionHistoryEntriesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/RemoveVirtualMachineFromVmClusterRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/RemoveVirtualMachineFromVmClusterRequest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/RemoveVirtualMachineFromVmClusterExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use RemoveVirtualMachineFromVmClusterRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RemoveVirtualMachineFromVmClusterRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.database.model.RemoveVirtualMachineFromVmClusterDetails> {
+
+    /**
+     * Request to remove Virtual Machines from the VM cluster.
+     */
+    private com.oracle.bmc.database.model.RemoveVirtualMachineFromVmClusterDetails
+            removeVirtualMachineFromVmClusterDetails;
+
+    /**
+     * The VM cluster [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String vmClusterId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations (for example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * may be rejected).
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the {@code if-match}
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.database.model.RemoveVirtualMachineFromVmClusterDetails getBody$() {
+        return removeVirtualMachineFromVmClusterDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RemoveVirtualMachineFromVmClusterRequest,
+                    com.oracle.bmc.database.model.RemoveVirtualMachineFromVmClusterDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveVirtualMachineFromVmClusterRequest o) {
+            removeVirtualMachineFromVmClusterDetails(
+                    o.getRemoveVirtualMachineFromVmClusterDetails());
+            vmClusterId(o.getVmClusterId());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RemoveVirtualMachineFromVmClusterRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RemoveVirtualMachineFromVmClusterRequest
+         */
+        public RemoveVirtualMachineFromVmClusterRequest build() {
+            RemoveVirtualMachineFromVmClusterRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.database.model.RemoveVirtualMachineFromVmClusterDetails body) {
+            removeVirtualMachineFromVmClusterDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/AddVirtualMachineToVmClusterResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/AddVirtualMachineToVmClusterResponse.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class AddVirtualMachineToVmClusterResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmCluster instance.
+     */
+    private com.oracle.bmc.database.model.VmCluster vmCluster;
+
+    private AddVirtualMachineToVmClusterResponse(
+            int __httpStatusCode__,
+            String opcWorkRequestId,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.database.model.VmCluster vmCluster) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.vmCluster = vmCluster;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddVirtualMachineToVmClusterResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmCluster(o.getVmCluster());
+
+            return this;
+        }
+
+        public AddVirtualMachineToVmClusterResponse build() {
+            return new AddVirtualMachineToVmClusterResponse(
+                    __httpStatusCode__, opcWorkRequestId, etag, opcRequestId, vmCluster);
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ConvertToPdbResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ConvertToPdbResponse.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ConvertToPdbResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned Database instance.
+     */
+    private com.oracle.bmc.database.model.Database database;
+
+    private ConvertToPdbResponse(
+            int __httpStatusCode__,
+            String opcWorkRequestId,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.database.model.Database database) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.database = database;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ConvertToPdbResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            database(o.getDatabase());
+
+            return this;
+        }
+
+        public ConvertToPdbResponse build() {
+            return new ConvertToPdbResponse(
+                    __httpStatusCode__, opcWorkRequestId, etag, opcRequestId, database);
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetDbServerResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetDbServerResponse.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetDbServerResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned DbServer instance.
+     */
+    private com.oracle.bmc.database.model.DbServer dbServer;
+
+    private GetDbServerResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.database.model.DbServer dbServer) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.dbServer = dbServer;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetDbServerResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            dbServer(o.getDbServer());
+
+            return this;
+        }
+
+        public GetDbServerResponse build() {
+            return new GetDbServerResponse(__httpStatusCode__, etag, opcRequestId, dbServer);
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetPdbConversionHistoryEntryResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/GetPdbConversionHistoryEntryResponse.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetPdbConversionHistoryEntryResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned PdbConversionHistoryEntry instance.
+     */
+    private com.oracle.bmc.database.model.PdbConversionHistoryEntry pdbConversionHistoryEntry;
+
+    private GetPdbConversionHistoryEntryResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            com.oracle.bmc.database.model.PdbConversionHistoryEntry pdbConversionHistoryEntry) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.pdbConversionHistoryEntry = pdbConversionHistoryEntry;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPdbConversionHistoryEntryResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            pdbConversionHistoryEntry(o.getPdbConversionHistoryEntry());
+
+            return this;
+        }
+
+        public GetPdbConversionHistoryEntryResponse build() {
+            return new GetPdbConversionHistoryEntryResponse(
+                    __httpStatusCode__, opcRequestId, pdbConversionHistoryEntry);
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListDbServersResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListDbServersResponse.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListDbServersResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the {@code page} parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of com.oracle.bmc.database.model.DbServerSummary instances.
+     */
+    private java.util.List<com.oracle.bmc.database.model.DbServerSummary> items;
+
+    private ListDbServersResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            java.util.List<com.oracle.bmc.database.model.DbServerSummary> items) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.items = items;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListDbServersResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+
+        public ListDbServersResponse build() {
+            return new ListDbServersResponse(__httpStatusCode__, opcRequestId, opcNextPage, items);
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListPdbConversionHistoryEntriesResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ListPdbConversionHistoryEntriesResponse.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListPdbConversionHistoryEntriesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then there are additional items still to get. Include this value as the {@code page} parameter for the
+     * subsequent GET request. For information about pagination, see
+     * [List Pagination](https://docs.cloud.oracle.com/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * A list of com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary instances.
+     */
+    private java.util.List<com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary> items;
+
+    private ListPdbConversionHistoryEntriesResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            java.util.List<com.oracle.bmc.database.model.PdbConversionHistoryEntrySummary> items) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.items = items;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListPdbConversionHistoryEntriesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            items(o.getItems());
+
+            return this;
+        }
+
+        public ListPdbConversionHistoryEntriesResponse build() {
+            return new ListPdbConversionHistoryEntriesResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, items);
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/RemoveVirtualMachineFromVmClusterResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/RemoveVirtualMachineFromVmClusterResponse.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RemoveVirtualMachineFromVmClusterResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VmCluster instance.
+     */
+    private com.oracle.bmc.database.model.VmCluster vmCluster;
+
+    private RemoveVirtualMachineFromVmClusterResponse(
+            int __httpStatusCode__,
+            String opcWorkRequestId,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.database.model.VmCluster vmCluster) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.vmCluster = vmCluster;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveVirtualMachineFromVmClusterResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vmCluster(o.getVmCluster());
+
+            return this;
+        }
+
+        public RemoveVirtualMachineFromVmClusterResponse build() {
+            return new RemoveVirtualMachineFromVmClusterResponse(
+                    __httpStatusCode__, opcWorkRequestId, etag, opcRequestId, vmCluster);
+        }
+    }
+}

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalytics.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalytics.java
@@ -819,6 +819,17 @@ public interface LogAnalytics extends AutoCloseable {
     GetParserSummaryResponse getParserSummary(GetParserSummaryRequest request);
 
     /**
+     * Lists the preferences of the tenant. Currently, only \"DEFAULT_HOMEPAGE\" is supported.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/GetPreferencesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetPreferences API.
+     */
+    GetPreferencesResponse getPreferences(GetPreferencesRequest request);
+
+    /**
      * Returns the intermediate results for a query that was specified to run asynchronously if the query has not completed,
      * otherwise the final query results identified by a queryWorkRequestId returned when submitting the query execute asynchronously.
      *
@@ -906,6 +917,18 @@ public interface LogAnalytics extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/GetStorageWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetStorageWorkRequest API.
      */
     GetStorageWorkRequestResponse getStorageWorkRequest(GetStorageWorkRequestRequest request);
+
+    /**
+     * This API retrieves details of the configured bucket that stores unprocessed payloads.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/GetUnprocessedDataBucketExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetUnprocessedDataBucket API.
+     */
+    GetUnprocessedDataBucketResponse getUnprocessedDataBucket(
+            GetUnprocessedDataBucketRequest request);
 
     /**
      * Gets an On-Demand Upload info by reference.
@@ -1586,6 +1609,17 @@ public interface LogAnalytics extends AutoCloseable {
             RemoveEntityAssociationsRequest request);
 
     /**
+     * Removes the tenant preferences. Currently, only \"DEFAULT_HOMEPAGE\" is supported.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/RemovePreferencesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RemovePreferences API.
+     */
+    RemovePreferencesResponse removePreferences(RemovePreferencesRequest request);
+
+    /**
      * Remove one or more event types from a source.
      *
      * @param request The request object containing the details to send
@@ -1619,6 +1653,20 @@ public interface LogAnalytics extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/RunExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use Run API.
      */
     RunResponse run(RunRequest request);
+
+    /**
+     * This API configures a bucket to store unprocessed payloads.
+     * While processing there could be reasons a payload cannot be processed (mismatched structure, corrupted archive format, etc),
+     * if configured the payload would be uploaded to the bucket for verification.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/SetUnprocessedDataBucketExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SetUnprocessedDataBucket API.
+     */
+    SetUnprocessedDataBucketResponse setUnprocessedDataBucket(
+            SetUnprocessedDataBucketRequest request);
 
     /**
      * Returns a context specific list of either commands, fields, or values to append to the end of the specified query string if applicable.
@@ -1767,6 +1815,17 @@ public interface LogAnalytics extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/UpdateLookupDataExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateLookupData API.
      */
     UpdateLookupDataResponse updateLookupData(UpdateLookupDataRequest request);
+
+    /**
+     * Updates the tenant preferences. Currently, only \"DEFAULT_HOMEPAGE\" is supported.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/UpdatePreferencesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdatePreferences API.
+     */
+    UpdatePreferencesResponse updatePreferences(UpdatePreferencesRequest request);
 
     /**
      * Update the scheduled task. Schedules may be updated only for taskType SAVED_SEARCH and PURGE.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsAsync.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsAsync.java
@@ -1168,6 +1168,22 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Lists the preferences of the tenant. Currently, only \"DEFAULT_HOMEPAGE\" is supported.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetPreferencesResponse> getPreferences(
+            GetPreferencesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetPreferencesRequest, GetPreferencesResponse>
+                    handler);
+
+    /**
      * Returns the intermediate results for a query that was specified to run asynchronously if the query has not completed,
      * otherwise the final query results identified by a queryWorkRequestId returned when submitting the query execute asynchronously.
      *
@@ -1294,6 +1310,23 @@ public interface LogAnalyticsAsync extends AutoCloseable {
             GetStorageWorkRequestRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             GetStorageWorkRequestRequest, GetStorageWorkRequestResponse>
+                    handler);
+
+    /**
+     * This API retrieves details of the configured bucket that stores unprocessed payloads.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetUnprocessedDataBucketResponse> getUnprocessedDataBucket(
+            GetUnprocessedDataBucketRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetUnprocessedDataBucketRequest, GetUnprocessedDataBucketResponse>
                     handler);
 
     /**
@@ -2230,6 +2263,23 @@ public interface LogAnalyticsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Removes the tenant preferences. Currently, only \"DEFAULT_HOMEPAGE\" is supported.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RemovePreferencesResponse> removePreferences(
+            RemovePreferencesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            RemovePreferencesRequest, RemovePreferencesResponse>
+                    handler);
+
+    /**
      * Remove one or more event types from a source.
      *
      *
@@ -2279,6 +2329,25 @@ public interface LogAnalyticsAsync extends AutoCloseable {
     java.util.concurrent.Future<RunResponse> run(
             RunRequest request,
             com.oracle.bmc.responses.AsyncHandler<RunRequest, RunResponse> handler);
+
+    /**
+     * This API configures a bucket to store unprocessed payloads.
+     * While processing there could be reasons a payload cannot be processed (mismatched structure, corrupted archive format, etc),
+     * if configured the payload would be uploaded to the bucket for verification.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<SetUnprocessedDataBucketResponse> setUnprocessedDataBucket(
+            SetUnprocessedDataBucketRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            SetUnprocessedDataBucketRequest, SetUnprocessedDataBucketResponse>
+                    handler);
 
     /**
      * Returns a context specific list of either commands, fields, or values to append to the end of the specified query string if applicable.
@@ -2456,6 +2525,23 @@ public interface LogAnalyticsAsync extends AutoCloseable {
     java.util.concurrent.Future<UpdateLookupDataResponse> updateLookupData(
             UpdateLookupDataRequest request,
             com.oracle.bmc.responses.AsyncHandler<UpdateLookupDataRequest, UpdateLookupDataResponse>
+                    handler);
+
+    /**
+     * Updates the tenant preferences. Currently, only \"DEFAULT_HOMEPAGE\" is supported.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdatePreferencesResponse> updatePreferences(
+            UpdatePreferencesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            UpdatePreferencesRequest, UpdatePreferencesResponse>
                     handler);
 
     /**

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsAsyncClient.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsAsyncClient.java
@@ -3331,6 +3331,45 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetPreferencesResponse> getPreferences(
+            GetPreferencesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetPreferencesRequest, GetPreferencesResponse>
+                    handler) {
+        LOG.trace("Called async getPreferences");
+        final GetPreferencesRequest interceptedRequest =
+                GetPreferencesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPreferencesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetPreferencesResponse>
+                transformer = GetPreferencesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetPreferencesRequest, GetPreferencesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetPreferencesRequest, GetPreferencesResponse>,
+                        java.util.concurrent.Future<GetPreferencesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetPreferencesRequest, GetPreferencesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetQueryResultResponse> getQueryResult(
             GetQueryResultRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -3629,6 +3668,47 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     GetStorageWorkRequestRequest, GetStorageWorkRequestResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetUnprocessedDataBucketResponse> getUnprocessedDataBucket(
+            GetUnprocessedDataBucketRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetUnprocessedDataBucketRequest, GetUnprocessedDataBucketResponse>
+                    handler) {
+        LOG.trace("Called async getUnprocessedDataBucket");
+        final GetUnprocessedDataBucketRequest interceptedRequest =
+                GetUnprocessedDataBucketConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetUnprocessedDataBucketConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetUnprocessedDataBucketResponse>
+                transformer = GetUnprocessedDataBucketConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetUnprocessedDataBucketRequest, GetUnprocessedDataBucketResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetUnprocessedDataBucketRequest, GetUnprocessedDataBucketResponse>,
+                        java.util.concurrent.Future<GetUnprocessedDataBucketResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetUnprocessedDataBucketRequest, GetUnprocessedDataBucketResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -6009,6 +6089,51 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<RemovePreferencesResponse> removePreferences(
+            RemovePreferencesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            RemovePreferencesRequest, RemovePreferencesResponse>
+                    handler) {
+        LOG.trace("Called async removePreferences");
+        final RemovePreferencesRequest interceptedRequest =
+                RemovePreferencesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemovePreferencesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, RemovePreferencesResponse>
+                transformer = RemovePreferencesConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<RemovePreferencesRequest, RemovePreferencesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RemovePreferencesRequest, RemovePreferencesResponse>,
+                        java.util.concurrent.Future<RemovePreferencesResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getRemovePreferencesDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RemovePreferencesRequest, RemovePreferencesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<RemoveSourceEventTypesResponse> removeSourceEventTypes(
             RemoveSourceEventTypesRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -6119,6 +6244,47 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     RunRequest, RunResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<SetUnprocessedDataBucketResponse> setUnprocessedDataBucket(
+            SetUnprocessedDataBucketRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            SetUnprocessedDataBucketRequest, SetUnprocessedDataBucketResponse>
+                    handler) {
+        LOG.trace("Called async setUnprocessedDataBucket");
+        final SetUnprocessedDataBucketRequest interceptedRequest =
+                SetUnprocessedDataBucketConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SetUnprocessedDataBucketConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, SetUnprocessedDataBucketResponse>
+                transformer = SetUnprocessedDataBucketConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        SetUnprocessedDataBucketRequest, SetUnprocessedDataBucketResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                SetUnprocessedDataBucketRequest, SetUnprocessedDataBucketResponse>,
+                        java.util.concurrent.Future<SetUnprocessedDataBucketResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    SetUnprocessedDataBucketRequest, SetUnprocessedDataBucketResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -6645,6 +6811,51 @@ public class LogAnalyticsAsyncClient implements LogAnalyticsAsync {
                     com.oracle.bmc.retrier.Retriers.tryResetStreamForRetry(
                             interceptedRequest.getUpdateLookupFileBody(), true);
                 }
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdatePreferencesResponse> updatePreferences(
+            UpdatePreferencesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdatePreferencesRequest, UpdatePreferencesResponse>
+                    handler) {
+        LOG.trace("Called async updatePreferences");
+        final UpdatePreferencesRequest interceptedRequest =
+                UpdatePreferencesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdatePreferencesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdatePreferencesResponse>
+                transformer = UpdatePreferencesConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<UpdatePreferencesRequest, UpdatePreferencesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdatePreferencesRequest, UpdatePreferencesResponse>,
+                        java.util.concurrent.Future<UpdatePreferencesResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getUpdatePreferencesDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdatePreferencesRequest, UpdatePreferencesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
             };
         } else {
             return futureSupplier.apply(handlerToUse);

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsClient.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/LogAnalyticsClient.java
@@ -2602,6 +2602,34 @@ public class LogAnalyticsClient implements LogAnalytics {
     }
 
     @Override
+    public GetPreferencesResponse getPreferences(GetPreferencesRequest request) {
+        LOG.trace("Called getPreferences");
+        final GetPreferencesRequest interceptedRequest =
+                GetPreferencesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetPreferencesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetPreferencesResponse>
+                transformer = GetPreferencesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetQueryResultResponse getQueryResult(GetQueryResultRequest request) {
         LOG.trace("Called getQueryResult");
         final GetQueryResultRequest interceptedRequest =
@@ -2805,6 +2833,35 @@ public class LogAnalyticsClient implements LogAnalytics {
                 GetStorageWorkRequestConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, GetStorageWorkRequestResponse>
                 transformer = GetStorageWorkRequestConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetUnprocessedDataBucketResponse getUnprocessedDataBucket(
+            GetUnprocessedDataBucketRequest request) {
+        LOG.trace("Called getUnprocessedDataBucket");
+        final GetUnprocessedDataBucketRequest interceptedRequest =
+                GetUnprocessedDataBucketConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetUnprocessedDataBucketConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetUnprocessedDataBucketResponse>
+                transformer = GetUnprocessedDataBucketConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -4557,6 +4614,39 @@ public class LogAnalyticsClient implements LogAnalytics {
     }
 
     @Override
+    public RemovePreferencesResponse removePreferences(RemovePreferencesRequest request) {
+        LOG.trace("Called removePreferences");
+        final RemovePreferencesRequest interceptedRequest =
+                RemovePreferencesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemovePreferencesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, RemovePreferencesResponse>
+                transformer = RemovePreferencesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getRemovePreferencesDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public RemoveSourceEventTypesResponse removeSourceEventTypes(
             RemoveSourceEventTypesRequest request) {
         LOG.trace("Called removeSourceEventTypes");
@@ -4632,6 +4722,36 @@ public class LogAnalyticsClient implements LogAnalytics {
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
                         interceptedRequest.getRetryConfiguration(), retryConfiguration);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public SetUnprocessedDataBucketResponse setUnprocessedDataBucket(
+            SetUnprocessedDataBucketRequest request) {
+        LOG.trace("Called setUnprocessedDataBucket");
+        final SetUnprocessedDataBucketRequest interceptedRequest =
+                SetUnprocessedDataBucketConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                SetUnprocessedDataBucketConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, SetUnprocessedDataBucketResponse>
+                transformer = SetUnprocessedDataBucketConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
         return retrier.execute(
                 interceptedRequest,
                 retryRequest -> {
@@ -5045,6 +5165,39 @@ public class LogAnalyticsClient implements LogAnalytics {
             com.oracle.bmc.io.internal.KeepOpenInputStream.closeStream(
                     request.getUpdateLookupFileBody());
         }
+    }
+
+    @Override
+    public UpdatePreferencesResponse updatePreferences(UpdatePreferencesRequest request) {
+        LOG.trace("Called updatePreferences");
+        final UpdatePreferencesRequest interceptedRequest =
+                UpdatePreferencesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdatePreferencesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdatePreferencesResponse>
+                transformer = UpdatePreferencesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getUpdatePreferencesDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
     }
 
     @Override

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/AppendLookupDataConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/AppendLookupDataConverter.java
@@ -77,6 +77,10 @@ public class AppendLookupDataConverter {
             ib.header("if-match", request.getIfMatch());
         }
 
+        if (request.getExpect() != null) {
+            ib.header("expect", request.getExpect());
+        }
+
         if (client.getClientConfigurator() != null) {
             client.getClientConfigurator().customizeRequest(request, ib);
         }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/GetPreferencesConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/GetPreferencesConverter.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class GetPreferencesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.GetPreferencesRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.GetPreferencesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.GetPreferencesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("preferences");
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.GetPreferencesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.GetPreferencesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.GetPreferencesResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.GetPreferencesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.GetPreferencesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.loganalytics.model
+                                                                .LogAnalyticsPreferenceCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.loganalytics.model
+                                                                        .LogAnalyticsPreferenceCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.loganalytics.model
+                                                        .LogAnalyticsPreferenceCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.GetPreferencesResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .GetPreferencesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.logAnalyticsPreferenceCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPrevPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-prev-page");
+                                if (opcPrevPageHeader.isPresent()) {
+                                    builder.opcPrevPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-prev-page",
+                                                    opcPrevPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.GetPreferencesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/GetUnprocessedDataBucketConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/GetUnprocessedDataBucketConverter.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class GetUnprocessedDataBucketConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.GetUnprocessedDataBucketRequest
+            interceptRequest(
+                    com.oracle.bmc.loganalytics.requests.GetUnprocessedDataBucketRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.GetUnprocessedDataBucketRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("unprocessedDataBucket");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.GetUnprocessedDataBucketResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.GetUnprocessedDataBucketResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses
+                                        .GetUnprocessedDataBucketResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses
+                                            .GetUnprocessedDataBucketResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.GetUnprocessedDataBucketResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.loganalytics.model
+                                                                .UnprocessedDataBucket>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.loganalytics.model
+                                                                        .UnprocessedDataBucket
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.loganalytics.model
+                                                        .UnprocessedDataBucket>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses
+                                                .GetUnprocessedDataBucketResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .GetUnprocessedDataBucketResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.unprocessedDataBucket(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses
+                                                .GetUnprocessedDataBucketResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ImportCustomContentConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/ImportCustomContentConverter.java
@@ -63,6 +63,10 @@ public class ImportCustomContentConverter {
             ib.header("opc-request-id", request.getOpcRequestId());
         }
 
+        if (request.getExpect() != null) {
+            ib.header("expect", request.getExpect());
+        }
+
         if (client.getClientConfigurator() != null) {
             client.getClientConfigurator().customizeRequest(request, ib);
         }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/RegisterLookupConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/RegisterLookupConverter.java
@@ -94,6 +94,10 @@ public class RegisterLookupConverter {
             ib.header("opc-request-id", request.getOpcRequestId());
         }
 
+        if (request.getExpect() != null) {
+            ib.header("expect", request.getExpect());
+        }
+
         if (client.getClientConfigurator() != null) {
             client.getClientConfigurator().customizeRequest(request, ib);
         }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/RemovePreferencesConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/RemovePreferencesConverter.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class RemovePreferencesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.RemovePreferencesRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.RemovePreferencesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.RemovePreferencesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notNull(
+                request.getRemovePreferencesDetails(), "removePreferencesDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("preferences")
+                        .path("actions")
+                        .path("removePreferences");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.RemovePreferencesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.RemovePreferencesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.RemovePreferencesResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.RemovePreferencesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.RemovePreferencesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.RemovePreferencesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .RemovePreferencesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.RemovePreferencesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/SetUnprocessedDataBucketConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/SetUnprocessedDataBucketConverter.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class SetUnprocessedDataBucketConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.SetUnprocessedDataBucketRequest
+            interceptRequest(
+                    com.oracle.bmc.loganalytics.requests.SetUnprocessedDataBucketRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.SetUnprocessedDataBucketRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notNull(request.getBucketName(), "bucketName is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("actions")
+                        .path("setUnprocessedDataBucket");
+
+        target =
+                target.queryParam(
+                        "bucketName",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getBucketName()));
+
+        if (request.getIsEnabled() != null) {
+            target =
+                    target.queryParam(
+                            "isEnabled",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getIsEnabled()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.SetUnprocessedDataBucketResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.SetUnprocessedDataBucketResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses
+                                        .SetUnprocessedDataBucketResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses
+                                            .SetUnprocessedDataBucketResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.SetUnprocessedDataBucketResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.loganalytics.model
+                                                                .UnprocessedDataBucket>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.loganalytics.model
+                                                                        .UnprocessedDataBucket
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.loganalytics.model
+                                                        .UnprocessedDataBucket>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses
+                                                .SetUnprocessedDataBucketResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .SetUnprocessedDataBucketResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.unprocessedDataBucket(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses
+                                                .SetUnprocessedDataBucketResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UpdateLookupDataConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UpdateLookupDataConverter.java
@@ -77,6 +77,10 @@ public class UpdateLookupDataConverter {
             ib.header("if-match", request.getIfMatch());
         }
 
+        if (request.getExpect() != null) {
+            ib.header("expect", request.getExpect());
+        }
+
         if (client.getClientConfigurator() != null) {
             client.getClientConfigurator().customizeRequest(request, ib);
         }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UpdatePreferencesConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UpdatePreferencesConverter.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.loganalytics.model.*;
+import com.oracle.bmc.loganalytics.requests.*;
+import com.oracle.bmc.loganalytics.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.extern.slf4j.Slf4j
+public class UpdatePreferencesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.loganalytics.requests.UpdatePreferencesRequest interceptRequest(
+            com.oracle.bmc.loganalytics.requests.UpdatePreferencesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.loganalytics.requests.UpdatePreferencesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getNamespaceName(), "namespaceName must not be blank");
+        Validate.notNull(
+                request.getUpdatePreferencesDetails(), "updatePreferencesDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20200601")
+                        .path("namespaces")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getNamespaceName()))
+                        .path("preferences")
+                        .path("actions")
+                        .path("updatePreferences");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.loganalytics.responses.UpdatePreferencesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.loganalytics.responses.UpdatePreferencesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.loganalytics.responses.UpdatePreferencesResponse>() {
+                            @Override
+                            public com.oracle.bmc.loganalytics.responses.UpdatePreferencesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.loganalytics.responses.UpdatePreferencesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.loganalytics.responses.UpdatePreferencesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.loganalytics.responses
+                                                        .UpdatePreferencesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.loganalytics.responses.UpdatePreferencesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UploadLogEventsFileConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UploadLogEventsFileConverter.java
@@ -80,6 +80,10 @@ public class UploadLogEventsFileConverter {
             ib.header("opc-retry-token", request.getOpcRetryToken());
         }
 
+        if (request.getExpect() != null) {
+            ib.header("expect", request.getExpect());
+        }
+
         if (client.getClientConfigurator() != null) {
             client.getClientConfigurator().customizeRequest(request, ib);
         }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UploadLogFileConverter.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/internal/http/UploadLogFileConverter.java
@@ -140,6 +140,10 @@ public class UploadLogFileConverter {
             ib.header("opc-retry-token", request.getOpcRetryToken());
         }
 
+        if (request.getExpect() != null) {
+            ib.header("expect", request.getExpect());
+        }
+
         if (client.getClientConfigurator() != null) {
             client.getClientConfigurator().customizeRequest(request, ib);
         }

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AbstractColumn.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AbstractColumn.java
@@ -90,6 +90,13 @@ public class AbstractColumn {
     Boolean isMultiValued;
 
     /**
+     * A flag indicating whether or not the field is a case sensitive field.  Only applies to string fields.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCaseSensitive")
+    Boolean isCaseSensitive;
+
+    /**
      * Identifies if this column can be used as a grouping field in any grouping command.
      *
      **/

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AbstractCommandDescriptor.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/AbstractCommandDescriptor.java
@@ -78,6 +78,10 @@ package com.oracle.bmc.loganalytics.model;
         name = "FIELD_SUMMARY"
     ),
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = GeoStatsCommandDescriptor.class,
+        name = "GEO_STATS"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = MapCommandDescriptor.class,
         name = "MAP"
     ),
@@ -245,6 +249,7 @@ public class AbstractCommandDescriptor {
         Command("COMMAND"),
         Search("SEARCH"),
         Stats("STATS"),
+        GeoStats("GEO_STATS"),
         TimeStats("TIME_STATS"),
         Sort("SORT"),
         Fields("FIELDS"),

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ChartColumn.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ChartColumn.java
@@ -76,6 +76,15 @@ public class ChartColumn extends AbstractColumn {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCaseSensitive")
+        private Boolean isCaseSensitive;
+
+        public Builder isCaseSensitive(Boolean isCaseSensitive) {
+            this.isCaseSensitive = isCaseSensitive;
+            this.__explicitlySet__.add("isCaseSensitive");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isGroupable")
         private Boolean isGroupable;
 
@@ -168,6 +177,7 @@ public class ChartColumn extends AbstractColumn {
                             values,
                             isListOfValues,
                             isMultiValued,
+                            isCaseSensitive,
                             isGroupable,
                             isEvaluable,
                             valueType,
@@ -189,6 +199,7 @@ public class ChartColumn extends AbstractColumn {
                             .values(o.getValues())
                             .isListOfValues(o.getIsListOfValues())
                             .isMultiValued(o.getIsMultiValued())
+                            .isCaseSensitive(o.getIsCaseSensitive())
                             .isGroupable(o.getIsGroupable())
                             .isEvaluable(o.getIsEvaluable())
                             .valueType(o.getValueType())
@@ -218,6 +229,7 @@ public class ChartColumn extends AbstractColumn {
             java.util.List<FieldValue> values,
             Boolean isListOfValues,
             Boolean isMultiValued,
+            Boolean isCaseSensitive,
             Boolean isGroupable,
             Boolean isEvaluable,
             ValueType valueType,
@@ -233,6 +245,7 @@ public class ChartColumn extends AbstractColumn {
                 values,
                 isListOfValues,
                 isMultiValued,
+                isCaseSensitive,
                 isGroupable,
                 isEvaluable,
                 valueType,

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ChartDataColumn.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ChartDataColumn.java
@@ -76,6 +76,15 @@ public class ChartDataColumn extends AbstractColumn {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCaseSensitive")
+        private Boolean isCaseSensitive;
+
+        public Builder isCaseSensitive(Boolean isCaseSensitive) {
+            this.isCaseSensitive = isCaseSensitive;
+            this.__explicitlySet__.add("isCaseSensitive");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isGroupable")
         private Boolean isGroupable;
 
@@ -150,6 +159,7 @@ public class ChartDataColumn extends AbstractColumn {
                             values,
                             isListOfValues,
                             isMultiValued,
+                            isCaseSensitive,
                             isGroupable,
                             isEvaluable,
                             valueType,
@@ -169,6 +179,7 @@ public class ChartDataColumn extends AbstractColumn {
                             .values(o.getValues())
                             .isListOfValues(o.getIsListOfValues())
                             .isMultiValued(o.getIsMultiValued())
+                            .isCaseSensitive(o.getIsCaseSensitive())
                             .isGroupable(o.getIsGroupable())
                             .isEvaluable(o.getIsEvaluable())
                             .valueType(o.getValueType())
@@ -196,6 +207,7 @@ public class ChartDataColumn extends AbstractColumn {
             java.util.List<FieldValue> values,
             Boolean isListOfValues,
             Boolean isMultiValued,
+            Boolean isCaseSensitive,
             Boolean isGroupable,
             Boolean isEvaluable,
             ValueType valueType,
@@ -209,6 +221,7 @@ public class ChartDataColumn extends AbstractColumn {
                 values,
                 isListOfValues,
                 isMultiValued,
+                isCaseSensitive,
                 isGroupable,
                 isEvaluable,
                 valueType,

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ClassifyColumn.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ClassifyColumn.java
@@ -76,6 +76,15 @@ public class ClassifyColumn extends AbstractColumn {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCaseSensitive")
+        private Boolean isCaseSensitive;
+
+        public Builder isCaseSensitive(Boolean isCaseSensitive) {
+            this.isCaseSensitive = isCaseSensitive;
+            this.__explicitlySet__.add("isCaseSensitive");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isGroupable")
         private Boolean isGroupable;
 
@@ -199,6 +208,7 @@ public class ClassifyColumn extends AbstractColumn {
                             values,
                             isListOfValues,
                             isMultiValued,
+                            isCaseSensitive,
                             isGroupable,
                             isEvaluable,
                             valueType,
@@ -223,6 +233,7 @@ public class ClassifyColumn extends AbstractColumn {
                             .values(o.getValues())
                             .isListOfValues(o.getIsListOfValues())
                             .isMultiValued(o.getIsMultiValued())
+                            .isCaseSensitive(o.getIsCaseSensitive())
                             .isGroupable(o.getIsGroupable())
                             .isEvaluable(o.getIsEvaluable())
                             .valueType(o.getValueType())
@@ -255,6 +266,7 @@ public class ClassifyColumn extends AbstractColumn {
             java.util.List<FieldValue> values,
             Boolean isListOfValues,
             Boolean isMultiValued,
+            Boolean isCaseSensitive,
             Boolean isGroupable,
             Boolean isEvaluable,
             ValueType valueType,
@@ -273,6 +285,7 @@ public class ClassifyColumn extends AbstractColumn {
                 values,
                 isListOfValues,
                 isMultiValued,
+                isCaseSensitive,
                 isGroupable,
                 isEvaluable,
                 valueType,

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/Column.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/Column.java
@@ -76,6 +76,15 @@ public class Column extends AbstractColumn {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCaseSensitive")
+        private Boolean isCaseSensitive;
+
+        public Builder isCaseSensitive(Boolean isCaseSensitive) {
+            this.isCaseSensitive = isCaseSensitive;
+            this.__explicitlySet__.add("isCaseSensitive");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isGroupable")
         private Boolean isGroupable;
 
@@ -132,6 +141,7 @@ public class Column extends AbstractColumn {
                             values,
                             isListOfValues,
                             isMultiValued,
+                            isCaseSensitive,
                             isGroupable,
                             isEvaluable,
                             valueType,
@@ -149,6 +159,7 @@ public class Column extends AbstractColumn {
                             .values(o.getValues())
                             .isListOfValues(o.getIsListOfValues())
                             .isMultiValued(o.getIsMultiValued())
+                            .isCaseSensitive(o.getIsCaseSensitive())
                             .isGroupable(o.getIsGroupable())
                             .isEvaluable(o.getIsEvaluable())
                             .valueType(o.getValueType())
@@ -174,6 +185,7 @@ public class Column extends AbstractColumn {
             java.util.List<FieldValue> values,
             Boolean isListOfValues,
             Boolean isMultiValued,
+            Boolean isCaseSensitive,
             Boolean isGroupable,
             Boolean isEvaluable,
             ValueType valueType,
@@ -185,6 +197,7 @@ public class Column extends AbstractColumn {
                 values,
                 isListOfValues,
                 isMultiValued,
+                isCaseSensitive,
                 isGroupable,
                 isEvaluable,
                 valueType,

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateLogAnalyticsObjectCollectionRuleDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/CreateLogAnalyticsObjectCollectionRuleDetails.java
@@ -154,6 +154,15 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("objectNameFilters")
+        private java.util.List<String> objectNameFilters;
+
+        public Builder objectNameFilters(java.util.List<String> objectNameFilters) {
+            this.objectNameFilters = objectNameFilters;
+            this.__explicitlySet__.add("objectNameFilters");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -193,6 +202,7 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
                             charEncoding,
                             isEnabled,
                             overrides,
+                            objectNameFilters,
                             definedTags,
                             freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -216,6 +226,7 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
                             .charEncoding(o.getCharEncoding())
                             .isEnabled(o.getIsEnabled())
                             .overrides(o.getOverrides())
+                            .objectNameFilters(o.getObjectNameFilters())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -331,6 +342,15 @@ public class CreateLogAnalyticsObjectCollectionRuleDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("overrides")
     java.util.Map<String, java.util.List<PropertyOverride>> overrides;
+
+    /**
+     * When the filters are provided, only the objects matching the filters are picked up for processing.
+     * The matchType supported is exact match and accommodates wildcard "*".
+     * For more information on filters, see [Event Filters](https://docs.oracle.com/en-us/iaas/Content/Events/Concepts/filterevents.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectNameFilters")
+    java.util.List<String> objectNameFilters;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ExtractLogHeaderResults.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/ExtractLogHeaderResults.java
@@ -44,18 +44,31 @@ public class ExtractLogHeaderResults {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("headerPaths")
+        private java.util.List<String> headerPaths;
+
+        public Builder headerPaths(java.util.List<String> headerPaths) {
+            this.headerPaths = headerPaths;
+            this.__explicitlySet__.add("headerPaths");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ExtractLogHeaderResults build() {
-            ExtractLogHeaderResults __instance__ = new ExtractLogHeaderResults(jsonPaths, xmlPaths);
+            ExtractLogHeaderResults __instance__ =
+                    new ExtractLogHeaderResults(jsonPaths, xmlPaths, headerPaths);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(ExtractLogHeaderResults o) {
-            Builder copiedBuilder = jsonPaths(o.getJsonPaths()).xmlPaths(o.getXmlPaths());
+            Builder copiedBuilder =
+                    jsonPaths(o.getJsonPaths())
+                            .xmlPaths(o.getXmlPaths())
+                            .headerPaths(o.getHeaderPaths());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -80,6 +93,12 @@ public class ExtractLogHeaderResults {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("xmlPaths")
     java.util.List<String> xmlPaths;
+
+    /**
+     * The log header values.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("headerPaths")
+    java.util.List<String> headerPaths;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/GeoStatsCommandDescriptor.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/GeoStatsCommandDescriptor.java
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Command descriptor for querylanguage GEOSTATS command.  This is similiar to STATS with some built in functions for City, State and Country by Coordinates.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = GeoStatsCommandDescriptor.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "name"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class GeoStatsCommandDescriptor extends AbstractCommandDescriptor {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayQueryString")
+        private String displayQueryString;
+
+        public Builder displayQueryString(String displayQueryString) {
+            this.displayQueryString = displayQueryString;
+            this.__explicitlySet__.add("displayQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("internalQueryString")
+        private String internalQueryString;
+
+        public Builder internalQueryString(String internalQueryString) {
+            this.internalQueryString = internalQueryString;
+            this.__explicitlySet__.add("internalQueryString");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("category")
+        private String category;
+
+        public Builder category(String category) {
+            this.category = category;
+            this.__explicitlySet__.add("category");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("referencedFields")
+        private java.util.List<AbstractField> referencedFields;
+
+        public Builder referencedFields(java.util.List<AbstractField> referencedFields) {
+            this.referencedFields = referencedFields;
+            this.__explicitlySet__.add("referencedFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("declaredFields")
+        private java.util.List<AbstractField> declaredFields;
+
+        public Builder declaredFields(java.util.List<AbstractField> declaredFields) {
+            this.declaredFields = declaredFields;
+            this.__explicitlySet__.add("declaredFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("include")
+        private Include include;
+
+        public Builder include(Include include) {
+            this.include = include;
+            this.__explicitlySet__.add("include");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("groupByFields")
+        private java.util.List<AbstractField> groupByFields;
+
+        public Builder groupByFields(java.util.List<AbstractField> groupByFields) {
+            this.groupByFields = groupByFields;
+            this.__explicitlySet__.add("groupByFields");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("functions")
+        private java.util.List<FunctionField> functions;
+
+        public Builder functions(java.util.List<FunctionField> functions) {
+            this.functions = functions;
+            this.__explicitlySet__.add("functions");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public GeoStatsCommandDescriptor build() {
+            GeoStatsCommandDescriptor __instance__ =
+                    new GeoStatsCommandDescriptor(
+                            displayQueryString,
+                            internalQueryString,
+                            category,
+                            referencedFields,
+                            declaredFields,
+                            include,
+                            groupByFields,
+                            functions);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(GeoStatsCommandDescriptor o) {
+            Builder copiedBuilder =
+                    displayQueryString(o.getDisplayQueryString())
+                            .internalQueryString(o.getInternalQueryString())
+                            .category(o.getCategory())
+                            .referencedFields(o.getReferencedFields())
+                            .declaredFields(o.getDeclaredFields())
+                            .include(o.getInclude())
+                            .groupByFields(o.getGroupByFields())
+                            .functions(o.getFunctions());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public GeoStatsCommandDescriptor(
+            String displayQueryString,
+            String internalQueryString,
+            String category,
+            java.util.List<AbstractField> referencedFields,
+            java.util.List<AbstractField> declaredFields,
+            Include include,
+            java.util.List<AbstractField> groupByFields,
+            java.util.List<FunctionField> functions) {
+        super(displayQueryString, internalQueryString, category, referencedFields, declaredFields);
+        this.include = include;
+        this.groupByFields = groupByFields;
+        this.functions = functions;
+    }
+
+    /**
+     * Indicates which coordinates to show.  Either client, server or both.  Defaults to client.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Include {
+        Client("CLIENT"),
+        Server("SERVER"),
+        ClientAndServer("CLIENT_AND_SERVER"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Include> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Include v : Include.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Include(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Include create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Include', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Indicates which coordinates to show.  Either client, server or both.  Defaults to client.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("include")
+    Include include;
+
+    /**
+     * Group by fields if specified in the query string.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("groupByFields")
+    java.util.List<AbstractField> groupByFields;
+
+    /**
+     * Statistical functions specified in the query string. Atleast 1 is required for a GEOSTATS command.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("functions")
+    java.util.List<FunctionField> functions;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/HighlightGroupsCommandDescriptor.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/HighlightGroupsCommandDescriptor.java
@@ -96,6 +96,15 @@ public class HighlightGroupsCommandDescriptor extends AbstractCommandDescriptor 
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("matchOnly")
+        private java.util.List<String> matchOnly;
+
+        public Builder matchOnly(java.util.List<String> matchOnly) {
+            this.matchOnly = matchOnly;
+            this.__explicitlySet__.add("matchOnly");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("fields")
         private java.util.List<String> fields;
 
@@ -136,6 +145,7 @@ public class HighlightGroupsCommandDescriptor extends AbstractCommandDescriptor 
                             declaredFields,
                             color,
                             priority,
+                            matchOnly,
                             fields,
                             keywords,
                             subQueries);
@@ -153,6 +163,7 @@ public class HighlightGroupsCommandDescriptor extends AbstractCommandDescriptor 
                             .declaredFields(o.getDeclaredFields())
                             .color(o.getColor())
                             .priority(o.getPriority())
+                            .matchOnly(o.getMatchOnly())
                             .fields(o.getFields())
                             .keywords(o.getKeywords())
                             .subQueries(o.getSubQueries());
@@ -178,12 +189,14 @@ public class HighlightGroupsCommandDescriptor extends AbstractCommandDescriptor 
             java.util.List<AbstractField> declaredFields,
             String color,
             String priority,
+            java.util.List<String> matchOnly,
             java.util.List<String> fields,
             java.util.List<String> keywords,
             java.util.List<ParseQueryOutput> subQueries) {
         super(displayQueryString, internalQueryString, category, referencedFields, declaredFields);
         this.color = color;
         this.priority = priority;
+        this.matchOnly = matchOnly;
         this.fields = fields;
         this.keywords = keywords;
         this.subQueries = subQueries;
@@ -202,6 +215,13 @@ public class HighlightGroupsCommandDescriptor extends AbstractCommandDescriptor 
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("priority")
     String priority;
+
+    /**
+     * List of fields to search for terms or phrases to highlight.  If not specified all string fields are scanned.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("matchOnly")
+    java.util.List<String> matchOnly;
 
     /**
      * List of fields to search for terms or phrases to highlight.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRule.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRule.java
@@ -199,6 +199,15 @@ public class LogAnalyticsObjectCollectionRule {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("objectNameFilters")
+        private java.util.List<String> objectNameFilters;
+
+        public Builder objectNameFilters(java.util.List<String> objectNameFilters) {
+            this.objectNameFilters = objectNameFilters;
+            this.__explicitlySet__.add("objectNameFilters");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -243,6 +252,7 @@ public class LogAnalyticsObjectCollectionRule {
                             timeCreated,
                             timeUpdated,
                             isEnabled,
+                            objectNameFilters,
                             definedTags,
                             freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -271,6 +281,7 @@ public class LogAnalyticsObjectCollectionRule {
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .isEnabled(o.getIsEnabled())
+                            .objectNameFilters(o.getObjectNameFilters())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -417,6 +428,15 @@ public class LogAnalyticsObjectCollectionRule {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
     Boolean isEnabled;
+
+    /**
+     * When the filters are provided, only the objects matching the filters are picked up for processing.
+     * The matchType supported is exact match and accommodates wildcard "*".
+     * For more information on filters, see [Event Filters](https://docs.oracle.com/en-us/iaas/Content/Events/Concepts/filterevents.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectNameFilters")
+    java.util.List<String> objectNameFilters;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRuleSummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsObjectCollectionRuleSummary.java
@@ -135,6 +135,15 @@ public class LogAnalyticsObjectCollectionRuleSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("objectNameFilters")
+        private java.util.List<String> objectNameFilters;
+
+        public Builder objectNameFilters(java.util.List<String> objectNameFilters) {
+            this.objectNameFilters = objectNameFilters;
+            this.__explicitlySet__.add("objectNameFilters");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -172,6 +181,7 @@ public class LogAnalyticsObjectCollectionRuleSummary {
                             timeCreated,
                             timeUpdated,
                             isEnabled,
+                            objectNameFilters,
                             definedTags,
                             freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -193,6 +203,7 @@ public class LogAnalyticsObjectCollectionRuleSummary {
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .isEnabled(o.getIsEnabled())
+                            .objectNameFilters(o.getObjectNameFilters())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -284,6 +295,15 @@ public class LogAnalyticsObjectCollectionRuleSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
     Boolean isEnabled;
+
+    /**
+     * When the filters are provided, only the objects matching the filters are picked up for processing.
+     * The matchType supported is exact match and accommodates wildcard "*".
+     * For more information on filters, see [Event Filters](https://docs.oracle.com/en-us/iaas/Content/Events/Concepts/filterevents.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectNameFilters")
+    java.util.List<String> objectNameFilters;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsParser.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsParser.java
@@ -305,6 +305,15 @@ public class LogAnalyticsParser {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isNamespaceAware")
+        private Boolean isNamespaceAware;
+
+        public Builder isNamespaceAware(Boolean isNamespaceAware) {
+            this.isNamespaceAware = isNamespaceAware;
+            this.__explicitlySet__.add("isNamespaceAware");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -341,7 +350,8 @@ public class LogAnalyticsParser {
                             fieldDelimiter,
                             fieldQualifier,
                             type,
-                            isUserDeleted);
+                            isUserDeleted,
+                            isNamespaceAware);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -379,7 +389,8 @@ public class LogAnalyticsParser {
                             .fieldDelimiter(o.getFieldDelimiter())
                             .fieldQualifier(o.getFieldQualifier())
                             .type(o.getType())
-                            .isUserDeleted(o.getIsUserDeleted());
+                            .isUserDeleted(o.getIsUserDeleted())
+                            .isNamespaceAware(o.getIsNamespaceAware());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -629,6 +640,13 @@ public class LogAnalyticsParser {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isUserDeleted")
     Boolean isUserDeleted;
+
+    /**
+     * A flag indicating whether the XML parser should consider the namespace(s) while processing the log data.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isNamespaceAware")
+    Boolean isNamespaceAware;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsParserSummary.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsParserSummary.java
@@ -305,6 +305,15 @@ public class LogAnalyticsParserSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isNamespaceAware")
+        private Boolean isNamespaceAware;
+
+        public Builder isNamespaceAware(Boolean isNamespaceAware) {
+            this.isNamespaceAware = isNamespaceAware;
+            this.__explicitlySet__.add("isNamespaceAware");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -341,7 +350,8 @@ public class LogAnalyticsParserSummary {
                             fieldDelimiter,
                             fieldQualifier,
                             type,
-                            isUserDeleted);
+                            isUserDeleted,
+                            isNamespaceAware);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -379,7 +389,8 @@ public class LogAnalyticsParserSummary {
                             .fieldDelimiter(o.getFieldDelimiter())
                             .fieldQualifier(o.getFieldQualifier())
                             .type(o.getType())
-                            .isUserDeleted(o.getIsUserDeleted());
+                            .isUserDeleted(o.getIsUserDeleted())
+                            .isNamespaceAware(o.getIsNamespaceAware());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -630,6 +641,13 @@ public class LogAnalyticsParserSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isUserDeleted")
     Boolean isUserDeleted;
+
+    /**
+     * A flag indicating whether the XML parser should consider the namespace(s) while processing the log data.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isNamespaceAware")
+    Boolean isNamespaceAware;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsPreference.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsPreference.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * The preference information
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LogAnalyticsPreference.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LogAnalyticsPreference {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("value")
+        private String value;
+
+        public Builder value(String value) {
+            this.value = value;
+            this.__explicitlySet__.add("value");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LogAnalyticsPreference build() {
+            LogAnalyticsPreference __instance__ = new LogAnalyticsPreference(name, value);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LogAnalyticsPreference o) {
+            Builder copiedBuilder = name(o.getName()).value(o.getValue());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The preference name. Currently, only "DEFAULT_HOMEPAGE" is supported.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * The preference value.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    String value;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsPreferenceCollection.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsPreferenceCollection.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * A collection of preference information.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LogAnalyticsPreferenceCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LogAnalyticsPreferenceCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<LogAnalyticsPreference> items;
+
+        public Builder items(java.util.List<LogAnalyticsPreference> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LogAnalyticsPreferenceCollection build() {
+            LogAnalyticsPreferenceCollection __instance__ =
+                    new LogAnalyticsPreferenceCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LogAnalyticsPreferenceCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * An array of tenant preferences.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<LogAnalyticsPreference> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsPreferenceDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsPreferenceDetails.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Preference information used to update preference settings.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = LogAnalyticsPreferenceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class LogAnalyticsPreferenceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<LogAnalyticsPreference> items;
+
+        public Builder items(java.util.List<LogAnalyticsPreference> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public LogAnalyticsPreferenceDetails build() {
+            LogAnalyticsPreferenceDetails __instance__ = new LogAnalyticsPreferenceDetails(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(LogAnalyticsPreferenceDetails o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * An array of tenant preference details.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<LogAnalyticsPreference> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsSourceFunction.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/LogAnalyticsSourceFunction.java
@@ -80,6 +80,15 @@ public class LogAnalyticsSourceFunction {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("features")
+        private java.util.List<String> features;
+
+        public Builder features(java.util.List<String> features) {
+            this.features = features;
+            this.__explicitlySet__.add("features");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("functionId")
         private Long functionId;
 
@@ -173,6 +182,7 @@ public class LogAnalyticsSourceFunction {
                             functionName,
                             functionReference,
                             sourceReference,
+                            features,
                             functionId,
                             order,
                             isSystem,
@@ -195,6 +205,7 @@ public class LogAnalyticsSourceFunction {
                             .functionName(o.getFunctionName())
                             .functionReference(o.getFunctionReference())
                             .sourceReference(o.getSourceReference())
+                            .features(o.getFeatures())
                             .functionId(o.getFunctionId())
                             .order(o.getOrder())
                             .isSystem(o.getIsSystem())
@@ -295,6 +306,12 @@ public class LogAnalyticsSourceFunction {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("sourceReference")
     String sourceReference;
+
+    /**
+     * Features of the source function to use for enrichment.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("features")
+    java.util.List<String> features;
 
     /**
      * The source function unique identifier.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/TestParserPayloadDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/TestParserPayloadDetails.java
@@ -260,6 +260,15 @@ public class TestParserPayloadDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isNamespaceAware")
+        private Boolean isNamespaceAware;
+
+        public Builder isNamespaceAware(Boolean isNamespaceAware) {
+            this.isNamespaceAware = isNamespaceAware;
+            this.__explicitlySet__.add("isNamespaceAware");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -291,7 +300,8 @@ public class TestParserPayloadDetails {
                             shouldTokenizeOriginalText,
                             fieldDelimiter,
                             fieldQualifier,
-                            type);
+                            type,
+                            isNamespaceAware);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -324,7 +334,8 @@ public class TestParserPayloadDetails {
                             .shouldTokenizeOriginalText(o.getShouldTokenizeOriginalText())
                             .fieldDelimiter(o.getFieldDelimiter())
                             .fieldQualifier(o.getFieldQualifier())
-                            .type(o.getType());
+                            .type(o.getType())
+                            .isNamespaceAware(o.getIsNamespaceAware());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -533,6 +544,13 @@ public class TestParserPayloadDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     Type type;
+
+    /**
+     * A flag indicating whether the XML parser should consider the namespace(s) while processing the log data.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isNamespaceAware")
+    Boolean isNamespaceAware;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/TimeColumn.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/TimeColumn.java
@@ -76,6 +76,15 @@ public class TimeColumn extends AbstractColumn {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCaseSensitive")
+        private Boolean isCaseSensitive;
+
+        public Builder isCaseSensitive(Boolean isCaseSensitive) {
+            this.isCaseSensitive = isCaseSensitive;
+            this.__explicitlySet__.add("isCaseSensitive");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isGroupable")
         private Boolean isGroupable;
 
@@ -150,6 +159,7 @@ public class TimeColumn extends AbstractColumn {
                             values,
                             isListOfValues,
                             isMultiValued,
+                            isCaseSensitive,
                             isGroupable,
                             isEvaluable,
                             valueType,
@@ -169,6 +179,7 @@ public class TimeColumn extends AbstractColumn {
                             .values(o.getValues())
                             .isListOfValues(o.getIsListOfValues())
                             .isMultiValued(o.getIsMultiValued())
+                            .isCaseSensitive(o.getIsCaseSensitive())
                             .isGroupable(o.getIsGroupable())
                             .isEvaluable(o.getIsEvaluable())
                             .valueType(o.getValueType())
@@ -196,6 +207,7 @@ public class TimeColumn extends AbstractColumn {
             java.util.List<FieldValue> values,
             Boolean isListOfValues,
             Boolean isMultiValued,
+            Boolean isCaseSensitive,
             Boolean isGroupable,
             Boolean isEvaluable,
             ValueType valueType,
@@ -209,6 +221,7 @@ public class TimeColumn extends AbstractColumn {
                 values,
                 isListOfValues,
                 isMultiValued,
+                isCaseSensitive,
                 isGroupable,
                 isEvaluable,
                 valueType,

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/TrendColumn.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/TrendColumn.java
@@ -76,6 +76,15 @@ public class TrendColumn extends AbstractColumn {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCaseSensitive")
+        private Boolean isCaseSensitive;
+
+        public Builder isCaseSensitive(Boolean isCaseSensitive) {
+            this.isCaseSensitive = isCaseSensitive;
+            this.__explicitlySet__.add("isCaseSensitive");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("isGroupable")
         private Boolean isGroupable;
 
@@ -188,6 +197,7 @@ public class TrendColumn extends AbstractColumn {
                             values,
                             isListOfValues,
                             isMultiValued,
+                            isCaseSensitive,
                             isGroupable,
                             isEvaluable,
                             valueType,
@@ -211,6 +221,7 @@ public class TrendColumn extends AbstractColumn {
                             .values(o.getValues())
                             .isListOfValues(o.getIsListOfValues())
                             .isMultiValued(o.getIsMultiValued())
+                            .isCaseSensitive(o.getIsCaseSensitive())
                             .isGroupable(o.getIsGroupable())
                             .isEvaluable(o.getIsEvaluable())
                             .valueType(o.getValueType())
@@ -242,6 +253,7 @@ public class TrendColumn extends AbstractColumn {
             java.util.List<FieldValue> values,
             Boolean isListOfValues,
             Boolean isMultiValued,
+            Boolean isCaseSensitive,
             Boolean isGroupable,
             Boolean isEvaluable,
             ValueType valueType,
@@ -259,6 +271,7 @@ public class TrendColumn extends AbstractColumn {
                 values,
                 isListOfValues,
                 isMultiValued,
+                isCaseSensitive,
                 isGroupable,
                 isEvaluable,
                 valueType,

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UnprocessedDataBucket.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UnprocessedDataBucket.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.model;
+
+/**
+ * Configuration details of the bucket that stores unprocessed payloads.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UnprocessedDataBucket.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UnprocessedDataBucket {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+        private String namespace;
+
+        public Builder namespace(String namespace) {
+            this.namespace = namespace;
+            this.__explicitlySet__.add("namespace");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("bucketName")
+        private String bucketName;
+
+        public Builder bucketName(String bucketName) {
+            this.bucketName = bucketName;
+            this.__explicitlySet__.add("bucketName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+        private Boolean isEnabled;
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            this.__explicitlySet__.add("isEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UnprocessedDataBucket build() {
+            UnprocessedDataBucket __instance__ =
+                    new UnprocessedDataBucket(
+                            namespace, bucketName, isEnabled, timeCreated, timeUpdated);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UnprocessedDataBucket o) {
+            Builder copiedBuilder =
+                    namespace(o.getNamespace())
+                            .bucketName(o.getBucketName())
+                            .isEnabled(o.getIsEnabled())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Object Storage namespace.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("namespace")
+    String namespace;
+
+    /**
+     * Name of the Object Storage bucket.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("bucketName")
+    String bucketName;
+
+    /**
+     * Flag that specifies if this configuration is enabled or not.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isEnabled")
+    Boolean isEnabled;
+
+    /**
+     * The time when this record is created. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The latest time when this record is updated. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateLogAnalyticsObjectCollectionRuleDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpdateLogAnalyticsObjectCollectionRuleDetails.java
@@ -91,6 +91,15 @@ public class UpdateLogAnalyticsObjectCollectionRuleDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("objectNameFilters")
+        private java.util.List<String> objectNameFilters;
+
+        public Builder objectNameFilters(java.util.List<String> objectNameFilters) {
+            this.objectNameFilters = objectNameFilters;
+            this.__explicitlySet__.add("objectNameFilters");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
         private java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
@@ -123,6 +132,7 @@ public class UpdateLogAnalyticsObjectCollectionRuleDetails {
                             charEncoding,
                             isEnabled,
                             overrides,
+                            objectNameFilters,
                             definedTags,
                             freeformTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -139,6 +149,7 @@ public class UpdateLogAnalyticsObjectCollectionRuleDetails {
                             .charEncoding(o.getCharEncoding())
                             .isEnabled(o.getIsEnabled())
                             .overrides(o.getOverrides())
+                            .objectNameFilters(o.getObjectNameFilters())
                             .definedTags(o.getDefinedTags())
                             .freeformTags(o.getFreeformTags());
 
@@ -205,6 +216,15 @@ public class UpdateLogAnalyticsObjectCollectionRuleDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("overrides")
     java.util.Map<String, java.util.List<PropertyOverride>> overrides;
+
+    /**
+     * When the filters are provided, only the objects matching the filters are picked up for processing.
+     * The matchType supported is exact match and accommodates wildcard "*".
+     * For more information on filters, see [Event Filters](https://docs.oracle.com/en-us/iaas/Content/Events/Concepts/filterevents.htm).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectNameFilters")
+    java.util.List<String> objectNameFilters;
 
     /**
      * Defined tags for this resource. Each key is predefined and scoped to a namespace.

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpsertLogAnalyticsParserDetails.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/model/UpsertLogAnalyticsParserDetails.java
@@ -242,6 +242,15 @@ public class UpsertLogAnalyticsParserDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isNamespaceAware")
+        private Boolean isNamespaceAware;
+
+        public Builder isNamespaceAware(Boolean isNamespaceAware) {
+            this.isNamespaceAware = isNamespaceAware;
+            this.__explicitlySet__.add("isNamespaceAware");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -271,7 +280,8 @@ public class UpsertLogAnalyticsParserDetails {
                             shouldTokenizeOriginalText,
                             fieldDelimiter,
                             fieldQualifier,
-                            type);
+                            type,
+                            isNamespaceAware);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -302,7 +312,8 @@ public class UpsertLogAnalyticsParserDetails {
                             .shouldTokenizeOriginalText(o.getShouldTokenizeOriginalText())
                             .fieldDelimiter(o.getFieldDelimiter())
                             .fieldQualifier(o.getFieldQualifier())
-                            .type(o.getType());
+                            .type(o.getType())
+                            .isNamespaceAware(o.getIsNamespaceAware());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -502,6 +513,13 @@ public class UpsertLogAnalyticsParserDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("type")
     Type type;
+
+    /**
+     * A flag indicating whether the XML parser should consider the namespace(s) while processing the log data.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isNamespaceAware")
+    Boolean isNamespaceAware;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/AppendLookupDataRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/AppendLookupDataRequest.java
@@ -72,6 +72,14 @@ public class AppendLookupDataRequest
     private String ifMatch;
 
     /**
+     * A value of {@code 100-continue} requests preliminary verification of the request method, path, and headers before the request body is sent.
+     * If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+     * The only allowed value for this parameter is "100-Continue" (case-insensitive).
+     *
+     */
+    private String expect;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -129,6 +137,7 @@ public class AppendLookupDataRequest
             opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
             ifMatch(o.getIfMatch());
+            expect(o.getExpect());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ExtractStructuredLogFieldPathsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ExtractStructuredLogFieldPathsRequest.java
@@ -43,6 +43,7 @@ public class ExtractStructuredLogFieldPathsRequest
     public enum ParserType {
         Xml("XML"),
         Json("JSON"),
+        Delimited("DELIMITED"),
         ;
 
         private final String value;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ExtractStructuredLogHeaderPathsRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ExtractStructuredLogHeaderPathsRequest.java
@@ -43,6 +43,7 @@ public class ExtractStructuredLogHeaderPathsRequest
     public enum ParserType {
         Xml("XML"),
         Json("JSON"),
+        Delimited("DELIMITED"),
         ;
 
         private final String value;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetPreferencesRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetPreferencesRequest.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/GetPreferencesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetPreferencesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetPreferencesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * The sort order to use, either ascending ({@code ASC}) or descending ({@code DESC}).
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending ({@code ASC}) or descending ({@code DESC}).
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The attribute used to sort the returned preferences.
+     */
+    private SortBy sortBy;
+
+    /**
+     * The attribute used to sort the returned preferences.
+     **/
+    public enum SortBy {
+        Name("name"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetPreferencesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPreferencesRequest o) {
+            namespaceName(o.getNamespaceName());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            limit(o.getLimit());
+            page(o.getPage());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetPreferencesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetPreferencesRequest
+         */
+        public GetPreferencesRequest build() {
+            GetPreferencesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetUnprocessedDataBucketRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/GetUnprocessedDataBucketRequest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/GetUnprocessedDataBucketExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetUnprocessedDataBucketRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetUnprocessedDataBucketRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetUnprocessedDataBucketRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetUnprocessedDataBucketRequest o) {
+            namespaceName(o.getNamespaceName());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetUnprocessedDataBucketRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetUnprocessedDataBucketRequest
+         */
+        public GetUnprocessedDataBucketRequest build() {
+            GetUnprocessedDataBucketRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ImportCustomContentRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/ImportCustomContentRequest.java
@@ -54,6 +54,14 @@ public class ImportCustomContentRequest
     private String opcRequestId;
 
     /**
+     * A value of {@code 100-continue} requests preliminary verification of the request method, path, and headers before the request body is sent.
+     * If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+     * The only allowed value for this parameter is "100-Continue" (case-insensitive).
+     *
+     */
+    private String expect;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -108,6 +116,7 @@ public class ImportCustomContentRequest
             isOverwrite(o.getIsOverwrite());
             opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
+            expect(o.getExpect());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/RegisterLookupRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/RegisterLookupRequest.java
@@ -110,6 +110,14 @@ public class RegisterLookupRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String opcRequestId;
 
     /**
+     * A value of {@code 100-continue} requests preliminary verification of the request method, path, and headers before the request body is sent.
+     * If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+     * The only allowed value for this parameter is "100-Continue" (case-insensitive).
+     *
+     */
+    private String expect;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -168,6 +176,7 @@ public class RegisterLookupRequest extends com.oracle.bmc.requests.BmcRequest<ja
             isHidden(o.getIsHidden());
             opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
+            expect(o.getExpect());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/RemovePreferencesRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/RemovePreferencesRequest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/RemovePreferencesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use RemovePreferencesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RemovePreferencesRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * Details of the tenant preferences to delete.
+     */
+    private com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails
+            removePreferencesDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails getBody$() {
+        return removePreferencesDetails;
+    }
+
+    @Override
+    public boolean supportsExpect100Continue() {
+        return true;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RemovePreferencesRequest,
+                    com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemovePreferencesRequest o) {
+            namespaceName(o.getNamespaceName());
+            removePreferencesDetails(o.getRemovePreferencesDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RemovePreferencesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RemovePreferencesRequest
+         */
+        public RemovePreferencesRequest build() {
+            RemovePreferencesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails body) {
+            removePreferencesDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/SetUnprocessedDataBucketRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/SetUnprocessedDataBucketRequest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/SetUnprocessedDataBucketExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use SetUnprocessedDataBucketRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SetUnprocessedDataBucketRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * Name of the Object Storage bucket.
+     */
+    private String bucketName;
+
+    /**
+     * The enabled flag used for filtering.  Only items with the specified enabled value
+     * will be returned.
+     *
+     */
+    private Boolean isEnabled;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    SetUnprocessedDataBucketRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SetUnprocessedDataBucketRequest o) {
+            namespaceName(o.getNamespaceName());
+            bucketName(o.getBucketName());
+            isEnabled(o.getIsEnabled());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of SetUnprocessedDataBucketRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of SetUnprocessedDataBucketRequest
+         */
+        public SetUnprocessedDataBucketRequest build() {
+            SetUnprocessedDataBucketRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLookupDataRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdateLookupDataRequest.java
@@ -72,6 +72,14 @@ public class UpdateLookupDataRequest
     private String ifMatch;
 
     /**
+     * A value of {@code 100-continue} requests preliminary verification of the request method, path, and headers before the request body is sent.
+     * If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+     * The only allowed value for this parameter is "100-Continue" (case-insensitive).
+     *
+     */
+    private String expect;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -129,6 +137,7 @@ public class UpdateLookupDataRequest
             opcRetryToken(o.getOpcRetryToken());
             opcRequestId(o.getOpcRequestId());
             ifMatch(o.getIfMatch());
+            expect(o.getExpect());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdatePreferencesRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UpdatePreferencesRequest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.requests;
+
+import com.oracle.bmc.loganalytics.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/loganalytics/UpdatePreferencesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdatePreferencesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdatePreferencesRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails> {
+
+    /**
+     * The Logging Analytics namespace used for the request.
+     *
+     */
+    private String namespaceName;
+
+    /**
+     * Details of the tenant preferences to update.
+     */
+    private com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails
+            updatePreferencesDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails getBody$() {
+        return updatePreferencesDetails;
+    }
+
+    @Override
+    public boolean supportsExpect100Continue() {
+        return true;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdatePreferencesRequest,
+                    com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdatePreferencesRequest o) {
+            namespaceName(o.getNamespaceName());
+            updatePreferencesDetails(o.getUpdatePreferencesDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdatePreferencesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdatePreferencesRequest
+         */
+        public UpdatePreferencesRequest build() {
+            UpdatePreferencesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceDetails body) {
+            updatePreferencesDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UploadLogEventsFileRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UploadLogEventsFileRequest.java
@@ -75,6 +75,14 @@ public class UploadLogEventsFileRequest
     private String opcRetryToken;
 
     /**
+     * A value of {@code 100-continue} requests preliminary verification of the request method, path, and headers before the request body is sent.
+     * If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+     * The only allowed value for this parameter is "100-Continue" (case-insensitive).
+     *
+     */
+    private String expect;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -132,6 +140,7 @@ public class UploadLogEventsFileRequest
             payloadType(o.getPayloadType());
             contentType(o.getContentType());
             opcRetryToken(o.getOpcRetryToken());
+            expect(o.getExpect());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UploadLogFileRequest.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/requests/UploadLogFileRequest.java
@@ -127,6 +127,14 @@ public class UploadLogFileRequest extends com.oracle.bmc.requests.BmcRequest<jav
     private String logSet;
 
     /**
+     * A value of {@code 100-continue} requests preliminary verification of the request method, path, and headers before the request body is sent.
+     * If no error results from such verification, the server will send a 100 (Continue) interim response to indicate readiness for the request body.
+     * The only allowed value for this parameter is "100-Continue" (case-insensitive).
+     *
+     */
+    private String expect;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -193,6 +201,7 @@ public class UploadLogFileRequest extends com.oracle.bmc.requests.BmcRequest<jav
             contentType(o.getContentType());
             opcRetryToken(o.getOpcRetryToken());
             logSet(o.getLogSet());
+            expect(o.getExpect());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/GetPreferencesResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/GetPreferencesResponse.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetPreferencesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then additional items may be available on the previous page of the list. Include this value as the {@code page} parameter for the
+     * subsequent request to get the previous batch of items.
+     *
+     */
+    private String opcPrevPage;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then additional items may be available on the next page of the list. Include this value as the {@code page} parameter for the
+     * subsequent request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned LogAnalyticsPreferenceCollection instance.
+     */
+    private com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceCollection
+            logAnalyticsPreferenceCollection;
+
+    private GetPreferencesResponse(
+            int __httpStatusCode__,
+            String opcPrevPage,
+            String opcNextPage,
+            String opcRequestId,
+            com.oracle.bmc.loganalytics.model.LogAnalyticsPreferenceCollection
+                    logAnalyticsPreferenceCollection) {
+        super(__httpStatusCode__);
+        this.opcPrevPage = opcPrevPage;
+        this.opcNextPage = opcNextPage;
+        this.opcRequestId = opcRequestId;
+        this.logAnalyticsPreferenceCollection = logAnalyticsPreferenceCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetPreferencesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcPrevPage(o.getOpcPrevPage());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            logAnalyticsPreferenceCollection(o.getLogAnalyticsPreferenceCollection());
+
+            return this;
+        }
+
+        public GetPreferencesResponse build() {
+            return new GetPreferencesResponse(
+                    __httpStatusCode__,
+                    opcPrevPage,
+                    opcNextPage,
+                    opcRequestId,
+                    logAnalyticsPreferenceCollection);
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/GetUnprocessedDataBucketResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/GetUnprocessedDataBucketResponse.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetUnprocessedDataBucketResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned UnprocessedDataBucket instance.
+     */
+    private com.oracle.bmc.loganalytics.model.UnprocessedDataBucket unprocessedDataBucket;
+
+    private GetUnprocessedDataBucketResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            com.oracle.bmc.loganalytics.model.UnprocessedDataBucket unprocessedDataBucket) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.unprocessedDataBucket = unprocessedDataBucket;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetUnprocessedDataBucketResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            unprocessedDataBucket(o.getUnprocessedDataBucket());
+
+            return this;
+        }
+
+        public GetUnprocessedDataBucketResponse build() {
+            return new GetUnprocessedDataBucketResponse(
+                    __httpStatusCode__, opcRequestId, unprocessedDataBucket);
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/RemovePreferencesResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/RemovePreferencesResponse.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RemovePreferencesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    private RemovePreferencesResponse(int __httpStatusCode__, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemovePreferencesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public RemovePreferencesResponse build() {
+            return new RemovePreferencesResponse(__httpStatusCode__, opcRequestId);
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/SetUnprocessedDataBucketResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/SetUnprocessedDataBucketResponse.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class SetUnprocessedDataBucketResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned UnprocessedDataBucket instance.
+     */
+    private com.oracle.bmc.loganalytics.model.UnprocessedDataBucket unprocessedDataBucket;
+
+    private SetUnprocessedDataBucketResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            com.oracle.bmc.loganalytics.model.UnprocessedDataBucket unprocessedDataBucket) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.unprocessedDataBucket = unprocessedDataBucket;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(SetUnprocessedDataBucketResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            unprocessedDataBucket(o.getUnprocessedDataBucket());
+
+            return this;
+        }
+
+        public SetUnprocessedDataBucketResponse build() {
+            return new SetUnprocessedDataBucketResponse(
+                    __httpStatusCode__, opcRequestId, unprocessedDataBucket);
+        }
+    }
+}

--- a/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/UpdatePreferencesResponse.java
+++ b/bmc-loganalytics/src/main/java/com/oracle/bmc/loganalytics/responses/UpdatePreferencesResponse.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.loganalytics.responses;
+
+import com.oracle.bmc.loganalytics.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdatePreferencesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. When you contact Oracle about a specific request, provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    private UpdatePreferencesResponse(int __httpStatusCode__, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdatePreferencesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public UpdatePreferencesResponse build() {
+            return new UpdatePreferencesResponse(__httpStatusCode__, opcRequestId);
+        }
+    }
+}

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.7.1</version>
+  <version>2.7.2</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for creating database systems from backups with database software images in the Database service

- Support for optionally providing a SID prefix during Exadata database creation in the Database service

- Support for node subsetting on VM clusters in the Database service

- Support for non-CDB to PDB conversion in the Database service

- Support for default homepages, unprocessed data buckets, and parsing geostats in the Logging Analytics service