### PR TITLE
Releasing version 2.9.0

### DIFF
--- a/ApacheConnector-README.md
+++ b/ApacheConnector-README.md
@@ -192,6 +192,11 @@ Note : If both the above Apache Connection closing strategies do not give you op
 An example can be found [here](https://github.com/oracle/oci-java-sdk/tree/master/bmc-examples/src/main/java/ApacheConnectorPropertiesExample.java  "here")
 
 ## More info
+
+### Disabling extra logs related to streams
+The SDK emits warnings related to streams when an API that returns streams in its response is called. To disable the logs around streams, you can set 
+the system property `oci.javasdk.extra.stream.logs.enabled` to `false`. This can be done programmitically or by passing a system property in the java command line.
+
 More examples related to customizing Apache Connector can be found [here](https://github.com/oracle/oci-java-sdk/tree/master/bmc-examples/src/main/java/ApacheConnectorPropertiesExample.java  "here") 
 
 ## License

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.9.0 - 2021-11-09
+### Added
+- Support for drill down metadata in the Management Dashboard service
+- Support for operator access control on dedicated autonomous databases in the Operator Access Control service
+
+### Breaking Changes
+- Return type of method `public java.lang.String getResourceType()` has been changed to `com.oracle.bmc.operatoraccesscontrol.model.ResourceTypes` in the model `com.oracle.bmc.operatoraccesscontrol.model.OperatorControlAssignmentSummary` in the Operator Access Control service
+
 ## 2.8.1 - 2021-11-02
 ### Added
 - Support for the Database Tools service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,552 +19,552 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificates</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usage</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasetools</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificates/pom.xml
+++ b/bmc-certificates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificates</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificatesmanagement/pom.xml
+++ b/bmc-certificatesmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-common/src/main/java/com/oracle/bmc/http/internal/ResponseHelper.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/internal/ResponseHelper.java
@@ -306,7 +306,7 @@ public class ResponseHelper {
             try {
                 response.close();
             } catch (Throwable t) {
-                LOG.info("Exception while closing response", t);
+                LOG.debug("Exception while closing response", t);
             }
         }
     }

--- a/bmc-common/src/test/java/com/oracle/bmc/RegionTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/RegionTest.java
@@ -60,9 +60,11 @@ public class RegionTest {
 
     @BeforeClass
     public static void init() throws Exception {
+
+        Map<String, String> newEnvMap = new HashMap<>();
+
         String regionBlob =
                 "{ \"realmKey\" : \"UCX\",\"realmDomainComponent\" : \"oracle-foobar.com\",\"regionKey\" : \"ABV\",\"regionIdentifier\" : \"us-abv-1\"}";
-        Map<String, String> newEnvMap = new HashMap<>();
         newEnvMap.put("OCI_REGION_METADATA", regionBlob);
         EnvironmentVariablesHelper.setEnvironmentVariable(newEnvMap);
     }
@@ -399,6 +401,23 @@ public class RegionTest {
         Region US_SAN_DIEGO_TST =
                 Region.register("us-abv-1", Realm.register("UCX", "oracle-foobar.com"), "ABV");
         assertSame(US_SAN_DIEGO_TST, region);
+    }
+
+    @Test
+    public void testExistingDefaultRealmEnvRegion() throws Exception {
+        String realmDomainComponentFromEnv = "oraclevaporcloud.space";
+        Region.defaultRealmEnvVar = realmDomainComponentFromEnv;
+        String regionId = "dummy-region-from-default-realm-env-var";
+        Region region = Region.fromRegionCodeOrId(regionId);
+        String regionId2 = "dummy-region-from-default-realm-env-var-2";
+        Region region2 = Region.fromRegionCodeOrId(regionId);
+        assertNotNull(region);
+        assertSame(region.getRegionId(), regionId);
+        assertSame(region.getRealm().getSecondLevelDomain(), realmDomainComponentFromEnv);
+        assertNotNull(region);
+        assertSame(region2.getRegionId(), regionId);
+        assertSame(region2.getRealm().getSecondLevelDomain(), realmDomainComponentFromEnv);
+        Region.defaultRealmEnvVar = null;
     }
 
     @Test

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasetools/pom.xml
+++ b/bmc-databasetools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasetools</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.8.1</version>
+        <version>2.9.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/CreateManagementDashboardDetails.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/CreateManagementDashboardDetails.java
@@ -197,6 +197,15 @@ public class CreateManagementDashboardDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+        private java.util.List<Object> drilldownConfig;
+
+        public Builder drilldownConfig(java.util.List<Object> drilldownConfig) {
+            this.drilldownConfig = drilldownConfig;
+            this.__explicitlySet__.add("drilldownConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -241,6 +250,7 @@ public class CreateManagementDashboardDetails {
                             type,
                             isFavorite,
                             parametersConfig,
+                            drilldownConfig,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -269,6 +279,7 @@ public class CreateManagementDashboardDetails {
                             .type(o.getType())
                             .isFavorite(o.getIsFavorite())
                             .parametersConfig(o.getParametersConfig())
+                            .drilldownConfig(o.getDrilldownConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -397,6 +408,12 @@ public class CreateManagementDashboardDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parametersConfig")
     java.util.List<Object> parametersConfig;
+
+    /**
+     * Drill-down configuration to define the destination of a drill-down action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+    java.util.List<Object> drilldownConfig;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/CreateManagementSavedSearchDetails.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/CreateManagementSavedSearchDetails.java
@@ -179,6 +179,15 @@ public class CreateManagementSavedSearchDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+        private java.util.List<Object> drilldownConfig;
+
+        public Builder drilldownConfig(java.util.List<Object> drilldownConfig) {
+            this.drilldownConfig = drilldownConfig;
+            this.__explicitlySet__.add("drilldownConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -221,6 +230,7 @@ public class CreateManagementSavedSearchDetails {
                             widgetTemplate,
                             widgetVM,
                             parametersConfig,
+                            drilldownConfig,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -247,6 +257,7 @@ public class CreateManagementSavedSearchDetails {
                             .widgetTemplate(o.getWidgetTemplate())
                             .widgetVM(o.getWidgetVM())
                             .parametersConfig(o.getParametersConfig())
+                            .drilldownConfig(o.getDrilldownConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -363,6 +374,12 @@ public class CreateManagementSavedSearchDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parametersConfig")
     java.util.List<Object> parametersConfig;
+
+    /**
+     * Drill-down configuration to define the destination of a drill-down action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+    java.util.List<Object> drilldownConfig;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/ManagementDashboard.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/ManagementDashboard.java
@@ -260,6 +260,15 @@ public class ManagementDashboard {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+        private java.util.List<Object> drilldownConfig;
+
+        public Builder drilldownConfig(java.util.List<Object> drilldownConfig) {
+            this.drilldownConfig = drilldownConfig;
+            this.__explicitlySet__.add("drilldownConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -311,6 +320,7 @@ public class ManagementDashboard {
                             savedSearches,
                             lifecycleState,
                             parametersConfig,
+                            drilldownConfig,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -346,6 +356,7 @@ public class ManagementDashboard {
                             .savedSearches(o.getSavedSearches())
                             .lifecycleState(o.getLifecycleState())
                             .parametersConfig(o.getParametersConfig())
+                            .drilldownConfig(o.getDrilldownConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -516,6 +527,12 @@ public class ManagementDashboard {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parametersConfig")
     java.util.List<Object> parametersConfig;
+
+    /**
+     * Drill-down configuration to define the destination of a drill-down action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+    java.util.List<Object> drilldownConfig;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/ManagementDashboardForImportExportDetails.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/ManagementDashboardForImportExportDetails.java
@@ -207,6 +207,15 @@ public class ManagementDashboardForImportExportDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+        private java.util.List<Object> drilldownConfig;
+
+        public Builder drilldownConfig(java.util.List<Object> drilldownConfig) {
+            this.drilldownConfig = drilldownConfig;
+            this.__explicitlySet__.add("drilldownConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -252,6 +261,7 @@ public class ManagementDashboardForImportExportDetails {
                             isFavorite,
                             savedSearches,
                             parametersConfig,
+                            drilldownConfig,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -281,6 +291,7 @@ public class ManagementDashboardForImportExportDetails {
                             .isFavorite(o.getIsFavorite())
                             .savedSearches(o.getSavedSearches())
                             .parametersConfig(o.getParametersConfig())
+                            .drilldownConfig(o.getDrilldownConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -415,6 +426,12 @@ public class ManagementDashboardForImportExportDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parametersConfig")
     java.util.List<Object> parametersConfig;
+
+    /**
+     * Drill-down configuration to define the destination of a drill-down action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+    java.util.List<Object> drilldownConfig;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/ManagementSavedSearch.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/ManagementSavedSearch.java
@@ -224,6 +224,15 @@ public class ManagementSavedSearch {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+        private java.util.List<Object> drilldownConfig;
+
+        public Builder drilldownConfig(java.util.List<Object> drilldownConfig) {
+            this.drilldownConfig = drilldownConfig;
+            this.__explicitlySet__.add("drilldownConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -271,6 +280,7 @@ public class ManagementSavedSearch {
                             widgetVM,
                             lifecycleState,
                             parametersConfig,
+                            drilldownConfig,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -302,6 +312,7 @@ public class ManagementSavedSearch {
                             .widgetVM(o.getWidgetVM())
                             .lifecycleState(o.getLifecycleState())
                             .parametersConfig(o.getParametersConfig())
+                            .drilldownConfig(o.getDrilldownConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -448,6 +459,12 @@ public class ManagementSavedSearch {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parametersConfig")
     java.util.List<Object> parametersConfig;
+
+    /**
+     * Drill-down configuration to define the destination of a drill-down action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+    java.util.List<Object> drilldownConfig;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/ManagementSavedSearchForImportDetails.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/ManagementSavedSearchForImportDetails.java
@@ -198,6 +198,15 @@ public class ManagementSavedSearchForImportDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+        private java.util.List<Object> drilldownConfig;
+
+        public Builder drilldownConfig(java.util.List<Object> drilldownConfig) {
+            this.drilldownConfig = drilldownConfig;
+            this.__explicitlySet__.add("drilldownConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -222,7 +231,8 @@ public class ManagementSavedSearchForImportDetails {
                             widgetVM,
                             freeformTags,
                             definedTags,
-                            parametersConfig);
+                            parametersConfig,
+                            drilldownConfig);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -248,7 +258,8 @@ public class ManagementSavedSearchForImportDetails {
                             .widgetVM(o.getWidgetVM())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
-                            .parametersConfig(o.getParametersConfig());
+                            .parametersConfig(o.getParametersConfig())
+                            .drilldownConfig(o.getDrilldownConfig());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -379,6 +390,12 @@ public class ManagementSavedSearchForImportDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parametersConfig")
     java.util.List<Object> parametersConfig;
+
+    /**
+     * Drill-down configuration to define the destination of a drill-down action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+    java.util.List<Object> drilldownConfig;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/UpdateManagementDashboardDetails.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/UpdateManagementDashboardDetails.java
@@ -188,6 +188,15 @@ public class UpdateManagementDashboardDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+        private java.util.List<Object> drilldownConfig;
+
+        public Builder drilldownConfig(java.util.List<Object> drilldownConfig) {
+            this.drilldownConfig = drilldownConfig;
+            this.__explicitlySet__.add("drilldownConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -231,6 +240,7 @@ public class UpdateManagementDashboardDetails {
                             type,
                             isFavorite,
                             parametersConfig,
+                            drilldownConfig,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -258,6 +268,7 @@ public class UpdateManagementDashboardDetails {
                             .type(o.getType())
                             .isFavorite(o.getIsFavorite())
                             .parametersConfig(o.getParametersConfig())
+                            .drilldownConfig(o.getDrilldownConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -380,6 +391,12 @@ public class UpdateManagementDashboardDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parametersConfig")
     java.util.List<Object> parametersConfig;
+
+    /**
+     * Drill-down configuration to define the destination of a drill-down action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+    java.util.List<Object> drilldownConfig;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/UpdateManagementSavedSearchDetails.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/UpdateManagementSavedSearchDetails.java
@@ -170,6 +170,15 @@ public class UpdateManagementSavedSearchDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+        private java.util.List<Object> drilldownConfig;
+
+        public Builder drilldownConfig(java.util.List<Object> drilldownConfig) {
+            this.drilldownConfig = drilldownConfig;
+            this.__explicitlySet__.add("drilldownConfig");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -211,6 +220,7 @@ public class UpdateManagementSavedSearchDetails {
                             widgetTemplate,
                             widgetVM,
                             parametersConfig,
+                            drilldownConfig,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -236,6 +246,7 @@ public class UpdateManagementSavedSearchDetails {
                             .widgetTemplate(o.getWidgetTemplate())
                             .widgetVM(o.getWidgetVM())
                             .parametersConfig(o.getParametersConfig())
+                            .drilldownConfig(o.getDrilldownConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -346,6 +357,12 @@ public class UpdateManagementSavedSearchDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("parametersConfig")
     java.util.List<Object> parametersConfig;
+
+    /**
+     * Drill-down configuration to define the destination of a drill-down action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("drilldownConfig")
+    java.util.List<Object> drilldownConfig;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequests.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequests.java
@@ -115,6 +115,19 @@ public interface AccessRequests extends AutoCloseable {
     RejectAccessRequestResponse rejectAccessRequest(RejectAccessRequestRequest request);
 
     /**
+     * Reviews the access request.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/operatoraccesscontrol/ReviewAccessRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ReviewAccessRequest API.
+     */
+    ReviewAccessRequestResponse reviewAccessRequest(ReviewAccessRequestRequest request);
+
+    /**
      * Revokes an already approved access request.
      *
      * @param request The request object containing the details to send

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsAsync.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsAsync.java
@@ -133,6 +133,23 @@ public interface AccessRequestsAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Reviews the access request.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ReviewAccessRequestResponse> reviewAccessRequest(
+            ReviewAccessRequestRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ReviewAccessRequestRequest, ReviewAccessRequestResponse>
+                    handler);
+
+    /**
      * Revokes an already approved access request.
      *
      *

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsAsyncClient.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsAsyncClient.java
@@ -595,6 +595,53 @@ public class AccessRequestsAsyncClient implements AccessRequestsAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ReviewAccessRequestResponse> reviewAccessRequest(
+            ReviewAccessRequestRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ReviewAccessRequestRequest, ReviewAccessRequestResponse>
+                    handler) {
+        LOG.trace("Called async reviewAccessRequest");
+        final ReviewAccessRequestRequest interceptedRequest =
+                ReviewAccessRequestConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ReviewAccessRequestConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ReviewAccessRequestResponse>
+                transformer = ReviewAccessRequestConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ReviewAccessRequestRequest, ReviewAccessRequestResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ReviewAccessRequestRequest, ReviewAccessRequestResponse>,
+                        java.util.concurrent.Future<ReviewAccessRequestResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getReviewAccessRequestDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ReviewAccessRequestRequest, ReviewAccessRequestResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<RevokeAccessRequestResponse> revokeAccessRequest(
             RevokeAccessRequestRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsClient.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/AccessRequestsClient.java
@@ -610,6 +610,39 @@ public class AccessRequestsClient implements AccessRequests {
     }
 
     @Override
+    public ReviewAccessRequestResponse reviewAccessRequest(ReviewAccessRequestRequest request) {
+        LOG.trace("Called reviewAccessRequest");
+        final ReviewAccessRequestRequest interceptedRequest =
+                ReviewAccessRequestConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ReviewAccessRequestConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ReviewAccessRequestResponse>
+                transformer = ReviewAccessRequestConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getReviewAccessRequestDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public RevokeAccessRequestResponse revokeAccessRequest(RevokeAccessRequestRequest request) {
         LOG.trace("Called revokeAccessRequest");
         final RevokeAccessRequestRequest interceptedRequest =

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListAccessRequestsConverter.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListAccessRequestsConverter.java
@@ -48,12 +48,36 @@ public class ListAccessRequestsConverter {
                                     request.getResourceName()));
         }
 
+        if (request.getResourceType() != null) {
+            target =
+                    target.queryParam(
+                            "resourceType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getResourceType()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(
                             "lifecycleState",
                             com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
                                     request.getLifecycleState().getValue()));
+        }
+
+        if (request.getTimeStart() != null) {
+            target =
+                    target.queryParam(
+                            "timeStart",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeStart()));
+        }
+
+        if (request.getTimeEnd() != null) {
+            target =
+                    target.queryParam(
+                            "timeEnd",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getTimeEnd()));
         }
 
         if (request.getLimit() != null) {

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListOperatorActionsConverter.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListOperatorActionsConverter.java
@@ -42,6 +42,14 @@ public class ListOperatorActionsConverter {
                                     request.getName()));
         }
 
+        if (request.getResourceType() != null) {
+            target =
+                    target.queryParam(
+                            "resourceType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getResourceType()));
+        }
+
         target =
                 target.queryParam(
                         "compartmentId",

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListOperatorControlAssignmentsConverter.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListOperatorControlAssignmentsConverter.java
@@ -59,6 +59,14 @@ public class ListOperatorControlAssignmentsConverter {
                         com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
                                 request.getCompartmentId()));
 
+        if (request.getResourceType() != null) {
+            target =
+                    target.queryParam(
+                            "resourceType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getResourceType()));
+        }
+
         if (request.getLifecycleState() != null) {
             target =
                     target.queryParam(

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListOperatorControlsConverter.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ListOperatorControlsConverter.java
@@ -56,6 +56,14 @@ public class ListOperatorControlsConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getResourceType() != null) {
+            target =
+                    target.queryParam(
+                            "resourceType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getResourceType()));
+        }
+
         if (request.getLimit() != null) {
             target =
                     target.queryParam(

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ReviewAccessRequestConverter.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/internal/http/ReviewAccessRequestConverter.java
@@ -12,16 +12,14 @@ import org.apache.commons.lang3.Validate;
 
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
 @lombok.extern.slf4j.Slf4j
-public class CreateOperatorControlAssignmentConverter {
+public class ReviewAccessRequestConverter {
     private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
             RESPONSE_CONVERSION_FACTORY =
                     new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
 
-    public static com.oracle.bmc.operatoraccesscontrol.requests
-                    .CreateOperatorControlAssignmentRequest
+    public static com.oracle.bmc.operatoraccesscontrol.requests.ReviewAccessRequestRequest
             interceptRequest(
-                    com.oracle.bmc.operatoraccesscontrol.requests
-                                    .CreateOperatorControlAssignmentRequest
+                    com.oracle.bmc.operatoraccesscontrol.requests.ReviewAccessRequestRequest
                             request) {
 
         return request;
@@ -29,15 +27,21 @@ public class CreateOperatorControlAssignmentConverter {
 
     public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
             com.oracle.bmc.http.internal.RestClient client,
-            com.oracle.bmc.operatoraccesscontrol.requests.CreateOperatorControlAssignmentRequest
-                    request) {
+            com.oracle.bmc.operatoraccesscontrol.requests.ReviewAccessRequestRequest request) {
         Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getAccessRequestId(), "accessRequestId must not be blank");
         Validate.notNull(
-                request.getCreateOperatorControlAssignmentDetails(),
-                "createOperatorControlAssignmentDetails is required");
+                request.getReviewAccessRequestDetails(), "reviewAccessRequestDetails is required");
 
         com.oracle.bmc.http.internal.WrappedWebTarget target =
-                client.getBaseTarget().path("/20200630").path("operatorControlAssignments");
+                client.getBaseTarget()
+                        .path("/20200630")
+                        .path("accessRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAccessRequestId()))
+                        .path("action")
+                        .path("review");
 
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
@@ -45,6 +49,10 @@ public class CreateOperatorControlAssignmentConverter {
 
         if (request.getOpcRetryToken() != null) {
             ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
         }
 
         if (request.getOpcRequestId() != null) {
@@ -59,52 +67,49 @@ public class CreateOperatorControlAssignmentConverter {
 
     public static com.google.common.base.Function<
                     javax.ws.rs.core.Response,
-                    com.oracle.bmc.operatoraccesscontrol.responses
-                            .CreateOperatorControlAssignmentResponse>
+                    com.oracle.bmc.operatoraccesscontrol.responses.ReviewAccessRequestResponse>
             fromResponse() {
         final com.google.common.base.Function<
                         javax.ws.rs.core.Response,
-                        com.oracle.bmc.operatoraccesscontrol.responses
-                                .CreateOperatorControlAssignmentResponse>
+                        com.oracle.bmc.operatoraccesscontrol.responses.ReviewAccessRequestResponse>
                 transformer =
                         new com.google.common.base.Function<
                                 javax.ws.rs.core.Response,
                                 com.oracle.bmc.operatoraccesscontrol.responses
-                                        .CreateOperatorControlAssignmentResponse>() {
+                                        .ReviewAccessRequestResponse>() {
                             @Override
                             public com.oracle.bmc.operatoraccesscontrol.responses
-                                            .CreateOperatorControlAssignmentResponse
+                                            .ReviewAccessRequestResponse
                                     apply(javax.ws.rs.core.Response rawResponse) {
                                 LOG.trace(
-                                        "Transform function invoked for com.oracle.bmc.operatoraccesscontrol.responses.CreateOperatorControlAssignmentResponse");
+                                        "Transform function invoked for com.oracle.bmc.operatoraccesscontrol.responses.ReviewAccessRequestResponse");
                                 com.google.common.base.Function<
                                                 javax.ws.rs.core.Response,
                                                 com.oracle.bmc.http.internal.WithHeaders<
                                                         com.oracle.bmc.operatoraccesscontrol.model
-                                                                .OperatorControlAssignment>>
+                                                                .AccessRequest>>
                                         responseFn =
                                                 RESPONSE_CONVERSION_FACTORY.create(
                                                         com.oracle.bmc.operatoraccesscontrol.model
-                                                                        .OperatorControlAssignment
+                                                                        .AccessRequest
                                                                 .class);
 
                                 com.oracle.bmc.http.internal.WithHeaders<
                                                 com.oracle.bmc.operatoraccesscontrol.model
-                                                        .OperatorControlAssignment>
+                                                        .AccessRequest>
                                         response = responseFn.apply(rawResponse);
                                 javax.ws.rs.core.MultivaluedMap<String, String> headers =
                                         response.getHeaders();
 
                                 com.oracle.bmc.operatoraccesscontrol.responses
-                                                .CreateOperatorControlAssignmentResponse.Builder
+                                                .ReviewAccessRequestResponse.Builder
                                         builder =
                                                 com.oracle.bmc.operatoraccesscontrol.responses
-                                                        .CreateOperatorControlAssignmentResponse
-                                                        .builder()
+                                                        .ReviewAccessRequestResponse.builder()
                                                         .__httpStatusCode__(
                                                                 rawResponse.getStatus());
 
-                                builder.operatorControlAssignment(response.getItem());
+                                builder.accessRequest(response.getItem());
 
                                 com.google.common.base.Optional<java.util.List<String>> etagHeader =
                                         com.oracle.bmc.http.internal.HeaderUtils.get(
@@ -113,18 +118,6 @@ public class CreateOperatorControlAssignmentConverter {
                                     builder.etag(
                                             com.oracle.bmc.http.internal.HeaderUtils.toValue(
                                                     "etag", etagHeader.get().get(0), String.class));
-                                }
-
-                                com.google.common.base.Optional<java.util.List<String>>
-                                        opcWorkRequestIdHeader =
-                                                com.oracle.bmc.http.internal.HeaderUtils.get(
-                                                        headers, "opc-work-request-id");
-                                if (opcWorkRequestIdHeader.isPresent()) {
-                                    builder.opcWorkRequestId(
-                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
-                                                    "opc-work-request-id",
-                                                    opcWorkRequestIdHeader.get().get(0),
-                                                    String.class));
                                 }
 
                                 com.google.common.base.Optional<java.util.List<String>>
@@ -140,7 +133,7 @@ public class CreateOperatorControlAssignmentConverter {
                                 }
 
                                 com.oracle.bmc.operatoraccesscontrol.responses
-                                                .CreateOperatorControlAssignmentResponse
+                                                .ReviewAccessRequestResponse
                                         responseWrapper = builder.build();
 
                                 ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/AccessRequest.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/AccessRequest.java
@@ -96,6 +96,15 @@ public class AccessRequest {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+        private ResourceTypes resourceType;
+
+        public Builder resourceType(ResourceTypes resourceType) {
+            this.resourceType = resourceType;
+            this.__explicitlySet__.add("resourceType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("actionRequestsList")
         private java.util.List<String> actionRequestsList;
 
@@ -183,6 +192,15 @@ public class AccessRequest {
         public Builder timeOfModification(java.util.Date timeOfModification) {
             this.timeOfModification = timeOfModification;
             this.__explicitlySet__.add("timeOfModification");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeOfUserCreation")
+        private java.util.Date timeOfUserCreation;
+
+        public Builder timeOfUserCreation(java.util.Date timeOfUserCreation) {
+            this.timeOfUserCreation = timeOfUserCreation;
+            this.__explicitlySet__.add("timeOfUserCreation");
             return this;
         }
 
@@ -290,6 +308,7 @@ public class AccessRequest {
                             resourceId,
                             resourceName,
                             compartmentId,
+                            resourceType,
                             actionRequestsList,
                             reason,
                             severity,
@@ -300,6 +319,7 @@ public class AccessRequest {
                             lifecycleState,
                             timeOfCreation,
                             timeOfModification,
+                            timeOfUserCreation,
                             userId,
                             approverComment,
                             closureComment,
@@ -324,6 +344,7 @@ public class AccessRequest {
                             .resourceId(o.getResourceId())
                             .resourceName(o.getResourceName())
                             .compartmentId(o.getCompartmentId())
+                            .resourceType(o.getResourceType())
                             .actionRequestsList(o.getActionRequestsList())
                             .reason(o.getReason())
                             .severity(o.getSeverity())
@@ -334,6 +355,7 @@ public class AccessRequest {
                             .lifecycleState(o.getLifecycleState())
                             .timeOfCreation(o.getTimeOfCreation())
                             .timeOfModification(o.getTimeOfModification())
+                            .timeOfUserCreation(o.getTimeOfUserCreation())
                             .userId(o.getUserId())
                             .approverComment(o.getApproverComment())
                             .closureComment(o.getClosureComment())
@@ -404,6 +426,12 @@ public class AccessRequest {
     String compartmentId;
 
     /**
+     * resourceType for which the AccessRequest is applicable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+    ResourceTypes resourceType;
+
+    /**
      * List of operator actions for which approval is sought by the operator user.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("actionRequestsList")
@@ -466,6 +494,13 @@ public class AccessRequest {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeOfModification")
     java.util.Date timeOfModification;
+
+    /**
+     * The time when access request is scheduled to be approved in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.Example: '2020-05-22T21:10:29.600Z'
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeOfUserCreation")
+    java.util.Date timeOfUserCreation;
 
     /**
      * The OCID of the user that last modified the access request.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/AccessRequestLifecycleStates.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/AccessRequestLifecycleStates.java
@@ -30,6 +30,8 @@ public enum AccessRequestLifecycleStates {
     Completing("COMPLETING"),
     Completed("COMPLETED"),
     Expired("EXPIRED"),
+    Approvedforfuture("APPROVEDFORFUTURE"),
+    Inreview("INREVIEW"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/AccessRequestSummary.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/AccessRequestSummary.java
@@ -80,6 +80,15 @@ public class AccessRequestSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+        private ResourceTypes resourceType;
+
+        public Builder resourceType(ResourceTypes resourceType) {
+            this.resourceType = resourceType;
+            this.__explicitlySet__.add("resourceType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private AccessRequestLifecycleStates lifecycleState;
 
@@ -104,6 +113,15 @@ public class AccessRequestSummary {
         public Builder timeOfModification(java.util.Date timeOfModification) {
             this.timeOfModification = timeOfModification;
             this.__explicitlySet__.add("timeOfModification");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeOfUserCreation")
+        private java.util.Date timeOfUserCreation;
+
+        public Builder timeOfUserCreation(java.util.Date timeOfUserCreation) {
+            this.timeOfUserCreation = timeOfUserCreation;
+            this.__explicitlySet__.add("timeOfUserCreation");
             return this;
         }
 
@@ -174,9 +192,11 @@ public class AccessRequestSummary {
                             compartmentId,
                             resourceId,
                             resourceName,
+                            resourceType,
                             lifecycleState,
                             timeOfCreation,
                             timeOfModification,
+                            timeOfUserCreation,
                             duration,
                             extendDuration,
                             severity,
@@ -196,9 +216,11 @@ public class AccessRequestSummary {
                             .compartmentId(o.getCompartmentId())
                             .resourceId(o.getResourceId())
                             .resourceName(o.getResourceName())
+                            .resourceType(o.getResourceType())
                             .lifecycleState(o.getLifecycleState())
                             .timeOfCreation(o.getTimeOfCreation())
                             .timeOfModification(o.getTimeOfModification())
+                            .timeOfUserCreation(o.getTimeOfUserCreation())
                             .duration(o.getDuration())
                             .extendDuration(o.getExtendDuration())
                             .severity(o.getSeverity())
@@ -257,6 +279,12 @@ public class AccessRequestSummary {
     String resourceName;
 
     /**
+     * resourceType for which the AccessRequest is applicable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+    ResourceTypes resourceType;
+
+    /**
      * The current state of the AccessRequest.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
@@ -275,6 +303,13 @@ public class AccessRequestSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeOfModification")
     java.util.Date timeOfModification;
+
+    /**
+     * The time when access request is scheduled to be approved in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.Example: '2020-05-22T21:10:29.600Z'
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeOfUserCreation")
+    java.util.Date timeOfUserCreation;
 
     /**
      * Duration in hours for which access is sought on the target resource.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/CreateOperatorControlAssignmentDetails.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/CreateOperatorControlAssignmentDetails.java
@@ -118,6 +118,51 @@ public class CreateOperatorControlAssignmentDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLogForwarded")
+        private Boolean isLogForwarded;
+
+        public Builder isLogForwarded(Boolean isLogForwarded) {
+            this.isLogForwarded = isLogForwarded;
+            this.__explicitlySet__.add("isLogForwarded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerAddress")
+        private String remoteSyslogServerAddress;
+
+        public Builder remoteSyslogServerAddress(String remoteSyslogServerAddress) {
+            this.remoteSyslogServerAddress = remoteSyslogServerAddress;
+            this.__explicitlySet__.add("remoteSyslogServerAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerPort")
+        private Integer remoteSyslogServerPort;
+
+        public Builder remoteSyslogServerPort(Integer remoteSyslogServerPort) {
+            this.remoteSyslogServerPort = remoteSyslogServerPort;
+            this.__explicitlySet__.add("remoteSyslogServerPort");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerCACert")
+        private String remoteSyslogServerCACert;
+
+        public Builder remoteSyslogServerCACert(String remoteSyslogServerCACert) {
+            this.remoteSyslogServerCACert = remoteSyslogServerCACert;
+            this.__explicitlySet__.add("remoteSyslogServerCACert");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoApproveDuringMaintenance")
+        private Boolean isAutoApproveDuringMaintenance;
+
+        public Builder isAutoApproveDuringMaintenance(Boolean isAutoApproveDuringMaintenance) {
+            this.isAutoApproveDuringMaintenance = isAutoApproveDuringMaintenance;
+            this.__explicitlySet__.add("isAutoApproveDuringMaintenance");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -153,6 +198,11 @@ public class CreateOperatorControlAssignmentDetails {
                             compartmentId,
                             isEnforcedAlways,
                             comment,
+                            isLogForwarded,
+                            remoteSyslogServerAddress,
+                            remoteSyslogServerPort,
+                            remoteSyslogServerCACert,
+                            isAutoApproveDuringMaintenance,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -172,6 +222,11 @@ public class CreateOperatorControlAssignmentDetails {
                             .compartmentId(o.getCompartmentId())
                             .isEnforcedAlways(o.getIsEnforcedAlways())
                             .comment(o.getComment())
+                            .isLogForwarded(o.getIsLogForwarded())
+                            .remoteSyslogServerAddress(o.getRemoteSyslogServerAddress())
+                            .remoteSyslogServerPort(o.getRemoteSyslogServerPort())
+                            .remoteSyslogServerCACert(o.getRemoteSyslogServerCACert())
+                            .isAutoApproveDuringMaintenance(o.getIsAutoApproveDuringMaintenance())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -248,6 +303,36 @@ public class CreateOperatorControlAssignmentDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("comment")
     String comment;
+
+    /**
+     * If set, then the audit logs will be forwarded to the relevant remote logging server
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLogForwarded")
+    Boolean isLogForwarded;
+
+    /**
+     * The address of the remote syslog server where the audit logs will be forwarded to. Address in host or IP format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerAddress")
+    String remoteSyslogServerAddress;
+
+    /**
+     * The listening port of the remote syslog server. The port range is 0 - 65535. Only TCP supported.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerPort")
+    Integer remoteSyslogServerPort;
+
+    /**
+     * The CA certificate of the remote syslog server. Identity of the remote syslog server will be asserted based on this certificate.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerCACert")
+    String remoteSyslogServerCACert;
+
+    /**
+     * The boolean if true would autoApprove during maintenance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoApproveDuringMaintenance")
+    Boolean isAutoApproveDuringMaintenance;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/CreateOperatorControlDetails.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/CreateOperatorControlDetails.java
@@ -85,6 +85,15 @@ public class CreateOperatorControlDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+        private ResourceTypes resourceType;
+
+        public Builder resourceType(ResourceTypes resourceType) {
+            this.resourceType = resourceType;
+            this.__explicitlySet__.add("resourceType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("emailIdList")
         private java.util.List<String> emailIdList;
 
@@ -143,6 +152,7 @@ public class CreateOperatorControlDetails {
                             approverGroupsList,
                             preApprovedOpActionList,
                             isFullyPreApproved,
+                            resourceType,
                             emailIdList,
                             systemMessage,
                             compartmentId,
@@ -161,6 +171,7 @@ public class CreateOperatorControlDetails {
                             .approverGroupsList(o.getApproverGroupsList())
                             .preApprovedOpActionList(o.getPreApprovedOpActionList())
                             .isFullyPreApproved(o.getIsFullyPreApproved())
+                            .resourceType(o.getResourceType())
                             .emailIdList(o.getEmailIdList())
                             .systemMessage(o.getSystemMessage())
                             .compartmentId(o.getCompartmentId())
@@ -218,6 +229,12 @@ public class CreateOperatorControlDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isFullyPreApproved")
     Boolean isFullyPreApproved;
+
+    /**
+     * resourceType for which the OperatorControl is applicable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+    ResourceTypes resourceType;
 
     /**
      * List of emailId.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorAction.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorAction.java
@@ -48,12 +48,30 @@ public class OperatorAction {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("customerDisplayName")
+        private String customerDisplayName;
+
+        public Builder customerDisplayName(String customerDisplayName) {
+            this.customerDisplayName = customerDisplayName;
+            this.__explicitlySet__.add("customerDisplayName");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("component")
         private String component;
 
         public Builder component(String component) {
             this.component = component;
             this.__explicitlySet__.add("component");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+        private ResourceTypes resourceType;
+
+        public Builder resourceType(ResourceTypes resourceType) {
+            this.resourceType = resourceType;
+            this.__explicitlySet__.add("resourceType");
             return this;
         }
 
@@ -80,7 +98,14 @@ public class OperatorAction {
 
         public OperatorAction build() {
             OperatorAction __instance__ =
-                    new OperatorAction(id, name, component, description, properties);
+                    new OperatorAction(
+                            id,
+                            name,
+                            customerDisplayName,
+                            component,
+                            resourceType,
+                            description,
+                            properties);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -90,7 +115,9 @@ public class OperatorAction {
             Builder copiedBuilder =
                     id(o.getId())
                             .name(o.getName())
+                            .customerDisplayName(o.getCustomerDisplayName())
                             .component(o.getComponent())
+                            .resourceType(o.getResourceType())
                             .description(o.getDescription())
                             .properties(o.getProperties());
 
@@ -113,16 +140,28 @@ public class OperatorAction {
     String id;
 
     /**
-     * Name of the operator action.
+     * Unique name of the operator action.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
+
+    /**
+     * Display Name of the operator action.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customerDisplayName")
+    String customerDisplayName;
 
     /**
      * Name of the infrastructure layer associated with the operator action.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("component")
     String component;
+
+    /**
+     * resourceType for which the OperatorAction is applicable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+    ResourceTypes resourceType;
 
     /**
      * Description of the operator action in terms of associated risk profile, and characteristics of the operating system commands made

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorActionSummary.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorActionSummary.java
@@ -62,6 +62,15 @@ public class OperatorActionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+        private ResourceTypes resourceType;
+
+        public Builder resourceType(ResourceTypes resourceType) {
+            this.resourceType = resourceType;
+            this.__explicitlySet__.add("resourceType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private OperatorActionLifecycleStates lifecycleState;
 
@@ -86,7 +95,13 @@ public class OperatorActionSummary {
         public OperatorActionSummary build() {
             OperatorActionSummary __instance__ =
                     new OperatorActionSummary(
-                            id, name, component, compartmentId, lifecycleState, description);
+                            id,
+                            name,
+                            component,
+                            compartmentId,
+                            resourceType,
+                            lifecycleState,
+                            description);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -98,6 +113,7 @@ public class OperatorActionSummary {
                             .name(o.getName())
                             .component(o.getComponent())
                             .compartmentId(o.getCompartmentId())
+                            .resourceType(o.getResourceType())
                             .lifecycleState(o.getLifecycleState())
                             .description(o.getDescription());
 
@@ -136,6 +152,12 @@ public class OperatorActionSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * resourceType for which the OperatorAction is applicable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+    ResourceTypes resourceType;
 
     /**
      * The current lifecycle state of the operator action.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControl.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControl.java
@@ -98,6 +98,24 @@ public class OperatorControl {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("emailIdList")
+        private java.util.List<String> emailIdList;
+
+        public Builder emailIdList(java.util.List<String> emailIdList) {
+            this.emailIdList = emailIdList;
+            this.__explicitlySet__.add("emailIdList");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+        private ResourceTypes resourceType;
+
+        public Builder resourceType(ResourceTypes resourceType) {
+            this.resourceType = resourceType;
+            this.__explicitlySet__.add("resourceType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("systemMessage")
         private String systemMessage;
 
@@ -194,6 +212,8 @@ public class OperatorControl {
                             preApprovedOpActionList,
                             approvalRequiredOpActionList,
                             isFullyPreApproved,
+                            emailIdList,
+                            resourceType,
                             systemMessage,
                             compartmentId,
                             lifecycleState,
@@ -218,6 +238,8 @@ public class OperatorControl {
                             .preApprovedOpActionList(o.getPreApprovedOpActionList())
                             .approvalRequiredOpActionList(o.getApprovalRequiredOpActionList())
                             .isFullyPreApproved(o.getIsFullyPreApproved())
+                            .emailIdList(o.getEmailIdList())
+                            .resourceType(o.getResourceType())
                             .systemMessage(o.getSystemMessage())
                             .compartmentId(o.getCompartmentId())
                             .lifecycleState(o.getLifecycleState())
@@ -294,6 +316,19 @@ public class OperatorControl {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isFullyPreApproved")
     Boolean isFullyPreApproved;
+
+    /**
+     * List of emailId.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("emailIdList")
+    java.util.List<String> emailIdList;
+
+    /**
+     * resourceType for which the OperatorControl is applicable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+    ResourceTypes resourceType;
 
     /**
      * System message that would be displayed to the operator users on accessing the target resource under the governance of this operator control.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControlAssignment.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControlAssignment.java
@@ -64,15 +64,6 @@ public class OperatorControlAssignment {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
-        private ResourceTypes resourceType;
-
-        public Builder resourceType(ResourceTypes resourceType) {
-            this.resourceType = resourceType;
-            this.__explicitlySet__.add("resourceType");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("resourceCompartmentId")
         private String resourceCompartmentId;
 
@@ -88,6 +79,15 @@ public class OperatorControlAssignment {
         public Builder compartmentId(String compartmentId) {
             this.compartmentId = compartmentId;
             this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+        private ResourceTypes resourceType;
+
+        public Builder resourceType(ResourceTypes resourceType) {
+            this.resourceType = resourceType;
+            this.__explicitlySet__.add("resourceType");
             return this;
         }
 
@@ -181,6 +181,69 @@ public class OperatorControlAssignment {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLogForwarded")
+        private Boolean isLogForwarded;
+
+        public Builder isLogForwarded(Boolean isLogForwarded) {
+            this.isLogForwarded = isLogForwarded;
+            this.__explicitlySet__.add("isLogForwarded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerAddress")
+        private String remoteSyslogServerAddress;
+
+        public Builder remoteSyslogServerAddress(String remoteSyslogServerAddress) {
+            this.remoteSyslogServerAddress = remoteSyslogServerAddress;
+            this.__explicitlySet__.add("remoteSyslogServerAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerPort")
+        private Integer remoteSyslogServerPort;
+
+        public Builder remoteSyslogServerPort(Integer remoteSyslogServerPort) {
+            this.remoteSyslogServerPort = remoteSyslogServerPort;
+            this.__explicitlySet__.add("remoteSyslogServerPort");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerCACert")
+        private String remoteSyslogServerCACert;
+
+        public Builder remoteSyslogServerCACert(String remoteSyslogServerCACert) {
+            this.remoteSyslogServerCACert = remoteSyslogServerCACert;
+            this.__explicitlySet__.add("remoteSyslogServerCACert");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoApproveDuringMaintenance")
+        private Boolean isAutoApproveDuringMaintenance;
+
+        public Builder isAutoApproveDuringMaintenance(Boolean isAutoApproveDuringMaintenance) {
+            this.isAutoApproveDuringMaintenance = isAutoApproveDuringMaintenance;
+            this.__explicitlySet__.add("isAutoApproveDuringMaintenance");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
+        private Integer errorCode;
+
+        public Builder errorCode(Integer errorCode) {
+            this.errorCode = errorCode;
+            this.__explicitlySet__.add("errorCode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorMessage")
+        private String errorMessage;
+
+        public Builder errorMessage(String errorMessage) {
+            this.errorMessage = errorMessage;
+            this.__explicitlySet__.add("errorMessage");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -210,9 +273,9 @@ public class OperatorControlAssignment {
                             operatorControlId,
                             resourceId,
                             resourceName,
-                            resourceType,
                             resourceCompartmentId,
                             compartmentId,
+                            resourceType,
                             timeAssignmentFrom,
                             timeAssignmentTo,
                             isEnforcedAlways,
@@ -223,6 +286,13 @@ public class OperatorControlAssignment {
                             unassignerId,
                             timeOfDeletion,
                             detachmentDescription,
+                            isLogForwarded,
+                            remoteSyslogServerAddress,
+                            remoteSyslogServerPort,
+                            remoteSyslogServerCACert,
+                            isAutoApproveDuringMaintenance,
+                            errorCode,
+                            errorMessage,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -236,9 +306,9 @@ public class OperatorControlAssignment {
                             .operatorControlId(o.getOperatorControlId())
                             .resourceId(o.getResourceId())
                             .resourceName(o.getResourceName())
-                            .resourceType(o.getResourceType())
                             .resourceCompartmentId(o.getResourceCompartmentId())
                             .compartmentId(o.getCompartmentId())
+                            .resourceType(o.getResourceType())
                             .timeAssignmentFrom(o.getTimeAssignmentFrom())
                             .timeAssignmentTo(o.getTimeAssignmentTo())
                             .isEnforcedAlways(o.getIsEnforcedAlways())
@@ -249,6 +319,13 @@ public class OperatorControlAssignment {
                             .unassignerId(o.getUnassignerId())
                             .timeOfDeletion(o.getTimeOfDeletion())
                             .detachmentDescription(o.getDetachmentDescription())
+                            .isLogForwarded(o.getIsLogForwarded())
+                            .remoteSyslogServerAddress(o.getRemoteSyslogServerAddress())
+                            .remoteSyslogServerPort(o.getRemoteSyslogServerPort())
+                            .remoteSyslogServerCACert(o.getRemoteSyslogServerCACert())
+                            .isAutoApproveDuringMaintenance(o.getIsAutoApproveDuringMaintenance())
+                            .errorCode(o.getErrorCode())
+                            .errorMessage(o.getErrorMessage())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -289,12 +366,6 @@ public class OperatorControlAssignment {
     String resourceName;
 
     /**
-     * Type of the target resource.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
-    ResourceTypes resourceType;
-
-    /**
      * The OCID of the compartment that contains the target resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("resourceCompartmentId")
@@ -305,6 +376,12 @@ public class OperatorControlAssignment {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * resourceType for which the OperatorControlAssignment is applicable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+    ResourceTypes resourceType;
 
     /**
      * The time at which the target resource will be brought under the governance of the operator control expressed in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
@@ -371,6 +448,48 @@ public class OperatorControlAssignment {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("detachmentDescription")
     String detachmentDescription;
+
+    /**
+     * If set indicates that the audit logs are being forwarded to the relevant remote logging server
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLogForwarded")
+    Boolean isLogForwarded;
+
+    /**
+     * The address of the remote syslog server where the audit logs are being forwarded to. Address in host or IP format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerAddress")
+    String remoteSyslogServerAddress;
+
+    /**
+     * The listening port of the remote syslog server. The port range is 0 - 65535. Only TCP supported.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerPort")
+    Integer remoteSyslogServerPort;
+
+    /**
+     * The CA certificate of the remote syslog server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerCACert")
+    String remoteSyslogServerCACert;
+
+    /**
+     * The boolean if true would autoApprove during maintenance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoApproveDuringMaintenance")
+    Boolean isAutoApproveDuringMaintenance;
+
+    /**
+     * The code identifying the error occurred during Assignment operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
+    Integer errorCode;
+
+    /**
+     * The message describing the error occurred during Assignment operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorMessage")
+    String errorMessage;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControlAssignmentLifecycleStates.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControlAssignmentLifecycleStates.java
@@ -13,7 +13,10 @@ public enum OperatorControlAssignmentLifecycleStates {
     Created("CREATED"),
     Applied("APPLIED"),
     Applyfailed("APPLYFAILED"),
+    Updating("UPDATING"),
+    Deleting("DELETING"),
     Deleted("DELETED"),
+    Deletionfailed("DELETIONFAILED"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControlAssignmentSummary.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControlAssignmentSummary.java
@@ -53,21 +53,21 @@ public class OperatorControlAssignmentSummary {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
-        private String resourceType;
-
-        public Builder resourceType(String resourceType) {
-            this.resourceType = resourceType;
-            this.__explicitlySet__.add("resourceType");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
         private String compartmentId;
 
         public Builder compartmentId(String compartmentId) {
             this.compartmentId = compartmentId;
             this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+        private ResourceTypes resourceType;
+
+        public Builder resourceType(ResourceTypes resourceType) {
+            this.resourceType = resourceType;
+            this.__explicitlySet__.add("resourceType");
             return this;
         }
 
@@ -104,6 +104,51 @@ public class OperatorControlAssignmentSummary {
         public Builder timeOfAssignment(java.util.Date timeOfAssignment) {
             this.timeOfAssignment = timeOfAssignment;
             this.__explicitlySet__.add("timeOfAssignment");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
+        private Integer errorCode;
+
+        public Builder errorCode(Integer errorCode) {
+            this.errorCode = errorCode;
+            this.__explicitlySet__.add("errorCode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("errorMessage")
+        private String errorMessage;
+
+        public Builder errorMessage(String errorMessage) {
+            this.errorMessage = errorMessage;
+            this.__explicitlySet__.add("errorMessage");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isLogForwarded")
+        private Boolean isLogForwarded;
+
+        public Builder isLogForwarded(Boolean isLogForwarded) {
+            this.isLogForwarded = isLogForwarded;
+            this.__explicitlySet__.add("isLogForwarded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerAddress")
+        private String remoteSyslogServerAddress;
+
+        public Builder remoteSyslogServerAddress(String remoteSyslogServerAddress) {
+            this.remoteSyslogServerAddress = remoteSyslogServerAddress;
+            this.__explicitlySet__.add("remoteSyslogServerAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerPort")
+        private Integer remoteSyslogServerPort;
+
+        public Builder remoteSyslogServerPort(Integer remoteSyslogServerPort) {
+            this.remoteSyslogServerPort = remoteSyslogServerPort;
+            this.__explicitlySet__.add("remoteSyslogServerPort");
             return this;
         }
 
@@ -144,12 +189,17 @@ public class OperatorControlAssignmentSummary {
                             id,
                             operatorControlId,
                             resourceId,
-                            resourceType,
                             compartmentId,
+                            resourceType,
                             timeAssignmentFrom,
                             timeAssignmentTo,
                             isEnforcedAlways,
                             timeOfAssignment,
+                            errorCode,
+                            errorMessage,
+                            isLogForwarded,
+                            remoteSyslogServerAddress,
+                            remoteSyslogServerPort,
                             lifecycleState,
                             freeformTags,
                             definedTags);
@@ -163,12 +213,17 @@ public class OperatorControlAssignmentSummary {
                     id(o.getId())
                             .operatorControlId(o.getOperatorControlId())
                             .resourceId(o.getResourceId())
-                            .resourceType(o.getResourceType())
                             .compartmentId(o.getCompartmentId())
+                            .resourceType(o.getResourceType())
                             .timeAssignmentFrom(o.getTimeAssignmentFrom())
                             .timeAssignmentTo(o.getTimeAssignmentTo())
                             .isEnforcedAlways(o.getIsEnforcedAlways())
                             .timeOfAssignment(o.getTimeOfAssignment())
+                            .errorCode(o.getErrorCode())
+                            .errorMessage(o.getErrorMessage())
+                            .isLogForwarded(o.getIsLogForwarded())
+                            .remoteSyslogServerAddress(o.getRemoteSyslogServerAddress())
+                            .remoteSyslogServerPort(o.getRemoteSyslogServerPort())
                             .lifecycleState(o.getLifecycleState())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
@@ -204,16 +259,16 @@ public class OperatorControlAssignmentSummary {
     String resourceId;
 
     /**
-     * Type of the target resource being governed by the operator control.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
-    String resourceType;
-
-    /**
      * The OCID of the compartment that contains the operator control assignment.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
+
+    /**
+     * resourceType for which the OperatorControlAssignment is applicable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+    ResourceTypes resourceType;
 
     /**
      * The time at which the target resource will be brought under the governance of the operator control in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format. Example: '2020-05-22T21:10:29.600Z'
@@ -241,6 +296,36 @@ public class OperatorControlAssignmentSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeOfAssignment")
     java.util.Date timeOfAssignment;
+
+    /**
+     * The code identifying the error occurred during Assignment operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorCode")
+    Integer errorCode;
+
+    /**
+     * The message describing the error occurred during Assignment operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("errorMessage")
+    String errorMessage;
+
+    /**
+     * If set, then the audit logs are being forwarded to the relevant remote logging server
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLogForwarded")
+    Boolean isLogForwarded;
+
+    /**
+     * The address of the remote syslog server where the audit logs are being forwarded to. Address in host or IP format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerAddress")
+    String remoteSyslogServerAddress;
+
+    /**
+     * The listening port of the remote syslog server. The port range is 0 - 65535.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerPort")
+    Integer remoteSyslogServerPort;
 
     /**
      * The current lifcycle state of the OperatorControl.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControlSummary.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/OperatorControlSummary.java
@@ -62,6 +62,15 @@ public class OperatorControlSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+        private ResourceTypes resourceType;
+
+        public Builder resourceType(ResourceTypes resourceType) {
+            this.resourceType = resourceType;
+            this.__explicitlySet__.add("resourceType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("timeOfCreation")
         private java.util.Date timeOfCreation;
 
@@ -127,6 +136,7 @@ public class OperatorControlSummary {
                             operatorControlName,
                             compartmentId,
                             isFullyPreApproved,
+                            resourceType,
                             timeOfCreation,
                             timeOfModification,
                             timeOfDeletion,
@@ -144,6 +154,7 @@ public class OperatorControlSummary {
                             .operatorControlName(o.getOperatorControlName())
                             .compartmentId(o.getCompartmentId())
                             .isFullyPreApproved(o.getIsFullyPreApproved())
+                            .resourceType(o.getResourceType())
                             .timeOfCreation(o.getTimeOfCreation())
                             .timeOfModification(o.getTimeOfModification())
                             .timeOfDeletion(o.getTimeOfDeletion())
@@ -186,6 +197,12 @@ public class OperatorControlSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isFullyPreApproved")
     Boolean isFullyPreApproved;
+
+    /**
+     * resourceType for which the OperatorControl is applicable
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceType")
+    ResourceTypes resourceType;
 
     /**
      * Time when the operator control was created, expressed in [RFC 3339] (https://tools.ietf.org/html/rfc3339) timestamp format. Example: '2020-05-22T21:10:29.600Z'

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/ResourceTypes.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/ResourceTypes.java
@@ -12,6 +12,8 @@ package com.oracle.bmc.operatoraccesscontrol.model;
 @lombok.extern.slf4j.Slf4j
 public enum ResourceTypes {
     Exacc("EXACC"),
+    Exadatainfrastructure("EXADATAINFRASTRUCTURE"),
+    Autonomousvmcluster("AUTONOMOUSVMCLUSTER"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/ReviewAccessRequestDetails.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/ReviewAccessRequestDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.operatoraccesscontrol.model;
 
 /**
- * Details of the access request approval.
+ * Details to mark access request in review.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -18,11 +18,11 @@ package com.oracle.bmc.operatoraccesscontrol.model;
 @lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
 @lombok.Value
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(
-    builder = ApproveAccessRequestDetails.Builder.class
+    builder = ReviewAccessRequestDetails.Builder.class
 )
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
 @lombok.Builder(builderClassName = "Builder", toBuilder = true)
-public class ApproveAccessRequestDetails {
+public class ReviewAccessRequestDetails {
     @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
     @lombok.experimental.Accessors(fluent = true)
     public static class Builder {
@@ -35,51 +35,19 @@ public class ApproveAccessRequestDetails {
             return this;
         }
 
-        @com.fasterxml.jackson.annotation.JsonProperty("auditType")
-        private java.util.List<String> auditType;
-
-        public Builder auditType(java.util.List<String> auditType) {
-            this.auditType = auditType;
-            this.__explicitlySet__.add("auditType");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("additionalMessage")
-        private String additionalMessage;
-
-        public Builder additionalMessage(String additionalMessage) {
-            this.additionalMessage = additionalMessage;
-            this.__explicitlySet__.add("additionalMessage");
-            return this;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonProperty("timeOfUserCreation")
-        private java.util.Date timeOfUserCreation;
-
-        public Builder timeOfUserCreation(java.util.Date timeOfUserCreation) {
-            this.timeOfUserCreation = timeOfUserCreation;
-            this.__explicitlySet__.add("timeOfUserCreation");
-            return this;
-        }
-
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
-        public ApproveAccessRequestDetails build() {
-            ApproveAccessRequestDetails __instance__ =
-                    new ApproveAccessRequestDetails(
-                            approverComment, auditType, additionalMessage, timeOfUserCreation);
+        public ReviewAccessRequestDetails build() {
+            ReviewAccessRequestDetails __instance__ =
+                    new ReviewAccessRequestDetails(approverComment);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
-        public Builder copy(ApproveAccessRequestDetails o) {
-            Builder copiedBuilder =
-                    approverComment(o.getApproverComment())
-                            .auditType(o.getAuditType())
-                            .additionalMessage(o.getAdditionalMessage())
-                            .timeOfUserCreation(o.getTimeOfUserCreation());
+        public Builder copy(ReviewAccessRequestDetails o) {
+            Builder copiedBuilder = approverComment(o.getApproverComment());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -94,32 +62,10 @@ public class ApproveAccessRequestDetails {
     }
 
     /**
-     * Comment by the approver during approval.
+     * Comment by the approver explaining that the access request is in review.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("approverComment")
     String approverComment;
-
-    /**
-     * Specifies the type of auditing to be enabled. There are two levels of auditing: command-level and keystroke-level.
-     * By default, auditing is enabled at the command level i.e., each command issued by the operator is audited. When keystroke-level is chosen,
-     * in addition to command level logging, key strokes are also logged.
-     *
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("auditType")
-    java.util.List<String> auditType;
-
-    /**
-     * Message that needs to be displayed to the Ops User.
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("additionalMessage")
-    String additionalMessage;
-
-    /**
-     * The time when access request is scheduled to be approved in [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.Example: '2020-05-22T21:10:29.600Z'
-     *
-     **/
-    @com.fasterxml.jackson.annotation.JsonProperty("timeOfUserCreation")
-    java.util.Date timeOfUserCreation;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/UpdateOperatorControlAssignmentDetails.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/model/UpdateOperatorControlAssignmentDetails.java
@@ -62,6 +62,51 @@ public class UpdateOperatorControlAssignmentDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isLogForwarded")
+        private Boolean isLogForwarded;
+
+        public Builder isLogForwarded(Boolean isLogForwarded) {
+            this.isLogForwarded = isLogForwarded;
+            this.__explicitlySet__.add("isLogForwarded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerAddress")
+        private String remoteSyslogServerAddress;
+
+        public Builder remoteSyslogServerAddress(String remoteSyslogServerAddress) {
+            this.remoteSyslogServerAddress = remoteSyslogServerAddress;
+            this.__explicitlySet__.add("remoteSyslogServerAddress");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerPort")
+        private Integer remoteSyslogServerPort;
+
+        public Builder remoteSyslogServerPort(Integer remoteSyslogServerPort) {
+            this.remoteSyslogServerPort = remoteSyslogServerPort;
+            this.__explicitlySet__.add("remoteSyslogServerPort");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerCACert")
+        private String remoteSyslogServerCACert;
+
+        public Builder remoteSyslogServerCACert(String remoteSyslogServerCACert) {
+            this.remoteSyslogServerCACert = remoteSyslogServerCACert;
+            this.__explicitlySet__.add("remoteSyslogServerCACert");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoApproveDuringMaintenance")
+        private Boolean isAutoApproveDuringMaintenance;
+
+        public Builder isAutoApproveDuringMaintenance(Boolean isAutoApproveDuringMaintenance) {
+            this.isAutoApproveDuringMaintenance = isAutoApproveDuringMaintenance;
+            this.__explicitlySet__.add("isAutoApproveDuringMaintenance");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -91,6 +136,11 @@ public class UpdateOperatorControlAssignmentDetails {
                             timeAssignmentTo,
                             isEnforcedAlways,
                             comment,
+                            isLogForwarded,
+                            remoteSyslogServerAddress,
+                            remoteSyslogServerPort,
+                            remoteSyslogServerCACert,
+                            isAutoApproveDuringMaintenance,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -104,6 +154,11 @@ public class UpdateOperatorControlAssignmentDetails {
                             .timeAssignmentTo(o.getTimeAssignmentTo())
                             .isEnforcedAlways(o.getIsEnforcedAlways())
                             .comment(o.getComment())
+                            .isLogForwarded(o.getIsLogForwarded())
+                            .remoteSyslogServerAddress(o.getRemoteSyslogServerAddress())
+                            .remoteSyslogServerPort(o.getRemoteSyslogServerPort())
+                            .remoteSyslogServerCACert(o.getRemoteSyslogServerCACert())
+                            .isAutoApproveDuringMaintenance(o.getIsAutoApproveDuringMaintenance())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -144,6 +199,36 @@ public class UpdateOperatorControlAssignmentDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("comment")
     String comment;
+
+    /**
+     * If set, then the audit logs will be forwarded to the relevant remote logging server
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isLogForwarded")
+    Boolean isLogForwarded;
+
+    /**
+     * The address of the remote syslog server where the audit logs will be forwarded to. Address in host or IP format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerAddress")
+    String remoteSyslogServerAddress;
+
+    /**
+     * The listening port of the remote syslog server. The port range is 0 - 65535. Only TCP supported.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerPort")
+    Integer remoteSyslogServerPort;
+
+    /**
+     * The CA certificate of the remote syslog server. Identity of the remote syslog server will be asserted based on this certificate.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remoteSyslogServerCACert")
+    String remoteSyslogServerCACert;
+
+    /**
+     * The boolean if true would autoApprove during maintenance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoApproveDuringMaintenance")
+    Boolean isAutoApproveDuringMaintenance;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListAccessRequestsRequest.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListAccessRequestsRequest.java
@@ -30,9 +30,30 @@ public class ListAccessRequestsRequest extends com.oracle.bmc.requests.BmcReques
     private String resourceName;
 
     /**
+     * A filter to return only lists of resources that match the entire given service type.
+     */
+    private String resourceType;
+
+    /**
      * A filter to return only resources whose lifecycleState matches the given AccessRequest lifecycleState.
      */
     private com.oracle.bmc.operatoraccesscontrol.model.AccessRequestLifecycleStates lifecycleState;
+
+    /**
+     * Query start time in UTC in ISO 8601 format(inclusive).
+     * Example 2019-10-30T00:00:00Z (yyyy-MM-ddThh:mm:ssZ).
+     * timeIntervalStart and timeIntervalEnd parameters are used together.
+     *
+     */
+    private java.util.Date timeStart;
+
+    /**
+     * Query start time in UTC in ISO 8601 format(inclusive).
+     * Example 2019-10-30T00:00:00Z (yyyy-MM-ddThh:mm:ssZ).
+     * timeIntervalStart and timeIntervalEnd parameters are used together.
+     *
+     */
+    private java.util.Date timeEnd;
 
     /**
      * The maximum number of items to return.
@@ -133,7 +154,10 @@ public class ListAccessRequestsRequest extends com.oracle.bmc.requests.BmcReques
         public Builder copy(ListAccessRequestsRequest o) {
             compartmentId(o.getCompartmentId());
             resourceName(o.getResourceName());
+            resourceType(o.getResourceType());
             lifecycleState(o.getLifecycleState());
+            timeStart(o.getTimeStart());
+            timeEnd(o.getTimeEnd());
             limit(o.getLimit());
             page(o.getPage());
             sortOrder(o.getSortOrder());

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListOperatorActionsRequest.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListOperatorActionsRequest.java
@@ -30,6 +30,11 @@ public class ListOperatorActionsRequest extends com.oracle.bmc.requests.BmcReque
     private String name;
 
     /**
+     * A filter to return only lists of resources that match the entire given service type.
+     */
+    private String resourceType;
+
+    /**
      * A filter to return only resources whose lifecycleState matches the given OperatorAction lifecycleState.
      */
     private com.oracle.bmc.operatoraccesscontrol.model.OperatorActionLifecycleStates lifecycleState;
@@ -133,6 +138,7 @@ public class ListOperatorActionsRequest extends com.oracle.bmc.requests.BmcReque
         public Builder copy(ListOperatorActionsRequest o) {
             compartmentId(o.getCompartmentId());
             name(o.getName());
+            resourceType(o.getResourceType());
             lifecycleState(o.getLifecycleState());
             limit(o.getLimit());
             page(o.getPage());

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListOperatorControlAssignmentsRequest.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListOperatorControlAssignmentsRequest.java
@@ -36,6 +36,11 @@ public class ListOperatorControlAssignmentsRequest
     private String resourceName;
 
     /**
+     * A filter to return only lists of resources that match the entire given service type.
+     */
+    private String resourceType;
+
+    /**
      * A filter to return only resources whose lifecycleState matches the given OperatorControlAssignment lifecycleState.
      */
     private com.oracle.bmc.operatoraccesscontrol.model.OperatorControlAssignmentLifecycleStates
@@ -141,6 +146,7 @@ public class ListOperatorControlAssignmentsRequest
             compartmentId(o.getCompartmentId());
             operatorControlName(o.getOperatorControlName());
             resourceName(o.getResourceName());
+            resourceType(o.getResourceType());
             lifecycleState(o.getLifecycleState());
             limit(o.getLimit());
             page(o.getPage());

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListOperatorControlsRequest.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ListOperatorControlsRequest.java
@@ -37,6 +37,11 @@ public class ListOperatorControlsRequest
     private String displayName;
 
     /**
+     * A filter to return only lists of resources that match the entire given service type.
+     */
+    private String resourceType;
+
+    /**
      * The maximum number of items to return.
      */
     private Integer limit;
@@ -136,6 +141,7 @@ public class ListOperatorControlsRequest
             compartmentId(o.getCompartmentId());
             lifecycleState(o.getLifecycleState());
             displayName(o.getDisplayName());
+            resourceType(o.getResourceType());
             limit(o.getLimit());
             page(o.getPage());
             sortOrder(o.getSortOrder());

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ReviewAccessRequestRequest.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/requests/ReviewAccessRequestRequest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.operatoraccesscontrol.requests;
+
+import com.oracle.bmc.operatoraccesscontrol.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/operatoraccesscontrol/ReviewAccessRequestExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ReviewAccessRequestRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20200630")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ReviewAccessRequestRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.operatoraccesscontrol.model.ReviewAccessRequestDetails> {
+
+    /**
+     * unique AccessRequest identifier
+     */
+    private String accessRequestId;
+
+    /**
+     * Details regarding the approval of an access request created by the operator.
+     */
+    private com.oracle.bmc.operatoraccesscontrol.model.ReviewAccessRequestDetails
+            reviewAccessRequestDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case of a timeout or
+     * server error without risk of executing that same action again. Retry tokens expire after 24
+     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * has been deleted and purged from the system, then a retry of the original creation request
+     * might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.operatoraccesscontrol.model.ReviewAccessRequestDetails getBody$() {
+        return reviewAccessRequestDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ReviewAccessRequestRequest,
+                    com.oracle.bmc.operatoraccesscontrol.model.ReviewAccessRequestDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ReviewAccessRequestRequest o) {
+            accessRequestId(o.getAccessRequestId());
+            reviewAccessRequestDetails(o.getReviewAccessRequestDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ReviewAccessRequestRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ReviewAccessRequestRequest
+         */
+        public ReviewAccessRequestRequest build() {
+            ReviewAccessRequestRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.operatoraccesscontrol.model.ReviewAccessRequestDetails body) {
+            reviewAccessRequestDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/responses/ReviewAccessRequestResponse.java
+++ b/bmc-operatoraccesscontrol/src/main/java/com/oracle/bmc/operatoraccesscontrol/responses/ReviewAccessRequestResponse.java
@@ -11,18 +11,12 @@ import com.oracle.bmc.operatoraccesscontrol.model.*;
 @lombok.ToString(callSuper = true)
 @lombok.EqualsAndHashCode(callSuper = true)
 @lombok.Getter
-public class CreateOperatorControlAssignmentResponse extends com.oracle.bmc.responses.BmcResponse {
+public class ReviewAccessRequestResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
      * For optimistic concurrency control. See {@code if-match}.
      *
      */
     private String etag;
-
-    /**
-     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
-     *
-     */
-    private String opcWorkRequestId;
 
     /**
      * Unique Oracle-assigned identifier for the request. If you need to contact
@@ -32,23 +26,19 @@ public class CreateOperatorControlAssignmentResponse extends com.oracle.bmc.resp
     private String opcRequestId;
 
     /**
-     * The returned OperatorControlAssignment instance.
+     * The returned AccessRequest instance.
      */
-    private com.oracle.bmc.operatoraccesscontrol.model.OperatorControlAssignment
-            operatorControlAssignment;
+    private com.oracle.bmc.operatoraccesscontrol.model.AccessRequest accessRequest;
 
-    private CreateOperatorControlAssignmentResponse(
+    private ReviewAccessRequestResponse(
             int __httpStatusCode__,
             String etag,
-            String opcWorkRequestId,
             String opcRequestId,
-            com.oracle.bmc.operatoraccesscontrol.model.OperatorControlAssignment
-                    operatorControlAssignment) {
+            com.oracle.bmc.operatoraccesscontrol.model.AccessRequest accessRequest) {
         super(__httpStatusCode__);
         this.etag = etag;
-        this.opcWorkRequestId = opcWorkRequestId;
         this.opcRequestId = opcRequestId;
-        this.operatorControlAssignment = operatorControlAssignment;
+        this.accessRequest = accessRequest;
     }
 
     public static class Builder {
@@ -63,23 +53,18 @@ public class CreateOperatorControlAssignmentResponse extends com.oracle.bmc.resp
          * Copy method to populate the builder with values from the given instance.
          * @return this builder instance
          */
-        public Builder copy(CreateOperatorControlAssignmentResponse o) {
+        public Builder copy(ReviewAccessRequestResponse o) {
             __httpStatusCode__(o.get__httpStatusCode__());
             etag(o.getEtag());
-            opcWorkRequestId(o.getOpcWorkRequestId());
             opcRequestId(o.getOpcRequestId());
-            operatorControlAssignment(o.getOperatorControlAssignment());
+            accessRequest(o.getAccessRequest());
 
             return this;
         }
 
-        public CreateOperatorControlAssignmentResponse build() {
-            return new CreateOperatorControlAssignmentResponse(
-                    __httpStatusCode__,
-                    etag,
-                    opcWorkRequestId,
-                    opcRequestId,
-                    operatorControlAssignment);
+        public ReviewAccessRequestResponse build() {
+            return new ReviewAccessRequestResponse(
+                    __httpStatusCode__, etag, opcRequestId, accessRequest);
         }
     }
 }

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usage/pom.xml
+++ b/bmc-usage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.8.1</version>
+    <version>2.9.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.8.1</version>
+      <version>2.9.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.8.1</version>
+  <version>2.9.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for drill down metadata in the Management Dashboard service

- Support for operator access control on dedicated autonomous databases in the Operator Access Control service



### Breaking Changes

- Return type of method `public java.lang.String getResourceType()` has been changed to `com.oracle.bmc.operatoraccesscontrol.model.ResourceTypes` in the model `com.oracle.bmc.operatoraccesscontrol.model.OperatorControlAssignmentSummary` in the Operator Access Control service
