### PR TITLE
Releasing version 2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.13.1 - 2022-01-18
+### Added
+- Support for calling Oracle Cloud Infrastructure services in the me-dcc-muscat-1 region
+- Support for the Visual Builder service
+- Support for cross-region replication of volume groups in the Block Storage service
+- Support for boot volume encryption in the Container Engine for Kubernetes service
+- Support for adding metadata to records when creating and updating records in the Data Labeling service
+- Support for global export formats in snapshot datasets in the Data Labeling service
+- Support for adding labeling instructions to datasets in the Data Labeling service
+- Support for updating autonomous dataguard associations for autonomous container databases in the Database service
+- Support for setting up automatic failover when creating autonomous container databases in the Database service
+- Support for setting the RECO storage size when updating a database system in the Database service
+- Support for reconnecting refreshable clones to source for autonomous databases on shared infrastructure in the Database service
+- Support for checking if an autonomous database on shared infrastructure can be reconnected to source, in the Database service
+
 ## 2.13.0 - 2022-01-11
 ### Added
 - Support for calling Oracle Cloud Infrastructure services in the af-johannesburg-1 and eu-stockholm-1 regions

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-appmgmtcontrol/pom.xml
+++ b/bmc-appmgmtcontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,576 +19,582 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificates</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usage</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasetools</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ospgateway</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identitydataplane</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
+        <optional>false</optional>
+      </dependency>
+      <dependency>
+        <groupId>com.oracle.oci.sdk</groupId>
+        <artifactId>oci-java-sdk-visualbuilder</artifactId>
+        <version>2.13.1</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificates/pom.xml
+++ b/bmc-certificates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificates</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificatesmanagement/pom.xml
+++ b/bmc-certificatesmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-common/src/main/java/com/oracle/bmc/Realm.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Realm.java
@@ -29,6 +29,7 @@ public final class Realm implements Serializable, Comparable<Realm> {
     public static final Realm OC3 = new Realm("oc3", "oraclegovcloud.com");
     public static final Realm OC4 = new Realm("oc4", "oraclegovcloud.uk");
     public static final Realm OC8 = new Realm("oc8", "oraclecloud8.com");
+    public static final Realm OC9 = new Realm("oc9", "oraclecloud9.com");
     private static final long serialVersionUID = -905344971L;
 
     @Getter

--- a/bmc-common/src/main/java/com/oracle/bmc/Region.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/Region.java
@@ -135,6 +135,9 @@ public final class Region implements Serializable, Comparable<Region> {
     public static final Region AP_CHIYODA_1 = register("ap-chiyoda-1", Realm.OC8, "nja");
     public static final Region AP_IBARAKI_1 = register("ap-ibaraki-1", Realm.OC8, "ukb");
 
+    // OC9
+    public static final Region ME_DCC_MUSCAT_1 = register("me-dcc-muscat-1", Realm.OC9, "mct");
+
     private static final Map<String, Map<Region, String>> SERVICE_TO_REGION_ENDPOINTS =
             new HashMap<>();
 

--- a/bmc-common/src/main/java/com/oracle/bmc/http/internal/ResponseHelper.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/internal/ResponseHelper.java
@@ -251,19 +251,21 @@ public class ResponseHelper {
                                             HttpHeaders.CONTENT_LENGTH,
                                             contentLengthHeader.get().get(0),
                                             Long.class);
-                            if (SHOULD_AUTO_CLOSE_RESPONSE_INPUTSTREAM) {
-                                if (ApacheUtils.isExtraStreamLogsEnabled()) {
-                                    LOG.warn(
-                                            "Wrapping response stream into auto closeable stream, to disable this, please "
-                                                    + "use ResponseHelper.shouldAutoCloseResponseInputStream(false)");
+                            if (contentLength > 0) {
+                                if (SHOULD_AUTO_CLOSE_RESPONSE_INPUTSTREAM) {
+                                    if (ApacheUtils.isExtraStreamLogsEnabled()) {
+                                        LOG.warn(
+                                                "Wrapping response stream into auto closeable stream, to disable this, please "
+                                                        + "use ResponseHelper.shouldAutoCloseResponseInputStream(false)");
+                                    }
+                                    inputStream =
+                                            new AutoCloseableContentLengthVerifyingInputStream(
+                                                    inputStream, contentLength);
+                                } else {
+                                    inputStream =
+                                            new ContentLengthVerifyingInputStream(
+                                                    inputStream, contentLength);
                                 }
-                                inputStream =
-                                        new AutoCloseableContentLengthVerifyingInputStream(
-                                                inputStream, contentLength);
-                            } else {
-                                inputStream =
-                                        new ContentLengthVerifyingInputStream(
-                                                inputStream, contentLength);
                             }
                         }
 

--- a/bmc-common/src/test/resources/regions.json
+++ b/bmc-common/src/test/resources/regions.json
@@ -232,5 +232,11 @@
         "realmDomainComponent": "oraclecloud.com", 
         "regionIdentifier": "af-johannesburg-1", 
         "realmKey": "oc1"
+    }, 
+    {
+        "regionKey": "mct", 
+        "realmDomainComponent": "oraclecloud9.com", 
+        "regionIdentifier": "me-dcc-muscat-1", 
+        "realmKey": "oc9"
     }
 ]

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateNodePoolNodeConfigDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateNodePoolNodeConfigDetails.java
@@ -44,6 +44,24 @@ public class CreateNodePoolNodeConfigDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+        private String kmsKeyId;
+
+        public Builder kmsKeyId(String kmsKeyId) {
+            this.kmsKeyId = kmsKeyId;
+            this.__explicitlySet__.add("kmsKeyId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
+        private Boolean isPvEncryptionInTransitEnabled;
+
+        public Builder isPvEncryptionInTransitEnabled(Boolean isPvEncryptionInTransitEnabled) {
+            this.isPvEncryptionInTransitEnabled = isPvEncryptionInTransitEnabled;
+            this.__explicitlySet__.add("isPvEncryptionInTransitEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("placementConfigs")
         private java.util.List<NodePoolPlacementConfigDetails> placementConfigs;
 
@@ -59,7 +77,12 @@ public class CreateNodePoolNodeConfigDetails {
 
         public CreateNodePoolNodeConfigDetails build() {
             CreateNodePoolNodeConfigDetails __instance__ =
-                    new CreateNodePoolNodeConfigDetails(size, nsgIds, placementConfigs);
+                    new CreateNodePoolNodeConfigDetails(
+                            size,
+                            nsgIds,
+                            kmsKeyId,
+                            isPvEncryptionInTransitEnabled,
+                            placementConfigs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -69,6 +92,8 @@ public class CreateNodePoolNodeConfigDetails {
             Builder copiedBuilder =
                     size(o.getSize())
                             .nsgIds(o.getNsgIds())
+                            .kmsKeyId(o.getKmsKeyId())
+                            .isPvEncryptionInTransitEnabled(o.getIsPvEncryptionInTransitEnabled())
                             .placementConfigs(o.getPlacementConfigs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -96,6 +121,18 @@ public class CreateNodePoolNodeConfigDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
     java.util.List<String> nsgIds;
+
+    /**
+     * The OCID of the Key Management Service key assigned to the boot volume.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+    String kmsKeyId;
+
+    /**
+     * Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
+    Boolean isPvEncryptionInTransitEnabled;
 
     /**
      * The placement configurations for the node pool. Provide one placement

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/KubernetesNetworkConfig.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/KubernetesNetworkConfig.java
@@ -71,13 +71,13 @@ public class KubernetesNetworkConfig {
     }
 
     /**
-     * The CIDR block for Kubernetes pods.
+     * The CIDR block for Kubernetes pods. Optional, defaults to 10.244.0.0/16.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("podsCidr")
     String podsCidr;
 
     /**
-     * The CIDR block for Kubernetes services.
+     * The CIDR block for Kubernetes services. Optional, defaults to 10.96.0.0/16.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("servicesCidr")
     String servicesCidr;

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodePoolNodeConfigDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/NodePoolNodeConfigDetails.java
@@ -44,6 +44,24 @@ public class NodePoolNodeConfigDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+        private String kmsKeyId;
+
+        public Builder kmsKeyId(String kmsKeyId) {
+            this.kmsKeyId = kmsKeyId;
+            this.__explicitlySet__.add("kmsKeyId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
+        private Boolean isPvEncryptionInTransitEnabled;
+
+        public Builder isPvEncryptionInTransitEnabled(Boolean isPvEncryptionInTransitEnabled) {
+            this.isPvEncryptionInTransitEnabled = isPvEncryptionInTransitEnabled;
+            this.__explicitlySet__.add("isPvEncryptionInTransitEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("placementConfigs")
         private java.util.List<NodePoolPlacementConfigDetails> placementConfigs;
 
@@ -59,7 +77,12 @@ public class NodePoolNodeConfigDetails {
 
         public NodePoolNodeConfigDetails build() {
             NodePoolNodeConfigDetails __instance__ =
-                    new NodePoolNodeConfigDetails(size, nsgIds, placementConfigs);
+                    new NodePoolNodeConfigDetails(
+                            size,
+                            nsgIds,
+                            kmsKeyId,
+                            isPvEncryptionInTransitEnabled,
+                            placementConfigs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -69,6 +92,8 @@ public class NodePoolNodeConfigDetails {
             Builder copiedBuilder =
                     size(o.getSize())
                             .nsgIds(o.getNsgIds())
+                            .kmsKeyId(o.getKmsKeyId())
+                            .isPvEncryptionInTransitEnabled(o.getIsPvEncryptionInTransitEnabled())
                             .placementConfigs(o.getPlacementConfigs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -96,6 +121,18 @@ public class NodePoolNodeConfigDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
     java.util.List<String> nsgIds;
+
+    /**
+     * The OCID of the Key Management Service key assigned to the boot volume.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+    String kmsKeyId;
+
+    /**
+     * Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
+    Boolean isPvEncryptionInTransitEnabled;
 
     /**
      * The placement configurations for the node pool. Provide one placement

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/UpdateNodePoolNodeConfigDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/UpdateNodePoolNodeConfigDetails.java
@@ -44,6 +44,24 @@ public class UpdateNodePoolNodeConfigDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+        private String kmsKeyId;
+
+        public Builder kmsKeyId(String kmsKeyId) {
+            this.kmsKeyId = kmsKeyId;
+            this.__explicitlySet__.add("kmsKeyId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
+        private Boolean isPvEncryptionInTransitEnabled;
+
+        public Builder isPvEncryptionInTransitEnabled(Boolean isPvEncryptionInTransitEnabled) {
+            this.isPvEncryptionInTransitEnabled = isPvEncryptionInTransitEnabled;
+            this.__explicitlySet__.add("isPvEncryptionInTransitEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("placementConfigs")
         private java.util.List<NodePoolPlacementConfigDetails> placementConfigs;
 
@@ -59,7 +77,12 @@ public class UpdateNodePoolNodeConfigDetails {
 
         public UpdateNodePoolNodeConfigDetails build() {
             UpdateNodePoolNodeConfigDetails __instance__ =
-                    new UpdateNodePoolNodeConfigDetails(size, nsgIds, placementConfigs);
+                    new UpdateNodePoolNodeConfigDetails(
+                            size,
+                            nsgIds,
+                            kmsKeyId,
+                            isPvEncryptionInTransitEnabled,
+                            placementConfigs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -69,6 +92,8 @@ public class UpdateNodePoolNodeConfigDetails {
             Builder copiedBuilder =
                     size(o.getSize())
                             .nsgIds(o.getNsgIds())
+                            .kmsKeyId(o.getKmsKeyId())
+                            .isPvEncryptionInTransitEnabled(o.getIsPvEncryptionInTransitEnabled())
                             .placementConfigs(o.getPlacementConfigs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -96,6 +121,18 @@ public class UpdateNodePoolNodeConfigDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nsgIds")
     java.util.List<String> nsgIds;
+
+    /**
+     * The OCID of the Key Management Service key assigned to the boot volume.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+    String kmsKeyId;
+
+    /**
+     * Whether to enable in-transit encryption for the data volume's paravirtualized attachment. This field applies to both block volumes and boot volumes. The default value is false.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isPvEncryptionInTransitEnabled")
+    Boolean isPvEncryptionInTransitEnabled;
 
     /**
      * The placement configurations for the node pool. Provide one placement

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/Blockstorage.java
@@ -624,6 +624,18 @@ public interface Blockstorage extends AutoCloseable {
     GetVolumeGroupBackupResponse getVolumeGroupBackup(GetVolumeGroupBackupRequest request);
 
     /**
+     * Gets information for the specified volume group replica.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/core/GetVolumeGroupReplicaExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetVolumeGroupReplica API.
+     */
+    GetVolumeGroupReplicaResponse getVolumeGroupReplica(GetVolumeGroupReplicaRequest request);
+
+    /**
      * Gets the Key Management encryption key assigned to the specified volume.
      *
      * @param request The request object containing the details to send
@@ -731,6 +743,20 @@ public interface Blockstorage extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/core/ListVolumeGroupBackupsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListVolumeGroupBackups API.
      */
     ListVolumeGroupBackupsResponse listVolumeGroupBackups(ListVolumeGroupBackupsRequest request);
+
+    /**
+     * Lists the volume group replicas in the specified compartment. You can filter the results by volume group.
+     * For more information, see [Volume Group Replication](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/volumegroupreplication.htm).
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/core/ListVolumeGroupReplicasExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListVolumeGroupReplicas API.
+     */
+    ListVolumeGroupReplicasResponse listVolumeGroupReplicas(ListVolumeGroupReplicasRequest request);
 
     /**
      * Lists the volume groups in the specified compartment and availability domain.

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsync.java
@@ -773,6 +773,22 @@ public interface BlockstorageAsync extends AutoCloseable {
                     handler);
 
     /**
+     * Gets information for the specified volume group replica.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetVolumeGroupReplicaResponse> getVolumeGroupReplica(
+            GetVolumeGroupReplicaRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>
+                    handler);
+
+    /**
      * Gets the Key Management encryption key assigned to the specified volume.
      *
      *
@@ -908,6 +924,24 @@ public interface BlockstorageAsync extends AutoCloseable {
             ListVolumeGroupBackupsRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ListVolumeGroupBackupsRequest, ListVolumeGroupBackupsResponse>
+                    handler);
+
+    /**
+     * Lists the volume group replicas in the specified compartment. You can filter the results by volume group.
+     * For more information, see [Volume Group Replication](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/volumegroupreplication.htm).
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListVolumeGroupReplicasResponse> listVolumeGroupReplicas(
+            ListVolumeGroupReplicasRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListVolumeGroupReplicasRequest, ListVolumeGroupReplicasResponse>
                     handler);
 
     /**

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsyncClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageAsyncClient.java
@@ -2077,6 +2077,47 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<GetVolumeGroupReplicaResponse> getVolumeGroupReplica(
+            GetVolumeGroupReplicaRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>
+                    handler) {
+        LOG.trace("Called async getVolumeGroupReplica");
+        final GetVolumeGroupReplicaRequest interceptedRequest =
+                GetVolumeGroupReplicaConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVolumeGroupReplicaConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, GetVolumeGroupReplicaResponse>
+                transformer = GetVolumeGroupReplicaConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>,
+                        java.util.concurrent.Future<GetVolumeGroupReplicaResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<GetVolumeKmsKeyResponse> getVolumeKmsKey(
             GetVolumeKmsKeyRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -2386,6 +2427,47 @@ public class BlockstorageAsyncClient implements BlockstorageAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListVolumeGroupBackupsRequest, ListVolumeGroupBackupsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListVolumeGroupReplicasResponse> listVolumeGroupReplicas(
+            ListVolumeGroupReplicasRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListVolumeGroupReplicasRequest, ListVolumeGroupReplicasResponse>
+                    handler) {
+        LOG.trace("Called async listVolumeGroupReplicas");
+        final ListVolumeGroupReplicasRequest interceptedRequest =
+                ListVolumeGroupReplicasConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVolumeGroupReplicasConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListVolumeGroupReplicasResponse>
+                transformer = ListVolumeGroupReplicasConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListVolumeGroupReplicasRequest, ListVolumeGroupReplicasResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListVolumeGroupReplicasRequest, ListVolumeGroupReplicasResponse>,
+                        java.util.concurrent.Future<ListVolumeGroupReplicasResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListVolumeGroupReplicasRequest, ListVolumeGroupReplicasResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageClient.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageClient.java
@@ -1716,6 +1716,36 @@ public class BlockstorageClient implements Blockstorage {
     }
 
     @Override
+    public GetVolumeGroupReplicaResponse getVolumeGroupReplica(
+            GetVolumeGroupReplicaRequest request) {
+        LOG.trace("Called getVolumeGroupReplica");
+        final GetVolumeGroupReplicaRequest interceptedRequest =
+                GetVolumeGroupReplicaConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVolumeGroupReplicaConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetVolumeGroupReplicaResponse>
+                transformer = GetVolumeGroupReplicaConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public GetVolumeKmsKeyResponse getVolumeKmsKey(GetVolumeKmsKeyRequest request) {
         LOG.trace("Called getVolumeKmsKey");
         final GetVolumeKmsKeyRequest interceptedRequest =
@@ -1932,6 +1962,36 @@ public class BlockstorageClient implements Blockstorage {
                 ListVolumeGroupBackupsConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListVolumeGroupBackupsResponse>
                 transformer = ListVolumeGroupBackupsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListVolumeGroupReplicasResponse listVolumeGroupReplicas(
+            ListVolumeGroupReplicasRequest request) {
+        LOG.trace("Called listVolumeGroupReplicas");
+        final ListVolumeGroupReplicasRequest interceptedRequest =
+                ListVolumeGroupReplicasConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVolumeGroupReplicasConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListVolumeGroupReplicasResponse>
+                transformer = ListVolumeGroupReplicasConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstoragePaginators.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstoragePaginators.java
@@ -957,6 +957,121 @@ public class BlockstoragePaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listVolumeGroupReplicas operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListVolumeGroupReplicasResponse> listVolumeGroupReplicasResponseIterator(
+            final ListVolumeGroupReplicasRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListVolumeGroupReplicasRequest.Builder, ListVolumeGroupReplicasRequest,
+                ListVolumeGroupReplicasResponse>(
+                new com.google.common.base.Supplier<ListVolumeGroupReplicasRequest.Builder>() {
+                    @Override
+                    public ListVolumeGroupReplicasRequest.Builder get() {
+                        return ListVolumeGroupReplicasRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVolumeGroupReplicasResponse, String>() {
+                    @Override
+                    public String apply(ListVolumeGroupReplicasResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVolumeGroupReplicasRequest.Builder>,
+                        ListVolumeGroupReplicasRequest>() {
+                    @Override
+                    public ListVolumeGroupReplicasRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVolumeGroupReplicasRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVolumeGroupReplicasRequest, ListVolumeGroupReplicasResponse>() {
+                    @Override
+                    public ListVolumeGroupReplicasResponse apply(
+                            ListVolumeGroupReplicasRequest request) {
+                        return client.listVolumeGroupReplicas(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.core.model.VolumeGroupReplica} objects
+     * contained in responses from the listVolumeGroupReplicas operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.core.model.VolumeGroupReplica} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.core.model.VolumeGroupReplica>
+            listVolumeGroupReplicasRecordIterator(final ListVolumeGroupReplicasRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListVolumeGroupReplicasRequest.Builder, ListVolumeGroupReplicasRequest,
+                ListVolumeGroupReplicasResponse, com.oracle.bmc.core.model.VolumeGroupReplica>(
+                new com.google.common.base.Supplier<ListVolumeGroupReplicasRequest.Builder>() {
+                    @Override
+                    public ListVolumeGroupReplicasRequest.Builder get() {
+                        return ListVolumeGroupReplicasRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVolumeGroupReplicasResponse, String>() {
+                    @Override
+                    public String apply(ListVolumeGroupReplicasResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVolumeGroupReplicasRequest.Builder>,
+                        ListVolumeGroupReplicasRequest>() {
+                    @Override
+                    public ListVolumeGroupReplicasRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVolumeGroupReplicasRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVolumeGroupReplicasRequest, ListVolumeGroupReplicasResponse>() {
+                    @Override
+                    public ListVolumeGroupReplicasResponse apply(
+                            ListVolumeGroupReplicasRequest request) {
+                        return client.listVolumeGroupReplicas(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVolumeGroupReplicasResponse,
+                        java.util.List<com.oracle.bmc.core.model.VolumeGroupReplica>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.core.model.VolumeGroupReplica> apply(
+                            ListVolumeGroupReplicasResponse response) {
+                        return response.getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listVolumeGroups operation. This iterable
      * will fetch more data from the server as needed.
      *

--- a/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageWaiters.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/BlockstorageWaiters.java
@@ -959,4 +959,109 @@ public class BlockstorageWaiters {
                                         .Terminated)),
                 request);
     }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>
+            forVolumeGroupReplica(
+                    GetVolumeGroupReplicaRequest request,
+                    com.oracle.bmc.core.model.VolumeGroupReplica.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forVolumeGroupReplica(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>
+            forVolumeGroupReplica(
+                    GetVolumeGroupReplicaRequest request,
+                    com.oracle.bmc.core.model.VolumeGroupReplica.LifecycleState targetState,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forVolumeGroupReplica(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>
+            forVolumeGroupReplica(
+                    GetVolumeGroupReplicaRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+                    com.oracle.bmc.core.model.VolumeGroupReplica.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forVolumeGroupReplica(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for VolumeGroupReplica.
+    private com.oracle.bmc.waiter.Waiter<
+                    GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>
+            forVolumeGroupReplica(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetVolumeGroupReplicaRequest request,
+                    final com.oracle.bmc.core.model.VolumeGroupReplica.LifecycleState...
+                            targetStates) {
+        final java.util.Set<com.oracle.bmc.core.model.VolumeGroupReplica.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetVolumeGroupReplicaRequest, GetVolumeGroupReplicaResponse>() {
+                            @Override
+                            public GetVolumeGroupReplicaResponse apply(
+                                    GetVolumeGroupReplicaRequest request) {
+                                return client.getVolumeGroupReplica(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetVolumeGroupReplicaResponse>() {
+                            @Override
+                            public boolean apply(GetVolumeGroupReplicaResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getVolumeGroupReplica().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.core.model.VolumeGroupReplica.LifecycleState
+                                        .Terminated)),
+                request);
+    }
 }

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetVolumeGroupReplicaConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/GetVolumeGroupReplicaConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class GetVolumeGroupReplicaConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.GetVolumeGroupReplicaRequest interceptRequest(
+            com.oracle.bmc.core.requests.GetVolumeGroupReplicaRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.GetVolumeGroupReplicaRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getVolumeGroupReplicaId(), "volumeGroupReplicaId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("volumeGroupReplicas")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVolumeGroupReplicaId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.GetVolumeGroupReplicaResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.GetVolumeGroupReplicaResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses.GetVolumeGroupReplicaResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses.GetVolumeGroupReplicaResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.GetVolumeGroupReplicaResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.core.model
+                                                                .VolumeGroupReplica>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.core.model.VolumeGroupReplica
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.core.model.VolumeGroupReplica>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses.GetVolumeGroupReplicaResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .GetVolumeGroupReplicaResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.volumeGroupReplica(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses.GetVolumeGroupReplicaResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListVolumeGroupReplicasConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/ListVolumeGroupReplicasConverter.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.core.model.*;
+import com.oracle.bmc.core.requests.*;
+import com.oracle.bmc.core.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ListVolumeGroupReplicasConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.core.requests.ListVolumeGroupReplicasRequest interceptRequest(
+            com.oracle.bmc.core.requests.ListVolumeGroupReplicasRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.core.requests.ListVolumeGroupReplicasRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getAvailabilityDomain(), "availabilityDomain is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20160918").path("volumeGroupReplicas");
+
+        target =
+                target.queryParam(
+                        "availabilityDomain",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getAvailabilityDomain()));
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.core.responses.ListVolumeGroupReplicasResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.core.responses.ListVolumeGroupReplicasResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.core.responses.ListVolumeGroupReplicasResponse>() {
+                            @Override
+                            public com.oracle.bmc.core.responses.ListVolumeGroupReplicasResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.core.responses.ListVolumeGroupReplicasResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        java.util.List<
+                                                                com.oracle.bmc.core.model
+                                                                        .VolumeGroupReplica>>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        new javax.ws.rs.core.GenericType<
+                                                                java.util.List<
+                                                                        com.oracle.bmc.core.model
+                                                                                .VolumeGroupReplica>>() {});
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                java.util.List<
+                                                        com.oracle.bmc.core.model
+                                                                .VolumeGroupReplica>>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.core.responses.ListVolumeGroupReplicasResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.core.responses
+                                                        .ListVolumeGroupReplicasResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.items(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.core.responses.ListVolumeGroupReplicasResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateVolumeGroupConverter.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/internal/http/UpdateVolumeGroupConverter.java
@@ -39,6 +39,14 @@ public class UpdateVolumeGroupConverter {
                                 com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
                                         request.getVolumeGroupId()));
 
+        if (request.getPreserveVolumeReplica() != null) {
+            target =
+                    target.queryParam(
+                            "preserveVolumeReplica",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPreserveVolumeReplica()));
+        }
+
         com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
 
         ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BlockVolumeReplica.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BlockVolumeReplica.java
@@ -145,6 +145,15 @@ public class BlockVolumeReplica {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicaId")
+        private String volumeGroupReplicaId;
+
+        public Builder volumeGroupReplicaId(String volumeGroupReplicaId) {
+            this.volumeGroupReplicaId = volumeGroupReplicaId;
+            this.__explicitlySet__.add("volumeGroupReplicaId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -162,7 +171,8 @@ public class BlockVolumeReplica {
                             timeCreated,
                             timeLastSynced,
                             blockVolumeId,
-                            totalDataTransferredInGBs);
+                            totalDataTransferredInGBs,
+                            volumeGroupReplicaId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -181,7 +191,8 @@ public class BlockVolumeReplica {
                             .timeCreated(o.getTimeCreated())
                             .timeLastSynced(o.getTimeLastSynced())
                             .blockVolumeId(o.getBlockVolumeId())
-                            .totalDataTransferredInGBs(o.getTotalDataTransferredInGBs());
+                            .totalDataTransferredInGBs(o.getTotalDataTransferredInGBs())
+                            .volumeGroupReplicaId(o.getVolumeGroupReplicaId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -334,6 +345,13 @@ public class BlockVolumeReplica {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("totalDataTransferredInGBs")
     Long totalDataTransferredInGBs;
+
+    /**
+     * The OCID of the volume group replica.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicaId")
+    String volumeGroupReplicaId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolumeReplica.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/BootVolumeReplica.java
@@ -154,6 +154,15 @@ public class BootVolumeReplica {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicaId")
+        private String volumeGroupReplicaId;
+
+        public Builder volumeGroupReplicaId(String volumeGroupReplicaId) {
+            this.volumeGroupReplicaId = volumeGroupReplicaId;
+            this.__explicitlySet__.add("volumeGroupReplicaId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -172,7 +181,8 @@ public class BootVolumeReplica {
                             timeLastSynced,
                             bootVolumeId,
                             imageId,
-                            totalDataTransferredInGBs);
+                            totalDataTransferredInGBs,
+                            volumeGroupReplicaId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -192,7 +202,8 @@ public class BootVolumeReplica {
                             .timeLastSynced(o.getTimeLastSynced())
                             .bootVolumeId(o.getBootVolumeId())
                             .imageId(o.getImageId())
-                            .totalDataTransferredInGBs(o.getTotalDataTransferredInGBs());
+                            .totalDataTransferredInGBs(o.getTotalDataTransferredInGBs())
+                            .volumeGroupReplicaId(o.getVolumeGroupReplicaId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -352,6 +363,13 @@ public class BootVolumeReplica {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("totalDataTransferredInGBs")
     Long totalDataTransferredInGBs;
+
+    /**
+     * The OCID of the volume group replica.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicaId")
+    String volumeGroupReplicaId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeGroupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/CreateVolumeGroupDetails.java
@@ -90,6 +90,16 @@ public class CreateVolumeGroupDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicas")
+        private java.util.List<VolumeGroupReplicaDetails> volumeGroupReplicas;
+
+        public Builder volumeGroupReplicas(
+                java.util.List<VolumeGroupReplicaDetails> volumeGroupReplicas) {
+            this.volumeGroupReplicas = volumeGroupReplicas;
+            this.__explicitlySet__.add("volumeGroupReplicas");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -102,7 +112,8 @@ public class CreateVolumeGroupDetails {
                             definedTags,
                             displayName,
                             freeformTags,
-                            sourceDetails);
+                            sourceDetails,
+                            volumeGroupReplicas);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -116,7 +127,8 @@ public class CreateVolumeGroupDetails {
                             .definedTags(o.getDefinedTags())
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
-                            .sourceDetails(o.getSourceDetails());
+                            .sourceDetails(o.getSourceDetails())
+                            .volumeGroupReplicas(o.getVolumeGroupReplicas());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -180,6 +192,14 @@ public class CreateVolumeGroupDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
     VolumeGroupSourceDetails sourceDetails;
+
+    /**
+     * The list of volume group replicas that this volume group will be enabled to have
+     * in the specified destination availability domains.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicas")
+    java.util.List<VolumeGroupReplicaDetails> volumeGroupReplicas;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/MemberReplica.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/MemberReplica.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * OCIDs for the volume replicas in this volume group replica.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = MemberReplica.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MemberReplica {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("volumeReplicaId")
+        private String volumeReplicaId;
+
+        public Builder volumeReplicaId(String volumeReplicaId) {
+            this.volumeReplicaId = volumeReplicaId;
+            this.__explicitlySet__.add("volumeReplicaId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MemberReplica build() {
+            MemberReplica __instance__ = new MemberReplica(volumeReplicaId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MemberReplica o) {
+            Builder copiedBuilder = volumeReplicaId(o.getVolumeReplicaId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The volume replica ID.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("volumeReplicaId")
+    String volumeReplicaId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeGroupDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/UpdateVolumeGroupDetails.java
@@ -63,12 +63,23 @@ public class UpdateVolumeGroupDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicas")
+        private java.util.List<VolumeGroupReplicaDetails> volumeGroupReplicas;
+
+        public Builder volumeGroupReplicas(
+                java.util.List<VolumeGroupReplicaDetails> volumeGroupReplicas) {
+            this.volumeGroupReplicas = volumeGroupReplicas;
+            this.__explicitlySet__.add("volumeGroupReplicas");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateVolumeGroupDetails build() {
             UpdateVolumeGroupDetails __instance__ =
-                    new UpdateVolumeGroupDetails(definedTags, displayName, freeformTags, volumeIds);
+                    new UpdateVolumeGroupDetails(
+                            definedTags, displayName, freeformTags, volumeIds, volumeGroupReplicas);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -79,7 +90,8 @@ public class UpdateVolumeGroupDetails {
                     definedTags(o.getDefinedTags())
                             .displayName(o.getDisplayName())
                             .freeformTags(o.getFreeformTags())
-                            .volumeIds(o.getVolumeIds());
+                            .volumeIds(o.getVolumeIds())
+                            .volumeGroupReplicas(o.getVolumeGroupReplicas());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -126,6 +138,14 @@ public class UpdateVolumeGroupDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("volumeIds")
     java.util.List<String> volumeIds;
+
+    /**
+     * The list of volume group replicas that this volume group will be updated to have
+     * in the specified destination availability domains.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicas")
+    java.util.List<VolumeGroupReplicaDetails> volumeGroupReplicas;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroup.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroup.java
@@ -147,6 +147,16 @@ public class VolumeGroup {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicas")
+        private java.util.List<VolumeGroupReplicaInfo> volumeGroupReplicas;
+
+        public Builder volumeGroupReplicas(
+                java.util.List<VolumeGroupReplicaInfo> volumeGroupReplicas) {
+            this.volumeGroupReplicas = volumeGroupReplicas;
+            this.__explicitlySet__.add("volumeGroupReplicas");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -165,7 +175,8 @@ public class VolumeGroup {
                             sourceDetails,
                             timeCreated,
                             volumeIds,
-                            isHydrated);
+                            isHydrated,
+                            volumeGroupReplicas);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -185,7 +196,8 @@ public class VolumeGroup {
                             .sourceDetails(o.getSourceDetails())
                             .timeCreated(o.getTimeCreated())
                             .volumeIds(o.getVolumeIds())
-                            .isHydrated(o.getIsHydrated());
+                            .isHydrated(o.getIsHydrated())
+                            .volumeGroupReplicas(o.getVolumeGroupReplicas());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -333,6 +345,12 @@ public class VolumeGroup {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isHydrated")
     Boolean isHydrated;
+
+    /**
+     * The list of volume group replicas of this volume group.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicas")
+    java.util.List<VolumeGroupReplicaInfo> volumeGroupReplicas;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupReplica.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupReplica.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * An asynchronous replica of a volume group that can then be used to create a new volume group
+ * or recover a volume group. For more information, see [Volume Group Replication](https://docs.cloud.oracle.com/iaas/Content/Block/Concepts/volumegroupreplication.htm).
+ * <p>
+ * To use any of the API operations, you must be authorized in an IAM policy. If you're not authorized,
+ * talk to an administrator. If you're an administrator who needs to write policies to give users access, see
+ * [Getting Started with Policies](https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/policygetstarted.htm).
+ * <p>
+ **Warning:** Oracle recommends that you avoid using any confidential information when you
+ * supply string values using the API.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VolumeGroupReplica.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VolumeGroupReplica {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+        private String availabilityDomain;
+
+        public Builder availabilityDomain(String availabilityDomain) {
+            this.availabilityDomain = availabilityDomain;
+            this.__explicitlySet__.add("availabilityDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sizeInGBs")
+        private Long sizeInGBs;
+
+        public Builder sizeInGBs(Long sizeInGBs) {
+            this.sizeInGBs = sizeInGBs;
+            this.__explicitlySet__.add("sizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupId")
+        private String volumeGroupId;
+
+        public Builder volumeGroupId(String volumeGroupId) {
+            this.volumeGroupId = volumeGroupId;
+            this.__explicitlySet__.add("volumeGroupId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("memberReplicas")
+        private java.util.List<MemberReplica> memberReplicas;
+
+        public Builder memberReplicas(java.util.List<MemberReplica> memberReplicas) {
+            this.memberReplicas = memberReplicas;
+            this.__explicitlySet__.add("memberReplicas");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeLastSynced")
+        private java.util.Date timeLastSynced;
+
+        public Builder timeLastSynced(java.util.Date timeLastSynced) {
+            this.timeLastSynced = timeLastSynced;
+            this.__explicitlySet__.add("timeLastSynced");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VolumeGroupReplica build() {
+            VolumeGroupReplica __instance__ =
+                    new VolumeGroupReplica(
+                            availabilityDomain,
+                            compartmentId,
+                            definedTags,
+                            displayName,
+                            freeformTags,
+                            id,
+                            lifecycleState,
+                            sizeInGBs,
+                            volumeGroupId,
+                            timeCreated,
+                            memberReplicas,
+                            timeLastSynced);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VolumeGroupReplica o) {
+            Builder copiedBuilder =
+                    availabilityDomain(o.getAvailabilityDomain())
+                            .compartmentId(o.getCompartmentId())
+                            .definedTags(o.getDefinedTags())
+                            .displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .id(o.getId())
+                            .lifecycleState(o.getLifecycleState())
+                            .sizeInGBs(o.getSizeInGBs())
+                            .volumeGroupId(o.getVolumeGroupId())
+                            .timeCreated(o.getTimeCreated())
+                            .memberReplicas(o.getMemberReplicas())
+                            .timeLastSynced(o.getTimeLastSynced());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The availability domain of the volume group replica.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+    String availabilityDomain;
+
+    /**
+     * The OCID of the compartment that contains the volume group replica.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a
+     * namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: {@code {"Operations": {"CostCenter": "42"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Free-form tags for this resource. Each tag is a simple key-value pair with no
+     * predefined name, type, or namespace. For more information, see [Resource Tags](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/resourcetags.htm).
+     * <p>
+     * Example: {@code {"Department": "Finance"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * The OCID for the volume group replica.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+    /**
+     * The current state of a volume group.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Provisioning("PROVISIONING"),
+        Available("AVAILABLE"),
+        Activating("ACTIVATING"),
+        Terminating("TERMINATING"),
+        Terminated("TERMINATED"),
+        Faulty("FAULTY"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of a volume group.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * The aggregate size of the volume group replica in GBs.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sizeInGBs")
+    Long sizeInGBs;
+
+    /**
+     * The OCID of the source volume group.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupId")
+    String volumeGroupId;
+
+    /**
+     * The date and time the volume group replica was created. Format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * Volume replicas within this volume group replica.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("memberReplicas")
+    java.util.List<MemberReplica> memberReplicas;
+
+    /**
+     * The date and time the volume group replica was last synced from the source volume group.
+     * Format defined by [RFC3339](https://tools.ietf.org/html/rfc3339).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeLastSynced")
+    java.util.Date timeLastSynced;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupReplicaDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupReplicaDetails.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Contains the details for the volume group replica.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VolumeGroupReplicaDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VolumeGroupReplicaDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+        private String availabilityDomain;
+
+        public Builder availabilityDomain(String availabilityDomain) {
+            this.availabilityDomain = availabilityDomain;
+            this.__explicitlySet__.add("availabilityDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VolumeGroupReplicaDetails build() {
+            VolumeGroupReplicaDetails __instance__ =
+                    new VolumeGroupReplicaDetails(displayName, availabilityDomain);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VolumeGroupReplicaDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName()).availabilityDomain(o.getAvailabilityDomain());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The availability domain of the volume group replica.
+     * <p>
+     * Example: {@code Uocm:PHX-AD-1}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+    String availabilityDomain;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupReplicaInfo.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupReplicaInfo.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Information about the volume group replica in the destination availability domain.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VolumeGroupReplicaInfo.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VolumeGroupReplicaInfo {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicaId")
+        private String volumeGroupReplicaId;
+
+        public Builder volumeGroupReplicaId(String volumeGroupReplicaId) {
+            this.volumeGroupReplicaId = volumeGroupReplicaId;
+            this.__explicitlySet__.add("volumeGroupReplicaId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+        private String availabilityDomain;
+
+        public Builder availabilityDomain(String availabilityDomain) {
+            this.availabilityDomain = availabilityDomain;
+            this.__explicitlySet__.add("availabilityDomain");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VolumeGroupReplicaInfo build() {
+            VolumeGroupReplicaInfo __instance__ =
+                    new VolumeGroupReplicaInfo(
+                            displayName, volumeGroupReplicaId, availabilityDomain);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VolumeGroupReplicaInfo o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .volumeGroupReplicaId(o.getVolumeGroupReplicaId())
+                            .availabilityDomain(o.getAvailabilityDomain());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * Avoid entering confidential information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * The volume group replica's Oracle ID (OCID).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicaId")
+    String volumeGroupReplicaId;
+
+    /**
+     * The availability domain of the boot volume replica replica.
+     * <p>
+     * Example: {@code Uocm:PHX-AD-1}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("availabilityDomain")
+    String availabilityDomain;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupSourceDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupSourceDetails.java
@@ -29,6 +29,10 @@ package com.oracle.bmc.core.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = VolumeGroupSourceFromVolumeGroupReplicaDetails.class,
+        name = "volumeGroupReplicaId"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = VolumeGroupSourceFromVolumeGroupDetails.class,
         name = "volumeGroupId"
     ),

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupSourceFromVolumeGroupReplicaDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VolumeGroupSourceFromVolumeGroupReplicaDetails.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * Specifies the source volume replica which the volume group will be created from.
+ * The volume group replica shoulbe be in the same availability domain as the volume group.
+ * Only one volume group can be created from a volume group replica at the same time.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VolumeGroupSourceFromVolumeGroupReplicaDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VolumeGroupSourceFromVolumeGroupReplicaDetails extends VolumeGroupSourceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicaId")
+        private String volumeGroupReplicaId;
+
+        public Builder volumeGroupReplicaId(String volumeGroupReplicaId) {
+            this.volumeGroupReplicaId = volumeGroupReplicaId;
+            this.__explicitlySet__.add("volumeGroupReplicaId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VolumeGroupSourceFromVolumeGroupReplicaDetails build() {
+            VolumeGroupSourceFromVolumeGroupReplicaDetails __instance__ =
+                    new VolumeGroupSourceFromVolumeGroupReplicaDetails(volumeGroupReplicaId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VolumeGroupSourceFromVolumeGroupReplicaDetails o) {
+            Builder copiedBuilder = volumeGroupReplicaId(o.getVolumeGroupReplicaId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public VolumeGroupSourceFromVolumeGroupReplicaDetails(String volumeGroupReplicaId) {
+        super();
+        this.volumeGroupReplicaId = volumeGroupReplicaId;
+    }
+
+    /**
+     * The OCID of the volume group replica.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("volumeGroupReplicaId")
+    String volumeGroupReplicaId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVolumeGroupReplicaRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/GetVolumeGroupReplicaRequest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/core/GetVolumeGroupReplicaExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetVolumeGroupReplicaRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetVolumeGroupReplicaRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the volume replica group.
+     */
+    private String volumeGroupReplicaId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetVolumeGroupReplicaRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVolumeGroupReplicaRequest o) {
+            volumeGroupReplicaId(o.getVolumeGroupReplicaId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetVolumeGroupReplicaRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetVolumeGroupReplicaRequest
+         */
+        public GetVolumeGroupReplicaRequest build() {
+            GetVolumeGroupReplicaRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListVolumeGroupReplicasRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/ListVolumeGroupReplicasRequest.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.requests;
+
+import com.oracle.bmc.core.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/core/ListVolumeGroupReplicasExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListVolumeGroupReplicasRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListVolumeGroupReplicasRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The name of the availability domain.
+     * <p>
+     * Example: {@code Uocm:PHX-AD-1}
+     *
+     */
+    private String availabilityDomain;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the compartment.
+     */
+    private String compartmentId;
+
+    /**
+     * For list pagination. The maximum number of results per page, or items to return in a paginated
+     * "List" call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     * <p>
+     * Example: {@code 50}
+     *
+     */
+    private Integer limit;
+
+    /**
+     * For list pagination. The value of the {@code opc-next-page} response header from the previous "List"
+     * call. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String page;
+
+    /**
+     * A filter to return only resources that match the given display name exactly.
+     *
+     */
+    private String displayName;
+
+    /**
+     * The field to sort by. You can provide one sort order ({@code sortOrder}). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some "List" operations (for example, {@code ListInstances}) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these "List" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. You can provide one sort order ({@code sortOrder}). Default order for
+     * TIMECREATED is descending. Default order for DISPLAYNAME is ascending. The DISPLAYNAME
+     * sort order is case sensitive.
+     * <p>
+     **Note:** In general, some "List" operations (for example, {@code ListInstances}) let you
+     * optionally filter by availability domain if the scope of the resource type is within a
+     * single availability domain. If you call one of these "List" operations without specifying
+     * an availability domain, the resources are grouped by availability domain, then sorted.
+     *
+     **/
+    public enum SortBy {
+        Timecreated("TIMECREATED"),
+        Displayname("DISPLAYNAME"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The sort order to use, either ascending ({@code ASC}) or descending ({@code DESC}). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either ascending ({@code ASC}) or descending ({@code DESC}). The DISPLAYNAME sort order
+     * is case sensitive.
+     *
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * A filter to only return resources that match the given lifecycle state. The state value is case-insensitive.
+     *
+     */
+    private com.oracle.bmc.core.model.VolumeGroupReplica.LifecycleState lifecycleState;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListVolumeGroupReplicasRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVolumeGroupReplicasRequest o) {
+            availabilityDomain(o.getAvailabilityDomain());
+            compartmentId(o.getCompartmentId());
+            limit(o.getLimit());
+            page(o.getPage());
+            displayName(o.getDisplayName());
+            sortBy(o.getSortBy());
+            sortOrder(o.getSortOrder());
+            lifecycleState(o.getLifecycleState());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListVolumeGroupReplicasRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListVolumeGroupReplicasRequest
+         */
+        public ListVolumeGroupReplicasRequest build() {
+            ListVolumeGroupReplicasRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVolumeGroupRequest.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/requests/UpdateVolumeGroupRequest.java
@@ -40,6 +40,14 @@ public class UpdateVolumeGroupRequest
     private String ifMatch;
 
     /**
+     * Specifies whether to disable or preserve the individual volume replication when removing a volume from the
+     * replication enabled volume group. When set to {@code true}, the individual volume replica is preserved. The default
+     * value is {@code true}.
+     *
+     */
+    private Boolean preserveVolumeReplica;
+
+    /**
      * Alternative accessor for the body parameter.
      * @return body parameter
      */
@@ -87,6 +95,7 @@ public class UpdateVolumeGroupRequest
             volumeGroupId(o.getVolumeGroupId());
             updateVolumeGroupDetails(o.getUpdateVolumeGroupDetails());
             ifMatch(o.getIfMatch());
+            preserveVolumeReplica(o.getPreserveVolumeReplica());
             invocationCallback(o.getInvocationCallback());
             retryConfiguration(o.getRetryConfiguration());
             return this;

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetVolumeGroupReplicaResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/GetVolumeGroupReplicaResponse.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetVolumeGroupReplicaResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     *
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VolumeGroupReplica instance.
+     */
+    private com.oracle.bmc.core.model.VolumeGroupReplica volumeGroupReplica;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "etag",
+        "opcRequestId",
+        "volumeGroupReplica"
+    })
+    private GetVolumeGroupReplicaResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.core.model.VolumeGroupReplica volumeGroupReplica) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.volumeGroupReplica = volumeGroupReplica;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVolumeGroupReplicaResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            volumeGroupReplica(o.getVolumeGroupReplica());
+
+            return this;
+        }
+
+        public GetVolumeGroupReplicaResponse build() {
+            return new GetVolumeGroupReplicaResponse(
+                    __httpStatusCode__, etag, opcRequestId, volumeGroupReplica);
+        }
+    }
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListVolumeGroupReplicasResponse.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/responses/ListVolumeGroupReplicasResponse.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.responses;
+
+import com.oracle.bmc.core.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListVolumeGroupReplicasResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For list pagination. When this header appears in the response, additional pages
+     * of results remain. For important details about how pagination works, see
+     * [List Pagination](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/usingapi.htm#nine).
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * A list of com.oracle.bmc.core.model.VolumeGroupReplica instances.
+     */
+    private java.util.List<com.oracle.bmc.core.model.VolumeGroupReplica> items;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcNextPage",
+        "opcRequestId",
+        "items"
+    })
+    private ListVolumeGroupReplicasResponse(
+            int __httpStatusCode__,
+            String opcNextPage,
+            String opcRequestId,
+            java.util.List<com.oracle.bmc.core.model.VolumeGroupReplica> items) {
+        super(__httpStatusCode__);
+        this.opcNextPage = opcNextPage;
+        this.opcRequestId = opcRequestId;
+        this.items = items;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVolumeGroupReplicasResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcNextPage(o.getOpcNextPage());
+            opcRequestId(o.getOpcRequestId());
+            items(o.getItems());
+
+            return this;
+        }
+
+        public ListVolumeGroupReplicasResponse build() {
+            return new ListVolumeGroupReplicasResponse(
+                    __httpStatusCode__, opcNextPage, opcRequestId, items);
+        }
+    }
+}

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
@@ -3268,6 +3268,21 @@ public interface Database extends AutoCloseable {
             UpdateAutonomousContainerDatabaseRequest request);
 
     /**
+     * Update Autonomous Data Guard association.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/UpdateAutonomousContainerDatabaseDataguardAssociationExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateAutonomousContainerDatabaseDataguardAssociation API.
+     */
+    UpdateAutonomousContainerDatabaseDataguardAssociationResponse
+            updateAutonomousContainerDatabaseDataguardAssociation(
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest request);
+
+    /**
      * Updates one or more attributes of the specified Autonomous Database. See the UpdateAutonomousDatabaseDetails resource for a full list of attributes that can be updated.
      *
      * @param request The request object containing the details to send

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
@@ -4177,6 +4177,25 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * Update Autonomous Data Guard association.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+            updateAutonomousContainerDatabaseDataguardAssociation(
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler);
+
+    /**
      * Updates one or more attributes of the specified Autonomous Database. See the UpdateAutonomousDatabaseDetails resource for a full list of attributes that can be updated.
      *
      *

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -10812,6 +10812,65 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<
+                    UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+            updateAutonomousContainerDatabaseDataguardAssociation(
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest,
+                                    UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+                            handler) {
+        LOG.trace("Called async updateAutonomousContainerDatabaseDataguardAssociation");
+        final UpdateAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                UpdateAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        UpdateAutonomousContainerDatabaseDataguardAssociationConverter
+                                .fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        UpdateAutonomousContainerDatabaseDataguardAssociationRequest,
+                        UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateAutonomousContainerDatabaseDataguardAssociationRequest,
+                                UpdateAutonomousContainerDatabaseDataguardAssociationResponse>,
+                        java.util.concurrent.Future<
+                                UpdateAutonomousContainerDatabaseDataguardAssociationResponse>>
+                futureSupplier =
+                        client.putFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest
+                                        .getUpdateAutonomousContainerDatabaseDataGuardAssociationDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest,
+                    UpdateAutonomousContainerDatabaseDataguardAssociationResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<UpdateAutonomousDatabaseResponse> updateAutonomousDatabase(
             UpdateAutonomousDatabaseRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -8033,6 +8033,48 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public UpdateAutonomousContainerDatabaseDataguardAssociationResponse
+            updateAutonomousContainerDatabaseDataguardAssociation(
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest request) {
+        LOG.trace("Called updateAutonomousContainerDatabaseDataguardAssociation");
+        final UpdateAutonomousContainerDatabaseDataguardAssociationRequest interceptedRequest =
+                UpdateAutonomousContainerDatabaseDataguardAssociationConverter.interceptRequest(
+                        request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateAutonomousContainerDatabaseDataguardAssociationConverter.fromRequest(
+                        client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        UpdateAutonomousContainerDatabaseDataguardAssociationConverter
+                                .fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest
+                                                        .getUpdateAutonomousContainerDatabaseDataGuardAssociationDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public UpdateAutonomousDatabaseResponse updateAutonomousDatabase(
             UpdateAutonomousDatabaseRequest request) {
         LOG.trace("Called updateAutonomousDatabase");

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
@@ -11109,6 +11109,73 @@ public class DatabaseWaiters {
      * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest,
+                    UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+            forUpdateAutonomousContainerDatabaseDataguardAssociation(
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest request) {
+        return forUpdateAutonomousContainerDatabaseDataguardAssociation(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest,
+                    UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+            forUpdateAutonomousContainerDatabaseDataguardAssociation(
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<
+                        UpdateAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                    @Override
+                    public UpdateAutonomousContainerDatabaseDataguardAssociationResponse call()
+                            throws Exception {
+                        final UpdateAutonomousContainerDatabaseDataguardAssociationResponse
+                                response =
+                                        client
+                                                .updateAutonomousContainerDatabaseDataguardAssociation(
+                                                        request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
                     UpdateAutonomousDatabaseRequest, UpdateAutonomousDatabaseResponse>
             forUpdateAutonomousDatabase(UpdateAutonomousDatabaseRequest request) {
         return forUpdateAutonomousDatabase(

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateAutonomousContainerDatabaseDataguardAssociationConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/UpdateAutonomousContainerDatabaseDataguardAssociationConverter.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class UpdateAutonomousContainerDatabaseDataguardAssociationConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests
+                    .UpdateAutonomousContainerDatabaseDataguardAssociationRequest
+            interceptRequest(
+                    com.oracle.bmc.database.requests
+                                    .UpdateAutonomousContainerDatabaseDataguardAssociationRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests
+                            .UpdateAutonomousContainerDatabaseDataguardAssociationRequest
+                    request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseId(),
+                "autonomousContainerDatabaseId must not be blank");
+        Validate.notBlank(
+                request.getAutonomousContainerDatabaseDataguardAssociationId(),
+                "autonomousContainerDatabaseDataguardAssociationId must not be blank");
+        Validate.notNull(
+                request.getUpdateAutonomousContainerDatabaseDataGuardAssociationDetails(),
+                "updateAutonomousContainerDatabaseDataGuardAssociationDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("autonomousContainerDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousContainerDatabaseId()))
+                        .path("autonomousContainerDatabaseDataguardAssociations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request
+                                                .getAutonomousContainerDatabaseDataguardAssociationId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses
+                            .UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses
+                                .UpdateAutonomousContainerDatabaseDataguardAssociationResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .UpdateAutonomousContainerDatabaseDataguardAssociationResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .UpdateAutonomousContainerDatabaseDataguardAssociationResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.UpdateAutonomousContainerDatabaseDataguardAssociationResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.database.model
+                                                                .AutonomousContainerDatabaseDataguardAssociation>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.database.model
+                                                                        .AutonomousContainerDatabaseDataguardAssociation
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.database.model
+                                                        .AutonomousContainerDatabaseDataguardAssociation>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses
+                                                .UpdateAutonomousContainerDatabaseDataguardAssociationResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .UpdateAutonomousContainerDatabaseDataguardAssociationResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.autonomousContainerDatabaseDataguardAssociation(
+                                        response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses
+                                                .UpdateAutonomousContainerDatabaseDataguardAssociationResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseDataguardAssociation.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousContainerDatabaseDataguardAssociation.java
@@ -138,6 +138,15 @@ public class AutonomousContainerDatabaseDataguardAssociation {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutomaticFailoverEnabled")
+        private Boolean isAutomaticFailoverEnabled;
+
+        public Builder isAutomaticFailoverEnabled(Boolean isAutomaticFailoverEnabled) {
+            this.isAutomaticFailoverEnabled = isAutomaticFailoverEnabled;
+            this.__explicitlySet__.add("isAutomaticFailoverEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("transportLag")
         private String transportLag;
 
@@ -192,6 +201,7 @@ public class AutonomousContainerDatabaseDataguardAssociation {
                             protectionMode,
                             applyLag,
                             applyRate,
+                            isAutomaticFailoverEnabled,
                             transportLag,
                             timeLastSynced,
                             timeCreated,
@@ -217,6 +227,7 @@ public class AutonomousContainerDatabaseDataguardAssociation {
                             .protectionMode(o.getProtectionMode())
                             .applyLag(o.getApplyLag())
                             .applyRate(o.getApplyRate())
+                            .isAutomaticFailoverEnabled(o.getIsAutomaticFailoverEnabled())
                             .transportLag(o.getTransportLag())
                             .timeLastSynced(o.getTimeLastSynced())
                             .timeCreated(o.getTimeCreated())
@@ -562,6 +573,13 @@ public class AutonomousContainerDatabaseDataguardAssociation {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("applyRate")
     String applyRate;
+
+    /**
+     * Indicates whether Automatic Failover is enabled for Autonomous Container Database Dataguard Association
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutomaticFailoverEnabled")
+    Boolean isAutomaticFailoverEnabled;
 
     /**
      * The approximate number of seconds of redo data not yet available on the standby Autonomous Container Database,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -706,6 +706,25 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isReconnectCloneEnabled")
+        private Boolean isReconnectCloneEnabled;
+
+        public Builder isReconnectCloneEnabled(Boolean isReconnectCloneEnabled) {
+            this.isReconnectCloneEnabled = isReconnectCloneEnabled;
+            this.__explicitlySet__.add("isReconnectCloneEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUntilReconnectCloneEnabled")
+        private java.util.Date timeUntilReconnectCloneEnabled;
+
+        public Builder timeUntilReconnectCloneEnabled(
+                java.util.Date timeUntilReconnectCloneEnabled) {
+            this.timeUntilReconnectCloneEnabled = timeUntilReconnectCloneEnabled;
+            this.__explicitlySet__.add("timeUntilReconnectCloneEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
         private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
 
@@ -807,6 +826,8 @@ public class AutonomousDatabase {
                             timeDataGuardRoleChanged,
                             peerDbIds,
                             isMtlsConnectionRequired,
+                            isReconnectCloneEnabled,
+                            timeUntilReconnectCloneEnabled,
                             autonomousMaintenanceScheduleType,
                             scheduledOperations);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -893,6 +914,8 @@ public class AutonomousDatabase {
                             .timeDataGuardRoleChanged(o.getTimeDataGuardRoleChanged())
                             .peerDbIds(o.getPeerDbIds())
                             .isMtlsConnectionRequired(o.getIsMtlsConnectionRequired())
+                            .isReconnectCloneEnabled(o.getIsReconnectCloneEnabled())
+                            .timeUntilReconnectCloneEnabled(o.getTimeUntilReconnectCloneEnabled())
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
                             .scheduledOperations(o.getScheduledOperations());
@@ -2056,6 +2079,18 @@ public class AutonomousDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isMtlsConnectionRequired")
     Boolean isMtlsConnectionRequired;
+
+    /**
+     * Indicates if the refreshable clone can be reconnected to its source database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isReconnectCloneEnabled")
+    Boolean isReconnectCloneEnabled;
+
+    /**
+     * The time and date as an RFC3339 formatted string, e.g., 2022-01-01T12:00:00.000Z, to set the limit for a refreshable clone to be reconnected to its source database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUntilReconnectCloneEnabled")
+    java.util.Date timeUntilReconnectCloneEnabled;
     /**
      * The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
      * follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseDataguardAssociation.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseDataguardAssociation.java
@@ -129,6 +129,15 @@ public class AutonomousDatabaseDataguardAssociation {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutomaticFailoverEnabled")
+        private Boolean isAutomaticFailoverEnabled;
+
+        public Builder isAutomaticFailoverEnabled(Boolean isAutomaticFailoverEnabled) {
+            this.isAutomaticFailoverEnabled = isAutomaticFailoverEnabled;
+            this.__explicitlySet__.add("isAutomaticFailoverEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("transportLag")
         private String transportLag;
 
@@ -182,6 +191,7 @@ public class AutonomousDatabaseDataguardAssociation {
                             protectionMode,
                             applyLag,
                             applyRate,
+                            isAutomaticFailoverEnabled,
                             transportLag,
                             timeLastSynced,
                             timeCreated,
@@ -205,6 +215,7 @@ public class AutonomousDatabaseDataguardAssociation {
                             .protectionMode(o.getProtectionMode())
                             .applyLag(o.getApplyLag())
                             .applyRate(o.getApplyRate())
+                            .isAutomaticFailoverEnabled(o.getIsAutomaticFailoverEnabled())
                             .transportLag(o.getTransportLag())
                             .timeLastSynced(o.getTimeLastSynced())
                             .timeCreated(o.getTimeCreated())
@@ -544,6 +555,13 @@ public class AutonomousDatabaseDataguardAssociation {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("applyRate")
     String applyRate;
+
+    /**
+     * Indicates whether Automatic Failover is enabled for Autonomous Container Database Dataguard Association
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutomaticFailoverEnabled")
+    Boolean isAutomaticFailoverEnabled;
 
     /**
      * The approximate number of seconds of redo data not yet available on the standby Autonomous Container Database,

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -708,6 +708,25 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isReconnectCloneEnabled")
+        private Boolean isReconnectCloneEnabled;
+
+        public Builder isReconnectCloneEnabled(Boolean isReconnectCloneEnabled) {
+            this.isReconnectCloneEnabled = isReconnectCloneEnabled;
+            this.__explicitlySet__.add("isReconnectCloneEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUntilReconnectCloneEnabled")
+        private java.util.Date timeUntilReconnectCloneEnabled;
+
+        public Builder timeUntilReconnectCloneEnabled(
+                java.util.Date timeUntilReconnectCloneEnabled) {
+            this.timeUntilReconnectCloneEnabled = timeUntilReconnectCloneEnabled;
+            this.__explicitlySet__.add("timeUntilReconnectCloneEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("autonomousMaintenanceScheduleType")
         private AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType;
 
@@ -809,6 +828,8 @@ public class AutonomousDatabaseSummary {
                             timeDataGuardRoleChanged,
                             peerDbIds,
                             isMtlsConnectionRequired,
+                            isReconnectCloneEnabled,
+                            timeUntilReconnectCloneEnabled,
                             autonomousMaintenanceScheduleType,
                             scheduledOperations);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -895,6 +916,8 @@ public class AutonomousDatabaseSummary {
                             .timeDataGuardRoleChanged(o.getTimeDataGuardRoleChanged())
                             .peerDbIds(o.getPeerDbIds())
                             .isMtlsConnectionRequired(o.getIsMtlsConnectionRequired())
+                            .isReconnectCloneEnabled(o.getIsReconnectCloneEnabled())
+                            .timeUntilReconnectCloneEnabled(o.getTimeUntilReconnectCloneEnabled())
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
                             .scheduledOperations(o.getScheduledOperations());
@@ -2058,6 +2081,18 @@ public class AutonomousDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isMtlsConnectionRequired")
     Boolean isMtlsConnectionRequired;
+
+    /**
+     * Indicates if the refreshable clone can be reconnected to its source database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isReconnectCloneEnabled")
+    Boolean isReconnectCloneEnabled;
+
+    /**
+     * The time and date as an RFC3339 formatted string, e.g., 2022-01-01T12:00:00.000Z, to set the limit for a refreshable clone to be reconnected to its source database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUntilReconnectCloneEnabled")
+    java.util.Date timeUntilReconnectCloneEnabled;
     /**
      * The maintenance schedule type of the Autonomous Database on shared Exadata infrastructure. The EARLY maintenance schedule of this Autonomous Database
      * follows a schedule that applies patches prior to the REGULAR schedule.The REGULAR maintenance schedule of this Autonomous Database follows the normal cycle.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousContainerDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousContainerDatabaseDetails.java
@@ -94,6 +94,15 @@ public class CreateAutonomousContainerDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutomaticFailoverEnabled")
+        private Boolean isAutomaticFailoverEnabled;
+
+        public Builder isAutomaticFailoverEnabled(Boolean isAutomaticFailoverEnabled) {
+            this.isAutomaticFailoverEnabled = isAutomaticFailoverEnabled;
+            this.__explicitlySet__.add("isAutomaticFailoverEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("peerCloudAutonomousVmClusterId")
         private String peerCloudAutonomousVmClusterId;
 
@@ -278,6 +287,7 @@ public class CreateAutonomousContainerDatabaseDetails {
                             peerAutonomousExadataInfrastructureId,
                             peerAutonomousContainerDatabaseDisplayName,
                             protectionMode,
+                            isAutomaticFailoverEnabled,
                             peerCloudAutonomousVmClusterId,
                             peerAutonomousVmClusterId,
                             peerAutonomousContainerDatabaseCompartmentId,
@@ -313,6 +323,7 @@ public class CreateAutonomousContainerDatabaseDetails {
                             .peerAutonomousContainerDatabaseDisplayName(
                                     o.getPeerAutonomousContainerDatabaseDisplayName())
                             .protectionMode(o.getProtectionMode())
+                            .isAutomaticFailoverEnabled(o.getIsAutomaticFailoverEnabled())
                             .peerCloudAutonomousVmClusterId(o.getPeerCloudAutonomousVmClusterId())
                             .peerAutonomousVmClusterId(o.getPeerAutonomousVmClusterId())
                             .peerAutonomousContainerDatabaseCompartmentId(
@@ -462,6 +473,13 @@ public class CreateAutonomousContainerDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("protectionMode")
     ProtectionMode protectionMode;
+
+    /**
+     * Indicates whether Automatic Failover is enabled for Autonomous Container Database Dataguard Association
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutomaticFailoverEnabled")
+    Boolean isAutomaticFailoverEnabled;
 
     /**
      * The OCID of the peer cloud Autonomous VM Cluster.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousContainerDatabaseDataGuardAssociationDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousContainerDatabaseDataGuardAssociationDetails.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The configuration details for updating a Autonomous Container DatabaseData Guard association for a Autonomous Container Database.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateAutonomousContainerDatabaseDataGuardAssociationDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateAutonomousContainerDatabaseDataGuardAssociationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutomaticFailoverEnabled")
+        private Boolean isAutomaticFailoverEnabled;
+
+        public Builder isAutomaticFailoverEnabled(Boolean isAutomaticFailoverEnabled) {
+            this.isAutomaticFailoverEnabled = isAutomaticFailoverEnabled;
+            this.__explicitlySet__.add("isAutomaticFailoverEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateAutonomousContainerDatabaseDataGuardAssociationDetails build() {
+            UpdateAutonomousContainerDatabaseDataGuardAssociationDetails __instance__ =
+                    new UpdateAutonomousContainerDatabaseDataGuardAssociationDetails(
+                            isAutomaticFailoverEnabled);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateAutonomousContainerDatabaseDataGuardAssociationDetails o) {
+            Builder copiedBuilder = isAutomaticFailoverEnabled(o.getIsAutomaticFailoverEnabled());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Indicates whether Automatic Failover is enabled for Autonomous Container Database Dataguard Association
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutomaticFailoverEnabled")
+    Boolean isAutomaticFailoverEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateDbSystemDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateDbSystemDetails.java
@@ -65,6 +65,15 @@ public class UpdateDbSystemDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("recoStorageSizeInGBs")
+        private Integer recoStorageSizeInGBs;
+
+        public Builder recoStorageSizeInGBs(Integer recoStorageSizeInGBs) {
+            this.recoStorageSizeInGBs = recoStorageSizeInGBs;
+            this.__explicitlySet__.add("recoStorageSizeInGBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -139,6 +148,7 @@ public class UpdateDbSystemDetails {
                             version,
                             sshPublicKeys,
                             dataStorageSizeInGBs,
+                            recoStorageSizeInGBs,
                             freeformTags,
                             definedTags,
                             shape,
@@ -157,6 +167,7 @@ public class UpdateDbSystemDetails {
                             .version(o.getVersion())
                             .sshPublicKeys(o.getSshPublicKeys())
                             .dataStorageSizeInGBs(o.getDataStorageSizeInGBs())
+                            .recoStorageSizeInGBs(o.getRecoStorageSizeInGBs())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .shape(o.getShape())
@@ -198,6 +209,13 @@ public class UpdateDbSystemDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("dataStorageSizeInGBs")
     Integer dataStorageSizeInGBs;
+
+    /**
+     * The size, in gigabytes, to scale the attached RECO storage up to for this virtual machine DB system. This value must be greater than current storage size. Note that the resulting total storage size attached will be greater than the amount requested to allow for the software volume. Applies only to virtual machine DB systems.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("recoStorageSizeInGBs")
+    Integer recoStorageSizeInGBs;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateAutonomousContainerDatabaseDataguardAssociationRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/UpdateAutonomousContainerDatabaseDataguardAssociationRequest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/UpdateAutonomousContainerDatabaseDataguardAssociationExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateAutonomousContainerDatabaseDataguardAssociationRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateAutonomousContainerDatabaseDataguardAssociationRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.database.model
+                        .UpdateAutonomousContainerDatabaseDataGuardAssociationDetails> {
+
+    /**
+     * The Autonomous Container Database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseId;
+
+    /**
+     * The Autonomous Container Database-Autonomous Data Guard association [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousContainerDatabaseDataguardAssociationId;
+
+    /**
+     * A request to update Data Guard association of a database.
+     */
+    private com.oracle.bmc.database.model
+                    .UpdateAutonomousContainerDatabaseDataGuardAssociationDetails
+            updateAutonomousContainerDatabaseDataGuardAssociationDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the {@code if-match}
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Unique identifier for the request.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.database.model
+                    .UpdateAutonomousContainerDatabaseDataGuardAssociationDetails
+            getBody$() {
+        return updateAutonomousContainerDatabaseDataGuardAssociationDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateAutonomousContainerDatabaseDataguardAssociationRequest,
+                    com.oracle.bmc.database.model
+                            .UpdateAutonomousContainerDatabaseDataGuardAssociationDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateAutonomousContainerDatabaseDataguardAssociationRequest o) {
+            autonomousContainerDatabaseId(o.getAutonomousContainerDatabaseId());
+            autonomousContainerDatabaseDataguardAssociationId(
+                    o.getAutonomousContainerDatabaseDataguardAssociationId());
+            updateAutonomousContainerDatabaseDataGuardAssociationDetails(
+                    o.getUpdateAutonomousContainerDatabaseDataGuardAssociationDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateAutonomousContainerDatabaseDataguardAssociationRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateAutonomousContainerDatabaseDataguardAssociationRequest
+         */
+        public UpdateAutonomousContainerDatabaseDataguardAssociationRequest build() {
+            UpdateAutonomousContainerDatabaseDataguardAssociationRequest request =
+                    buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.database.model
+                                .UpdateAutonomousContainerDatabaseDataGuardAssociationDetails
+                        body) {
+            updateAutonomousContainerDatabaseDataGuardAssociationDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateAutonomousContainerDatabaseDataguardAssociationResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/UpdateAutonomousContainerDatabaseDataguardAssociationResponse.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateAutonomousContainerDatabaseDataguardAssociationResponse
+        extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you must contact Oracle about
+     * a particular request, then provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned AutonomousContainerDatabaseDataguardAssociation instance.
+     */
+    private com.oracle.bmc.database.model.AutonomousContainerDatabaseDataguardAssociation
+            autonomousContainerDatabaseDataguardAssociation;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "etag",
+        "opcRequestId",
+        "opcWorkRequestId",
+        "autonomousContainerDatabaseDataguardAssociation"
+    })
+    private UpdateAutonomousContainerDatabaseDataguardAssociationResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            String opcWorkRequestId,
+            com.oracle.bmc.database.model.AutonomousContainerDatabaseDataguardAssociation
+                    autonomousContainerDatabaseDataguardAssociation) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.autonomousContainerDatabaseDataguardAssociation =
+                autonomousContainerDatabaseDataguardAssociation;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateAutonomousContainerDatabaseDataguardAssociationResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            autonomousContainerDatabaseDataguardAssociation(
+                    o.getAutonomousContainerDatabaseDataguardAssociation());
+
+            return this;
+        }
+
+        public UpdateAutonomousContainerDatabaseDataguardAssociationResponse build() {
+            return new UpdateAutonomousContainerDatabaseDataguardAssociationResponse(
+                    __httpStatusCode__,
+                    etag,
+                    opcRequestId,
+                    opcWorkRequestId,
+                    autonomousContainerDatabaseDataguardAssociation);
+        }
+    }
+}

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasetools/pom.xml
+++ b/bmc-databasetools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasetools</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/DataLabelingManagement.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/DataLabelingManagement.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.datalabelingservice.requests.*;
 import com.oracle.bmc.datalabelingservice.responses.*;
 
 /**
- * A description of the DataLabelingService API
+ * Use Data Labeling Management API to create, list, edit & delete datasets.
  * This service client uses CircuitBreakerUtils.DEFAULT_CIRCUIT_BREAKER for all the operations by default if no circuit breaker configuration is defined by the user.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/DataLabelingManagementAsync.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/DataLabelingManagementAsync.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.datalabelingservice.requests.*;
 import com.oracle.bmc.datalabelingservice.responses.*;
 
 /**
- * A description of the DataLabelingService API
+ * Use Data Labeling Management API to create, list, edit & delete datasets.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")
 public interface DataLabelingManagementAsync extends AutoCloseable {

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/CreateDatasetDetails.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/CreateDatasetDetails.java
@@ -99,6 +99,15 @@ public class CreateDatasetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("labelingInstructions")
+        private String labelingInstructions;
+
+        public Builder labelingInstructions(String labelingInstructions) {
+            this.labelingInstructions = labelingInstructions;
+            this.__explicitlySet__.add("labelingInstructions");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -132,6 +141,7 @@ public class CreateDatasetDetails {
                             datasetFormatDetails,
                             initialRecordGenerationConfiguration,
                             labelSet,
+                            labelingInstructions,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -150,6 +160,7 @@ public class CreateDatasetDetails {
                             .initialRecordGenerationConfiguration(
                                     o.getInitialRecordGenerationConfiguration())
                             .labelSet(o.getLabelSet())
+                            .labelingInstructions(o.getLabelingInstructions())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -202,16 +213,22 @@ public class CreateDatasetDetails {
     LabelSet labelSet;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * The labeling instructions for human labelers in rich text format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("labelingInstructions")
+    String labelingInstructions;
+
+    /**
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/Dataset.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/Dataset.java
@@ -143,6 +143,15 @@ public class Dataset {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("labelingInstructions")
+        private String labelingInstructions;
+
+        public Builder labelingInstructions(String labelingInstructions) {
+            this.labelingInstructions = labelingInstructions;
+            this.__explicitlySet__.add("labelingInstructions");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -190,6 +199,7 @@ public class Dataset {
                             datasetFormatDetails,
                             labelSet,
                             initialRecordGenerationConfiguration,
+                            labelingInstructions,
                             freeformTags,
                             definedTags,
                             systemTags);
@@ -214,6 +224,7 @@ public class Dataset {
                             .labelSet(o.getLabelSet())
                             .initialRecordGenerationConfiguration(
                                     o.getInitialRecordGenerationConfiguration())
+                            .labelingInstructions(o.getLabelingInstructions())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .systemTags(o.getSystemTags());
@@ -363,24 +374,30 @@ public class Dataset {
     InitialRecordGenerationConfiguration initialRecordGenerationConfiguration;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * The labeling instructions for human labelers in rich text format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("labelingInstructions")
+    String labelingInstructions;
+
+    /**
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * Usage of system tag keys. These predefined keys are scoped to namespaces.
-     * Example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
+     * The usage of system tag keys. These predefined keys are scoped to namespaces.
+     * For example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("systemTags")

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/DatasetFormatDetails.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/DatasetFormatDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservice.model;
 
 /**
- * Specifies how to process the data. Supported formats include IMAGE and TEXT.
+ * Specifies how to process the data. Supported formats include DOCUMENT, IMAGE and TEXT.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -45,7 +45,7 @@ package com.oracle.bmc.datalabelingservice.model;
 public class DatasetFormatDetails {
 
     /**
-     * Format type. IMAGE format are for record contents that are JPEGs or PNGs. TEXT format is for record contents that are txt files.
+     * Format type. DOCUMENT format is for record contents that are PDFs or TIFFs. IMAGE format is for record contents that are JPEGs or PNGs. TEXT format is for record contents that are txt files.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum FormatType {

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/DatasetSummary.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/DatasetSummary.java
@@ -235,24 +235,24 @@ public class DatasetSummary {
     DatasetFormatDetails datasetFormatDetails;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * Usage of system tag keys. These predefined keys are scoped to namespaces.
-     * Example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
+     * The usage of system tag keys. These predefined keys are scoped to namespaces.
+     * For example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("systemTags")

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/ExportFormat.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/ExportFormat.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datalabelingservice.model;
+
+/**
+ * Specifies the export format to be used for exporting snapshot.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ExportFormat.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ExportFormat {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private Name name;
+
+        public Builder name(Name name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private Version version;
+
+        public Builder version(Version version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ExportFormat build() {
+            ExportFormat __instance__ = new ExportFormat(name, version);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ExportFormat o) {
+            Builder copiedBuilder = name(o.getName()).version(o.getVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Name of export format.
+     **/
+    public enum Name {
+        Jsonl("JSONL"),
+        JsonlConsolidated("JSONL_CONSOLIDATED"),
+        Conll("CONLL"),
+        Spacy("SPACY"),
+        Coco("COCO"),
+        Yolo("YOLO"),
+        PascalVoc("PASCAL_VOC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Name> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Name v : Name.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Name(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Name create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Name: " + key);
+        }
+    };
+    /**
+     * Name of export format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    Name name;
+    /**
+     * Version of export format.
+     **/
+    public enum Version {
+        V2003("V2003"),
+        V5("V5"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, Version> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Version v : Version.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        Version(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Version create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid Version: " + key);
+        }
+    };
+    /**
+     * Version of export format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    Version version;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/ObjectStorageSourceDetails.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/ObjectStorageSourceDetails.java
@@ -108,7 +108,7 @@ public class ObjectStorageSourceDetails extends DatasetSourceDetails {
     String bucket;
 
     /**
-     * A common path prefix shared by the objects that make up the dataset.
+     * A common path prefix shared by the objects that make up the dataset. Records will not be generated for objects whose name match exactly with prefix.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("prefix")
     String prefix;

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/SnapshotDatasetDetails.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/SnapshotDatasetDetails.java
@@ -53,13 +53,25 @@ public class SnapshotDatasetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("exportFormat")
+        private ExportFormat exportFormat;
+
+        public Builder exportFormat(ExportFormat exportFormat) {
+            this.exportFormat = exportFormat;
+            this.__explicitlySet__.add("exportFormat");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public SnapshotDatasetDetails build() {
             SnapshotDatasetDetails __instance__ =
                     new SnapshotDatasetDetails(
-                            areAnnotationsIncluded, areUnannotatedRecordsIncluded, exportDetails);
+                            areAnnotationsIncluded,
+                            areUnannotatedRecordsIncluded,
+                            exportDetails,
+                            exportFormat);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -69,7 +81,8 @@ public class SnapshotDatasetDetails {
             Builder copiedBuilder =
                     areAnnotationsIncluded(o.getAreAnnotationsIncluded())
                             .areUnannotatedRecordsIncluded(o.getAreUnannotatedRecordsIncluded())
-                            .exportDetails(o.getExportDetails());
+                            .exportDetails(o.getExportDetails())
+                            .exportFormat(o.getExportFormat());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -97,6 +110,9 @@ public class SnapshotDatasetDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("exportDetails")
     ObjectStorageSnapshotExportDetails exportDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("exportFormat")
+    ExportFormat exportFormat;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/UpdateDatasetDetails.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/model/UpdateDatasetDetails.java
@@ -45,6 +45,15 @@ public class UpdateDatasetDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("labelingInstructions")
+        private String labelingInstructions;
+
+        public Builder labelingInstructions(String labelingInstructions) {
+            this.labelingInstructions = labelingInstructions;
+            this.__explicitlySet__.add("labelingInstructions");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -69,7 +78,12 @@ public class UpdateDatasetDetails {
 
         public UpdateDatasetDetails build() {
             UpdateDatasetDetails __instance__ =
-                    new UpdateDatasetDetails(displayName, description, freeformTags, definedTags);
+                    new UpdateDatasetDetails(
+                            displayName,
+                            description,
+                            labelingInstructions,
+                            freeformTags,
+                            definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -79,6 +93,7 @@ public class UpdateDatasetDetails {
             Builder copiedBuilder =
                     displayName(o.getDisplayName())
                             .description(o.getDescription())
+                            .labelingInstructions(o.getLabelingInstructions())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -107,16 +122,22 @@ public class UpdateDatasetDetails {
     String description;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * The labeling instructions for human labelers in rich text format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("labelingInstructions")
+    String labelingInstructions;
+
+    /**
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/AddDatasetLabelsResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/AddDatasetLabelsResponse.java
@@ -13,13 +13,13 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class AddDatasetLabelsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     * A unique Oracle-assigned identifier for the asynchronous request. You can use this to query the status of the asynchronous operation.
      *
      */
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ChangeDatasetCompartmentResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ChangeDatasetCompartmentResponse.java
@@ -13,13 +13,13 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class ChangeDatasetCompartmentResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     * A unique Oracle-assigned identifier for the asynchronous request. You can use this to query the status of the asynchronous operation.
      *
      */
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/CreateDatasetResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/CreateDatasetResponse.java
@@ -31,13 +31,13 @@ public class CreateDatasetResponse extends com.oracle.bmc.responses.BmcResponse 
     private String contentLocation;
 
     /**
-     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     * A unique Oracle-assigned identifier for the asynchronous request. You can use this to query the status of the asynchronous operation.
      *
      */
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/DeleteDatasetResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/DeleteDatasetResponse.java
@@ -13,13 +13,13 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class DeleteDatasetResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     * A unique Oracle-assigned identifier for the asynchronous request. You can use this to query the status of the asynchronous operation.
      *
      */
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/GenerateDatasetRecordsResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/GenerateDatasetRecordsResponse.java
@@ -13,13 +13,13 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class GenerateDatasetRecordsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     * A unique Oracle-assigned identifier for the asynchronous request. You can use this to query the status of the asynchronous operation.
      *
      */
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/GetDatasetResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/GetDatasetResponse.java
@@ -19,7 +19,7 @@ public class GetDatasetResponse extends com.oracle.bmc.responses.BmcResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/GetWorkRequestResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/GetWorkRequestResponse.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class GetWorkRequestResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListAnnotationFormatsResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListAnnotationFormatsResponse.java
@@ -13,14 +13,14 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class ListAnnotationFormatsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * For the pagination of a list of items. When paging through a list, if this header appears in the response,
      * then a partial list might have been returned. Include this value as the {@code page} parameter for the
      * subsequent GET request to get the next batch of items.
      *

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListDatasetsResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListDatasetsResponse.java
@@ -13,14 +13,14 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class ListDatasetsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * For the pagination of a list of items. When paging through a list, if this header appears in the response,
      * then a partial list might have been returned. Include this value as the {@code page} parameter for the
      * subsequent GET request to get the next batch of items.
      *

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListWorkRequestErrorsResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListWorkRequestErrorsResponse.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class ListWorkRequestErrorsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * For the pagination of a list of items. When paging through a list, if this header appears in the response,
      * then a partial list might have been returned. Include this value as the {@code page} parameter for the
      * subsequent GET request to get the next batch of items.
      *
@@ -21,7 +21,7 @@ public class ListWorkRequestErrorsResponse extends com.oracle.bmc.responses.BmcR
     private String opcNextPage;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListWorkRequestLogsResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListWorkRequestLogsResponse.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class ListWorkRequestLogsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * For the pagination of a list of items. When paging through a list, if this header appears in the response,
      * then a partial list might have been returned. Include this value as the {@code page} parameter for the
      * subsequent GET request to get the next batch of items.
      *
@@ -21,7 +21,7 @@ public class ListWorkRequestLogsResponse extends com.oracle.bmc.responses.BmcRes
     private String opcNextPage;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListWorkRequestsResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/ListWorkRequestsResponse.java
@@ -13,14 +13,14 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class ListWorkRequestsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * For the pagination of a list of items. When paging through a list, if this header appears in the response,
      * then a partial list might have been returned. Include this value as the {@code page} parameter for the
      * subsequent GET request to get the next batch of items.
      *

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/RemoveDatasetLabelsResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/RemoveDatasetLabelsResponse.java
@@ -13,13 +13,13 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class RemoveDatasetLabelsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     * A unique Oracle-assigned identifier for the asynchronous request. You can use this to query the status of the asynchronous operation.
      *
      */
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/RenameDatasetLabelsResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/RenameDatasetLabelsResponse.java
@@ -13,13 +13,13 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class RenameDatasetLabelsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     * A unique Oracle-assigned identifier for the asynchronous request. You can use this to query the status of the asynchronous operation.
      *
      */
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/SnapshotDatasetResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/SnapshotDatasetResponse.java
@@ -13,13 +13,13 @@ import com.oracle.bmc.datalabelingservice.model.*;
 @lombok.Getter
 public class SnapshotDatasetResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the asynchronous request. You can use this to query status of the asynchronous operation.
+     * A unique Oracle-assigned identifier for the asynchronous request. You can use this to query the status of the asynchronous operation.
      *
      */
     private String opcWorkRequestId;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/UpdateDatasetResponse.java
+++ b/bmc-datalabelingservice/src/main/java/com/oracle/bmc/datalabelingservice/responses/UpdateDatasetResponse.java
@@ -19,7 +19,7 @@ public class UpdateDatasetResponse extends com.oracle.bmc.responses.BmcResponse 
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/DataLabeling.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/DataLabeling.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.datalabelingservicedataplane.requests.*;
 import com.oracle.bmc.datalabelingservicedataplane.responses.*;
 
 /**
- * A description of the DlsDataPlane API.
+ * Use Data Labeling API to create Annotations on Images, Texts & Documents, and generate snapshots.
  * This service client uses CircuitBreakerUtils.DEFAULT_CIRCUIT_BREAKER for all the operations by default if no circuit breaker configuration is defined by the user.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")
@@ -60,7 +60,7 @@ public interface DataLabeling extends AutoCloseable {
     CreateAnnotationResponse createAnnotation(CreateAnnotationRequest request);
 
     /**
-     * Creates a Record.
+     * Creates a record.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -73,7 +73,7 @@ public interface DataLabeling extends AutoCloseable {
     CreateRecordResponse createRecord(CreateRecordRequest request);
 
     /**
-     * Deletes an Annotation resource by identifier
+     * It deletes an annotation resource by identifier.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -86,7 +86,7 @@ public interface DataLabeling extends AutoCloseable {
     DeleteAnnotationResponse deleteAnnotation(DeleteAnnotationRequest request);
 
     /**
-     * Deletes a Record resource by identifier
+     * Deletes a record resource by identifier.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -99,7 +99,7 @@ public interface DataLabeling extends AutoCloseable {
     DeleteRecordResponse deleteRecord(DeleteRecordRequest request);
 
     /**
-     * Gets an Annotation
+     * Gets an annotation.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -112,7 +112,7 @@ public interface DataLabeling extends AutoCloseable {
     GetAnnotationResponse getAnnotation(GetAnnotationRequest request);
 
     /**
-     * Gets a Dataset by identifier
+     * Gets a dataset by identifier.
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -124,7 +124,7 @@ public interface DataLabeling extends AutoCloseable {
     GetDatasetResponse getDataset(GetDatasetRequest request);
 
     /**
-     * Gets a record
+     * Gets a record.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -137,7 +137,7 @@ public interface DataLabeling extends AutoCloseable {
     GetRecordResponse getRecord(GetRecordRequest request);
 
     /**
-     * Retrieves the content of the record from the Dataset source.
+     * Retrieves the content of the record from the dataset source.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -150,7 +150,7 @@ public interface DataLabeling extends AutoCloseable {
     GetRecordContentResponse getRecordContent(GetRecordContentRequest request);
 
     /**
-     * Retrieves the preview of the record content from the Dataset source.
+     * Retrieves the preview of the record content from the dataset source.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -163,7 +163,7 @@ public interface DataLabeling extends AutoCloseable {
     GetRecordPreviewContentResponse getRecordPreviewContent(GetRecordPreviewContentRequest request);
 
     /**
-     * Returns a list of Annotations.
+     * Returns a list of annotations.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -176,7 +176,7 @@ public interface DataLabeling extends AutoCloseable {
     ListAnnotationsResponse listAnnotations(ListAnnotationsRequest request);
 
     /**
-     * List Record in the specified compartment.
+     * The list of records in the specified compartment.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -189,7 +189,7 @@ public interface DataLabeling extends AutoCloseable {
     ListRecordsResponse listRecords(ListRecordsRequest request);
 
     /**
-     * Summarize annotations created for a given dataset
+     * Summarize the annotations created for a given dataset.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -203,7 +203,7 @@ public interface DataLabeling extends AutoCloseable {
             SummarizeAnnotationAnalyticsRequest request);
 
     /**
-     * Summarize records created for a given dataset
+     * Summarize the records created for a given dataset.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -230,7 +230,7 @@ public interface DataLabeling extends AutoCloseable {
     UpdateAnnotationResponse updateAnnotation(UpdateAnnotationRequest request);
 
     /**
-     * Updates record.
+     * Updates a record.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/DataLabelingAsync.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/DataLabelingAsync.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.datalabelingservicedataplane.requests.*;
 import com.oracle.bmc.datalabelingservicedataplane.responses.*;
 
 /**
- * A description of the DlsDataPlane API.
+ * Use Data Labeling API to create Annotations on Images, Texts & Documents, and generate snapshots.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")
 public interface DataLabelingAsync extends AutoCloseable {
@@ -62,7 +62,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Creates a Record.
+     * Creates a record.
      *
      *
      * @param request The request object containing the details to send
@@ -78,7 +78,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes an Annotation resource by identifier
+     * It deletes an annotation resource by identifier.
      *
      *
      * @param request The request object containing the details to send
@@ -94,7 +94,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Deletes a Record resource by identifier
+     * Deletes a record resource by identifier.
      *
      *
      * @param request The request object containing the details to send
@@ -110,7 +110,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets an Annotation
+     * Gets an annotation.
      *
      *
      * @param request The request object containing the details to send
@@ -126,7 +126,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Gets a Dataset by identifier
+     * Gets a dataset by identifier.
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -140,7 +140,7 @@ public interface DataLabelingAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetDatasetRequest, GetDatasetResponse> handler);
 
     /**
-     * Gets a record
+     * Gets a record.
      *
      *
      * @param request The request object containing the details to send
@@ -155,7 +155,7 @@ public interface DataLabelingAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<GetRecordRequest, GetRecordResponse> handler);
 
     /**
-     * Retrieves the content of the record from the Dataset source.
+     * Retrieves the content of the record from the dataset source.
      *
      *
      * @param request The request object containing the details to send
@@ -171,7 +171,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Retrieves the preview of the record content from the Dataset source.
+     * Retrieves the preview of the record content from the dataset source.
      *
      *
      * @param request The request object containing the details to send
@@ -188,7 +188,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Returns a list of Annotations.
+     * Returns a list of annotations.
      *
      *
      * @param request The request object containing the details to send
@@ -204,7 +204,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * List Record in the specified compartment.
+     * The list of records in the specified compartment.
      *
      *
      * @param request The request object containing the details to send
@@ -219,7 +219,7 @@ public interface DataLabelingAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<ListRecordsRequest, ListRecordsResponse> handler);
 
     /**
-     * Summarize annotations created for a given dataset
+     * Summarize the annotations created for a given dataset.
      *
      *
      * @param request The request object containing the details to send
@@ -237,7 +237,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Summarize records created for a given dataset
+     * Summarize the records created for a given dataset.
      *
      *
      * @param request The request object containing the details to send
@@ -270,7 +270,7 @@ public interface DataLabelingAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Updates record.
+     * Updates a record.
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Annotation.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Annotation.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * An Annotation represents a user/machine generated annotation for a given record.  The details of the annotation are captured in the RecordAnnotationDetails.
+ * An annotation represents a user- or machine-generated annotation for a given record.  The details of the annotation are captured in the RecordAnnotationDetails.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -173,7 +173,7 @@ public class Annotation {
     }
 
     /**
-     * The OCID of the annotation
+     * The OCID of the annotation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -191,25 +191,25 @@ public class Annotation {
     java.util.Date timeUpdated;
 
     /**
-     * The OCID of the principal who created the annotation
+     * The OCID of the principal which created the annotation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("createdBy")
     String createdBy;
 
     /**
-     * The OCID of the principal who updated the annotation
+     * The OCID of the principal which updated the annotation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("updatedBy")
     String updatedBy;
 
     /**
-     * The OCID of the record annotated
+     * The OCID of the record annotated.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("recordId")
     String recordId;
 
     /**
-     * The entity types will be validated against the dataset to ensure consistency.
+     * The entity types are validated against the dataset to ensure consistency.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("entities")
     java.util.List<Entity> entities;
@@ -220,10 +220,10 @@ public class Annotation {
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
     /**
-     * Lifecycle State of an Annotation.
-     * ACTIVE - Annotation is active to be used for labeling.
-     * INACTIVE - Annotation has been marked as inactive and should not be used for labeling.
-     * DELETED - Annotation been deleted and no longer available for labeling.
+     * The lifecycle state of an annotation.
+     * ACTIVE - The annotation is active to be used for labeling.
+     * INACTIVE - The annotation has been marked as inactive and should not be used for labeling.
+     * DELETED - Tha annotation been deleted and no longer available for labeling.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -271,26 +271,26 @@ public class Annotation {
         }
     };
     /**
-     * Lifecycle State of an Annotation.
-     * ACTIVE - Annotation is active to be used for labeling.
-     * INACTIVE - Annotation has been marked as inactive and should not be used for labeling.
-     * DELETED - Annotation been deleted and no longer available for labeling.
+     * The lifecycle state of an annotation.
+     * ACTIVE - The annotation is active to be used for labeling.
+     * INACTIVE - The annotation has been marked as inactive and should not be used for labeling.
+     * DELETED - Tha annotation been deleted and no longer available for labeling.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationAggregationDimensions.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationAggregationDimensions.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Dimensions to summarize annotations for a given dataset
+ * The dimensions to summarize annotations for a given dataset.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -74,7 +74,7 @@ public class AnnotationAggregationDimensions {
     Label label;
 
     /**
-     * The OCID of the principal who updated the resource.
+     * The OCID of the principal which updated the resource.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("updatedBy")
     String updatedBy;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationAnalyticsAggregation.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationAnalyticsAggregation.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Aggregation entities are required by the api consistency guidelines for API Consistency Guidelines#AnalyticsAPIs.  These are used to summarize annotations for a given dataset and will be used to populate UI elements.  Aggregations need to have the fields that identify the exact scope that they're summarizing.  Any filters to the list API we apply would have to show up in the aggregation. We should limit the number of filters and dimensions as much as possible.
+ * Aggregation entities are required by the API consistency guidelines for API Consistency Guidelines#AnalyticsAPIs.  These are used to summarize annotations for a given dataset and will be used to populate UI elements.  Aggregations need to have the fields that identify the exact scope that they're summarizing.  Any filters applied to the list API, have to show up in the aggregation.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -114,13 +114,13 @@ public class AnnotationAnalyticsAggregation {
     }
 
     /**
-     * the count of the matching results
+     * The count of the matching results.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("count")
     java.math.BigDecimal count;
 
     /**
-     * OCID of the dataset the annotations belongs to
+     * The OCID of the dataset the annotations belong to.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("datasetId")
     String datasetId;
@@ -129,13 +129,13 @@ public class AnnotationAnalyticsAggregation {
     AnnotationAggregationDimensions dimensions;
 
     /**
-     * The OCID of the principal who updated the annotation
+     * The OCID of the principal which updated the annotation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("updatedBy")
     String updatedBy;
 
     /**
-     * OCID of the compartment containing the annotations
+     * The OCID of the compartment containing the annotations.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationAnalyticsAggregationCollection.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationAnalyticsAggregationCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Aggregation entities are required by the api consistency guidelines for API Consistency Guidelines#AnalyticsAPIs.  These are used to summarize annotations for a given dataset and will be used to populate UI elements.  Aggregations need to have the fields that identify the exact scope that they're summarizing.  Any filters to the list API we apply would have to show up in the aggregation. We should limit the number of filters and dimensions as much as possible.
+ * Aggregation entities are required by the API consistency guidelines for API Consistency Guidelines#AnalyticsAPIs.  These are used to summarize annotations for a given dataset and will be used to populate UI elements.  Aggregations need to have the fields that identify the exact scope that they're summarizing.  Any filters applied to the list API, have to show up in the aggregation.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -62,7 +62,7 @@ public class AnnotationAnalyticsAggregationCollection {
     }
 
     /**
-     * List of Annotation entities.
+     * The list of annotation entities.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<AnnotationAnalyticsAggregation> items;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationCollection.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Results of a annotations search. Contains boh AnnotationSummary items and other information, such as metadata.
+ * The results of an annotations search. It contains AnnotationSummary items and other information, such as metadata.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -61,7 +61,7 @@ public class AnnotationCollection {
     }
 
     /**
-     * List of annotations.
+     * The list of annotations.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<AnnotationSummary> items;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationSummary.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/AnnotationSummary.java
@@ -142,7 +142,7 @@ public class AnnotationSummary {
     }
 
     /**
-     * The OCID of the annotation
+     * The OCID of the annotation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -160,13 +160,13 @@ public class AnnotationSummary {
     java.util.Date timeUpdated;
 
     /**
-     * The OCID of the record annotated
+     * The OCID of the record annotated.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("recordId")
     String recordId;
 
     /**
-     * The OCID of the compartment for the annotation
+     * The OCID of the compartment for the annotation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
@@ -178,16 +178,16 @@ public class AnnotationSummary {
     Annotation.LifecycleState lifecycleState;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/BoundingPolygon.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/BoundingPolygon.java
@@ -59,7 +59,7 @@ public class BoundingPolygon {
     }
 
     /**
-     * The normalized vertices that make up the polygon.  They are in order of the segments that they connect.
+     * The normalized vertices that make up the polygon.  They are in the order of the segments they connect.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("normalizedVertices")
     java.util.List<NormalizedVertex> normalizedVertices;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/CreateAnnotationDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/CreateAnnotationDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * This is the payload sent in the CreateAnnotation operation.  It contains all the information required for a user to create an Annotation for a record.
+ * This is the payload sent in the CreateAnnotation operation.  It contains all the information required for a user to create an annotation for a record.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -105,34 +105,34 @@ public class CreateAnnotationDetails {
     }
 
     /**
-     * The OCID of the record annotated
+     * The OCID of the record annotated.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("recordId")
     String recordId;
 
     /**
-     * The OCID of the compartment for the annotation
+     * The OCID of the compartment for the annotation.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
     String compartmentId;
 
     /**
-     * The entity types will be validated against the dataset to ensure consistency.
+     * The entity types are validated against the dataset to ensure consistency.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("entities")
     java.util.List<Entity> entities;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/CreateRecordDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/CreateRecordDetails.java
@@ -62,6 +62,15 @@ public class CreateRecordDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("recordMetadata")
+        private RecordMetadata recordMetadata;
+
+        public Builder recordMetadata(RecordMetadata recordMetadata) {
+            this.recordMetadata = recordMetadata;
+            this.__explicitlySet__.add("recordMetadata");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -91,6 +100,7 @@ public class CreateRecordDetails {
                             datasetId,
                             compartmentId,
                             sourceDetails,
+                            recordMetadata,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -104,6 +114,7 @@ public class CreateRecordDetails {
                             .datasetId(o.getDatasetId())
                             .compartmentId(o.getCompartmentId())
                             .sourceDetails(o.getSourceDetails())
+                            .recordMetadata(o.getRecordMetadata())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -120,7 +131,7 @@ public class CreateRecordDetails {
     }
 
     /**
-     * This will be automatically assigned by the service. It will be unique and immutable.
+     * The name is automatically assigned by the service. It is unique and immutable.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
@@ -140,17 +151,20 @@ public class CreateRecordDetails {
     @com.fasterxml.jackson.annotation.JsonProperty("sourceDetails")
     CreateSourceDetails sourceDetails;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("recordMetadata")
+    RecordMetadata recordMetadata;
+
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/CreateSourceDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/CreateSourceDetails.java
@@ -39,7 +39,7 @@ public class CreateSourceDetails {
 
     /**
      * The type of data source.
-     * OBJECT_STORAGE - source details for an object storage bucket.
+     * OBJECT_STORAGE - The source details for an object storage bucket.
      *
      **/
     public enum SourceType {

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Dataset.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Dataset.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * A dataset is a logical collection of records. The dataset contains all the information necessary to describe a record's source, format, type of annotations allowed on these records, and labels allowed on annotations.
+ * A dataset is a logical collection of records. The dataset contains all the information necessary to describe a record's source, format, the type of annotations allowed for the record, and the labels allowed on annotations.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -143,6 +143,15 @@ public class Dataset {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("labelingInstructions")
+        private String labelingInstructions;
+
+        public Builder labelingInstructions(String labelingInstructions) {
+            this.labelingInstructions = labelingInstructions;
+            this.__explicitlySet__.add("labelingInstructions");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -190,6 +199,7 @@ public class Dataset {
                             datasetFormatDetails,
                             labelSet,
                             initialRecordGenerationConfiguration,
+                            labelingInstructions,
                             freeformTags,
                             definedTags,
                             systemTags);
@@ -214,6 +224,7 @@ public class Dataset {
                             .labelSet(o.getLabelSet())
                             .initialRecordGenerationConfiguration(
                                     o.getInitialRecordGenerationConfiguration())
+                            .labelingInstructions(o.getLabelingInstructions())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
                             .systemTags(o.getSystemTags());
@@ -231,7 +242,7 @@ public class Dataset {
     }
 
     /**
-     * The OCID of the Dataset.
+     * The OCID of the dataset.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
@@ -249,7 +260,7 @@ public class Dataset {
     String compartmentId;
 
     /**
-     * A user provided description of the dataset
+     * A user-provided description of the dataset
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("description")
     String description;
@@ -267,10 +278,10 @@ public class Dataset {
     java.util.Date timeUpdated;
     /**
      * The state of a dataset.
-     * CREATING - The dataset is being created.  It will transition to ACTIVE when it is ready for labeling.
+     * CREATING - The dataset is being created.  It transitions to ACTIVE when it is ready for labeling.
      * ACTIVE   - The dataset is ready for labeling.
-     * UPDATING - The dataset is being updated.  It and its related resources may be unavailable for other updates until it returns to ACTIVE.
-     * NEEDS_ATTENTION - A dataset updation operation has failed due to validation or other errors and needs attention.
+     * UPDATING - The dataset is being updated.  It, and its related resources, might be unavailable for other updates until it returns to ACTIVE.
+     * NEEDS_ATTENTION - A dataset updaten operation has failed due to validation or other errors, and needs attention.
      * DELETING - The dataset and its related resources are being deleted.
      * DELETED  - The dataset has been deleted and is no longer available.
      * FAILED   - The dataset has failed due to validation or other errors.
@@ -326,10 +337,10 @@ public class Dataset {
     };
     /**
      * The state of a dataset.
-     * CREATING - The dataset is being created.  It will transition to ACTIVE when it is ready for labeling.
+     * CREATING - The dataset is being created.  It transitions to ACTIVE when it is ready for labeling.
      * ACTIVE   - The dataset is ready for labeling.
-     * UPDATING - The dataset is being updated.  It and its related resources may be unavailable for other updates until it returns to ACTIVE.
-     * NEEDS_ATTENTION - A dataset updation operation has failed due to validation or other errors and needs attention.
+     * UPDATING - The dataset is being updated.  It, and its related resources, might be unavailable for other updates until it returns to ACTIVE.
+     * NEEDS_ATTENTION - A dataset updaten operation has failed due to validation or other errors, and needs attention.
      * DELETING - The dataset and its related resources are being deleted.
      * DELETED  - The dataset has been deleted and is no longer available.
      * FAILED   - The dataset has failed due to validation or other errors.
@@ -363,24 +374,30 @@ public class Dataset {
     InitialRecordGenerationConfiguration initialRecordGenerationConfiguration;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * The labeling instructions for human labelers in rich text format
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("labelingInstructions")
+    String labelingInstructions;
+
+    /**
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
 
     /**
-     * Usage of system tag keys. These predefined keys are scoped to namespaces.
-     * Example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
+     * The usage of system tag keys. These predefined keys are scoped to namespaces.
+     * For example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("systemTags")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/DatasetFormatDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/DatasetFormatDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Specifies how to process the data. Supported formats include IMAGE and TEXT.
+ * It specifies how to process the data. Supported formats include DOCUMENT, IMAGE, and TEXT.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -45,7 +45,7 @@ package com.oracle.bmc.datalabelingservicedataplane.model;
 public class DatasetFormatDetails {
 
     /**
-     * Format type. IMAGE format are for record contents that are JPEGs or PNGs. TEXT format is for record contents that are txt files.
+     * The format type. DOCUMENT format is for record contents that are PDFs or TIFFs. IMAGE format is for record contents that are JPEGs or PNGs. TEXT format is for record contents that are TXT files.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum FormatType {

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/DatasetSourceDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/DatasetSourceDetails.java
@@ -37,7 +37,7 @@ package com.oracle.bmc.datalabelingservicedataplane.model;
 public class DatasetSourceDetails {
 
     /**
-     * Source type.  OBJECT_STORAGE allows the customer to describe where the dataset is in object storage.
+     * The source type.  OBJECT_STORAGE allows the user to describe where in object storage the dataset is.
      **/
     @lombok.extern.slf4j.Slf4j
     public enum SourceType {

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/DocumentDatasetFormatDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/DocumentDatasetFormatDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Allows the user to specify that the dataset is comprised of document files (e.g. PDFs, DOCs, etc.).  It is open for further configurability.
+ * It indicates the dataset is comprised of document files.  It is open for further configurability.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/DocumentMetadata.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/DocumentMetadata.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datalabelingservicedataplane.model;
+
+/**
+ * Collection of metadata related to document record.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = DocumentMetadata.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "recordType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DocumentMetadata extends RecordMetadata {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DocumentMetadata build() {
+            DocumentMetadata __instance__ = new DocumentMetadata();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DocumentMetadata o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public DocumentMetadata() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Entity.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Entity.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * An entity allows the labeler to identify an object in the record to label.  This can be a snippet of text, an entire image, a bounding box within an image, or, eventually, a custom format that works for them.  All entity types will have an array of labels that we'll index. If more than one label is provided, but the annotationType on the corresponding Dataset is for single class, the API will reject the create annotation request.
+ * An entity allows the labeler to identify an object in the record to label.  This can be, for example, a snippet of text, an entire image, or a bounding box within an image.  All entity types have an array of labels that are indexed. If more than one label is provided, but the annotationType on the corresponding dataset is for a single class, the API rejects the create annotation request.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -46,10 +46,10 @@ package com.oracle.bmc.datalabelingservicedataplane.model;
 public class Entity {
 
     /**
-     * The entity type described in the annotation
+     * The entity type described in the annotation.
      * GENERIC  - An extensible entity type that is the base entity type for some annotation formats.
      * IMAGEOBJECTSELECTION- - This allows the labeler to use specify a bounding polygon on the image to represent an object and apply labels to it.
-     * TEXTSELECTION - This allows the labeler to highlight text by specifying an offset and a length and apply labels to it.
+     * TEXTSELECTION - This allows the labeler to highlight text, by specifying an offset and a length, and apply labels to it.
      *
      **/
     @lombok.extern.slf4j.Slf4j

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/GenericEntity.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/GenericEntity.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * This is an extensible entity type for users and the base entity type for some annotation formats
+ * This is an extensible entity type for users, and the base entity type for some annotation formats.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -82,14 +82,14 @@ public class GenericEntity extends Entity {
     }
 
     /**
-     * collection of Label entities
+     * A collection of label entities.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("labels")
     java.util.List<Label> labels;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("extendedMetadata")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ImageDatasetFormatDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ImageDatasetFormatDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Indicates the dataset is comprised of images.
+ * It indicates the dataset is comprised of images.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ImageMetadata.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ImageMetadata.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datalabelingservicedataplane.model;
+
+/**
+ * Collection of metadata related to image record.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = ImageMetadata.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "recordType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ImageMetadata extends RecordMetadata {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("height")
+        private Integer height;
+
+        public Builder height(Integer height) {
+            this.height = height;
+            this.__explicitlySet__.add("height");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("width")
+        private Integer width;
+
+        public Builder width(Integer width) {
+            this.width = width;
+            this.__explicitlySet__.add("width");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("depth")
+        private Integer depth;
+
+        public Builder depth(Integer depth) {
+            this.depth = depth;
+            this.__explicitlySet__.add("depth");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ImageMetadata build() {
+            ImageMetadata __instance__ = new ImageMetadata(height, width, depth);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ImageMetadata o) {
+            Builder copiedBuilder = height(o.getHeight()).width(o.getWidth()).depth(o.getDepth());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ImageMetadata(Integer height, Integer width, Integer depth) {
+        super();
+        this.height = height;
+        this.width = width;
+        this.depth = depth;
+    }
+
+    /**
+     * Height of the image record.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("height")
+    Integer height;
+
+    /**
+     * Width of the image record.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("width")
+    Integer width;
+
+    /**
+     * Depth of the image record.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("depth")
+    Integer depth;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ImageObjectSelectionEntity.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ImageObjectSelectionEntity.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * This allows the labeler to use specify a series of coordinates in the image to represent an object and apply labels to it.  The coordinates will be connected in the order that they are provided and the last coordinate in the array will be connected to the first.
+ * This lets the labeler specify a series of coordinates in the image to represent an object and apply labels to it.  The coordinates are connected in the order that they are provided. The last coordinate in the array is connected to the first coordinate.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -100,7 +100,7 @@ public class ImageObjectSelectionEntity extends Entity {
     }
 
     /**
-     * Collection of Label entities
+     * A collection of label entities.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("labels")
     java.util.List<Label> labels;
@@ -109,8 +109,8 @@ public class ImageObjectSelectionEntity extends Entity {
     BoundingPolygon boundingPolygon;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("extendedMetadata")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/InitialRecordGenerationConfiguration.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/InitialRecordGenerationConfiguration.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Initial Generate Records configuration, generates records from the Dataset's source.
+ * The initial generate records configuration It generates records from the dataset's source.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -62,7 +62,7 @@ public class InitialRecordGenerationConfiguration {
     }
 
     /**
-     * the maximum number of records to generate.
+     * The maximum number of records to generate.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("limit")
     java.math.BigDecimal limit;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Label.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Label.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * A label is a string value.  The API will validate that it's one of the dataset's pre-defined labels. In the future, we'll be able to support a confidence score.
+ * A label is a string value.  The API validates that it's one of the dataset's pre-defined labels.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/LabelName.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/LabelName.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Represents a label.
+ * It represents a label.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/LabelSet.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/LabelSet.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * An ordered collection of Labels that are unique by name.
+ * An ordered collection of labels that are unique by name.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -60,7 +60,7 @@ public class LabelSet {
     }
 
     /**
-     * An ordered collection of Labels that are unique by name.
+     * An ordered collection of labels that are unique by name.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<LabelName> items;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/NormalizedVertex.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/NormalizedVertex.java
@@ -68,13 +68,13 @@ public class NormalizedVertex {
     }
 
     /**
-     * X axis coordinate
+     * The X axis coordinate.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("x")
     Float x;
 
     /**
-     * Y axis coordinate
+     * The Y axis coordinate.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("y")
     Float y;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ObjectStorageDatasetSourceDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ObjectStorageDatasetSourceDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Specifies the dataset location in object storage. This requires that all records are in this bucket, and under this prefix. We do not support a dataset with objects in arbitrary locations across buckets or prefixes.
+ * Specifies the dataset location in object storage. This requires that all records are in this bucket, and under this prefix. A dataset with objects in arbitrary locations across buckets or prefixes is not allowed.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -96,19 +96,19 @@ public class ObjectStorageDatasetSourceDetails extends DatasetSourceDetails {
     }
 
     /**
-     * Namespace of the bucket that contains the dataset data source
+     * The namespace of the bucket that contains the dataset data source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("namespace")
     String namespace;
 
     /**
-     * The object storage bucket that contains the dataset data source
+     * The object storage bucket that contains the dataset data source.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("bucket")
     String bucket;
 
     /**
-     * A common path prefix shared by the objects that make up the dataset.
+     * A common path prefix shared by the objects that make up the dataset. Records will not be generated for objects whose name match exactly with prefix.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("prefix")
     String prefix;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ObjectStorageSourceDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/ObjectStorageSourceDetails.java
@@ -130,7 +130,7 @@ public class ObjectStorageSourceDetails extends SourceDetails {
     java.math.BigDecimal offset;
 
     /**
-     * The length from offset into the file containing the content.
+     * The length from the offset into the file containing the content.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("length")
     java.math.BigDecimal length;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Record.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/Record.java
@@ -105,6 +105,15 @@ public class Record {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("recordMetadata")
+        private RecordMetadata recordMetadata;
+
+        public Builder recordMetadata(RecordMetadata recordMetadata) {
+            this.recordMetadata = recordMetadata;
+            this.__explicitlySet__.add("recordMetadata");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -139,6 +148,7 @@ public class Record {
                             sourceDetails,
                             isLabeled,
                             lifecycleState,
+                            recordMetadata,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -157,6 +167,7 @@ public class Record {
                             .sourceDetails(o.getSourceDetails())
                             .isLabeled(o.getIsLabeled())
                             .lifecycleState(o.getLifecycleState())
+                            .recordMetadata(o.getRecordMetadata())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -173,13 +184,13 @@ public class Record {
     }
 
     /**
-     * The OCID of the record
+     * The OCID of the record.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * This will be created by Customer. It will be unique and immutable.
+     * The name is created by the user. It is unique and immutable.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
@@ -197,7 +208,7 @@ public class Record {
     java.util.Date timeUpdated;
 
     /**
-     * The OCID of the dataset to associate the record with
+     * The OCID of the dataset to associate the record with.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("datasetId")
     String datasetId;
@@ -212,15 +223,15 @@ public class Record {
     SourceDetails sourceDetails;
 
     /**
-     * Whether the record has been labeled and has associated annotations.
+     * Whether or not the record has been labeled and has associated annotations.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isLabeled")
     Boolean isLabeled;
     /**
-     * Lifecycle state of the Record.
-     * ACTIVE - Record is active and ready for labeling.
-     * INACTIVE - Record has been marked as inactive and should not be used for labeling.
-     * DELETED - Record has been deleted and no longer available for labeling.
+     * The lifecycle state of the record.
+     * ACTIVE - The record is active and ready for labeling.
+     * INACTIVE - The record has been marked as inactive and should not be used for labeling.
+     * DELETED - The record has been deleted and is no longer available for labeling.
      *
      **/
     @lombok.extern.slf4j.Slf4j
@@ -268,26 +279,29 @@ public class Record {
         }
     };
     /**
-     * Lifecycle state of the Record.
-     * ACTIVE - Record is active and ready for labeling.
-     * INACTIVE - Record has been marked as inactive and should not be used for labeling.
-     * DELETED - Record has been deleted and no longer available for labeling.
+     * The lifecycle state of the record.
+     * ACTIVE - The record is active and ready for labeling.
+     * INACTIVE - The record has been marked as inactive and should not be used for labeling.
+     * DELETED - The record has been deleted and is no longer available for labeling.
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
 
+    @com.fasterxml.jackson.annotation.JsonProperty("recordMetadata")
+    RecordMetadata recordMetadata;
+
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordAggregationDimensions.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordAggregationDimensions.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Dimensions to summarize record information for a given dataset
+ * The dimensions to summarize record information for a given dataset.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -73,13 +73,13 @@ public class RecordAggregationDimensions {
     }
 
     /**
-     * Whether the record has been labeled and has associated annotations.
+     * Whether or not the record has been labeled and has associated annotations.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isLabeled")
     Boolean isLabeled;
 
     /**
-     * Whether the annotation contains label.
+     * Whether or not the annotation contains a label.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("annotationLabelContains")
     String annotationLabelContains;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordAnalyticsAggregation.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordAnalyticsAggregation.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Aggregation entities are required by the api consistency guidelines for API Consistency Guidelines#AnalyticsAPIs.  These are used to summarize record information for a given dataset and will be used to populate UI elements.  Aggregations need to have the fields that identify the exact scope that they're summarizing.  Any filters to the list API we apply would have to show up in the aggregation. We should limit the number of filters and dimensions as much as possible.
+ * Aggregation entities are required by the API consistency guidelines for API Consistency Guidelines#AnalyticsAPIs.  These are used to summarize record information for a given dataset and are used to populate UI elements.  Aggregations need to have the fields that identify the exact scope that they're summarizing.  Any filters applied to the list API, have to show up in the aggregation.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordAnalyticsAggregationCollection.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordAnalyticsAggregationCollection.java
@@ -62,7 +62,7 @@ public class RecordAnalyticsAggregationCollection {
     }
 
     /**
-     * List of Record entities.
+     * The list of record entities.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<RecordAnalyticsAggregation> items;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordCollection.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordCollection.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Results of a record search. Contains both RecordSummary items and other data.
+ * The results of a record search. It contains RecordSummary items and other data.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -59,7 +59,7 @@ public class RecordCollection {
     }
 
     /**
-     * List of records.
+     * The list of records.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("items")
     java.util.List<RecordSummary> items;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordMetadata.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordMetadata.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datalabelingservicedataplane.model;
+
+/**
+ * Collection of record's metadata.  This can be, for example, the height, width or depth of image for an image record.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "recordType",
+    defaultImpl = RecordMetadata.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = DocumentMetadata.class,
+        name = "DOCUMENT_METADATA"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ImageMetadata.class,
+        name = "IMAGE_METADATA"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = TextMetadata.class,
+        name = "TEXT_METADATA"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class RecordMetadata {
+
+    /**
+     * The record type based on dataset format details.
+     * IMAGE_METADATA  - Collection of metadata related to image record.
+     * TEXT_METADATA - Collection of metadata related to text record.
+     * DOCUMENT_METADATA - Collection of metadata related to document record.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum RecordType {
+        ImageMetadata("IMAGE_METADATA"),
+        TextMetadata("TEXT_METADATA"),
+        DocumentMetadata("DOCUMENT_METADATA"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, RecordType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RecordType v : RecordType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        RecordType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RecordType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'RecordType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+}

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordSummary.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/RecordSummary.java
@@ -162,13 +162,13 @@ public class RecordSummary {
     }
 
     /**
-     * The OCID of the record
+     * The OCID of the record.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("id")
     String id;
 
     /**
-     * This will be automatically assigned by the service. It will be unique and immutable
+     * The name is automatically assigned by the service. It is unique and immutable
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("name")
     String name;
@@ -186,7 +186,7 @@ public class RecordSummary {
     java.util.Date timeUpdated;
 
     /**
-     * The OCID of the dataset to associate the record with
+     * The OCID of the dataset to associate the record with.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("datasetId")
     String datasetId;
@@ -198,7 +198,7 @@ public class RecordSummary {
     String compartmentId;
 
     /**
-     * Whether the record has been labeled and has associated annotations.
+     * Whether or not the record has been labeled and has associated annotations.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("isLabeled")
     Boolean isLabeled;
@@ -210,16 +210,16 @@ public class RecordSummary {
     Record.LifecycleState lifecycleState;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/SortOrders.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/SortOrders.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Sort orders.
+ * The sort orders.
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")
 public enum SortOrders {

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/SourceDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/SourceDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * The source information is a polymorphic entity. It captures the details of data used for record creation. The discriminator type must match the dataset's source type. The convention will be enforced by the API.
+ * The source information is a polymorphic entity. It captures the details of data used for record creation. The discriminator type must match the dataset's source type. The convention is enforced by the API.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -39,7 +39,7 @@ public class SourceDetails {
 
     /**
      * The type of data source.
-     * OBJECT_STORAGE - source details for an object storage bucket.
+     * OBJECT_STORAGE - The source details for an object storage bucket.
      *
      **/
     @lombok.extern.slf4j.Slf4j

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/TextDatasetFormatDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/TextDatasetFormatDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Indicates the dataset is comprised of txt files.
+ * It indicates the dataset is comprised of TXT files.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/TextMetadata.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/TextMetadata.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datalabelingservicedataplane.model;
+
+/**
+ * Collection of metadata related to text record.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20211001")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = TextMetadata.Builder.class)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "recordType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class TextMetadata extends RecordMetadata {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public TextMetadata build() {
+            TextMetadata __instance__ = new TextMetadata();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(TextMetadata o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public TextMetadata() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/TextSelectionEntity.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/TextSelectionEntity.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * This allows the labeler to highlight text by specifying an offset and a length and apply labels to it.
+ * This lets the labeler highlight text, by specifying an offset and a length, and apply labels to it.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -100,7 +100,7 @@ public class TextSelectionEntity extends Entity {
     }
 
     /**
-     * Collection of Label entities
+     * A collection of label entities.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("labels")
     java.util.List<Label> labels;
@@ -109,8 +109,8 @@ public class TextSelectionEntity extends Entity {
     TextSpan textSpan;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("extendedMetadata")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/TextSpan.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/TextSpan.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * A wrapper class for offset and length, which together represent a span of text in a text document.
+ * A wrapper class for offset and length, which together, represent a span of text in a text document.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -68,13 +68,13 @@ public class TextSpan {
     }
 
     /**
-     * Offset of the selected text within the entire text.
+     * The offset of the selected text within the entire text.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("offset")
     java.math.BigDecimal offset;
 
     /**
-     * Length of the selected text.
+     * The length of the selected text.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("length")
     java.math.BigDecimal length;

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/UpdateAnnotationDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/UpdateAnnotationDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * This is the payload sent in the CreateAnnotation operation. It contains all the information required for a user to create an Annotation for a record.
+ * This is the payload sent in the CreateAnnotation operation. It contains all the information required for a user to create an annotation for a record.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -84,22 +84,22 @@ public class UpdateAnnotationDetails {
     }
 
     /**
-     * The entity types will be validated against the dataset to ensure consistency.
+     * The entity types are validated against the dataset to ensure consistency.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("entities")
     java.util.List<Entity> entities;
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/UpdateRecordDetails.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/model/UpdateRecordDetails.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.datalabelingservicedataplane.model;
 
 /**
- * Assuming we support tags, tags are supposed to be updatable.
+ * The details of the tags that is updated.
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
  * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
@@ -45,11 +45,21 @@ public class UpdateRecordDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("recordMetadata")
+        private RecordMetadata recordMetadata;
+
+        public Builder recordMetadata(RecordMetadata recordMetadata) {
+            this.recordMetadata = recordMetadata;
+            this.__explicitlySet__.add("recordMetadata");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateRecordDetails build() {
-            UpdateRecordDetails __instance__ = new UpdateRecordDetails(freeformTags, definedTags);
+            UpdateRecordDetails __instance__ =
+                    new UpdateRecordDetails(freeformTags, definedTags, recordMetadata);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -57,7 +67,9 @@ public class UpdateRecordDetails {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(UpdateRecordDetails o) {
             Builder copiedBuilder =
-                    freeformTags(o.getFreeformTags()).definedTags(o.getDefinedTags());
+                    freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .recordMetadata(o.getRecordMetadata());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -72,20 +84,23 @@ public class UpdateRecordDetails {
     }
 
     /**
-     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
-     * Example: {@code {"bar-key": "value"}}
+     * A simple key-value pair that is applied without any predefined name, type, or scope. It exists for cross-compatibility only.
+     * For example: {@code {"bar-key": "value"}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
     java.util.Map<String, String> freeformTags;
 
     /**
-     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
-     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     * The defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * For example: {@code {"foo-namespace": {"bar-key": "value"}}}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("recordMetadata")
+    RecordMetadata recordMetadata;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/CreateAnnotationRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/CreateAnnotationRequest.java
@@ -28,9 +28,9 @@ public class CreateAnnotationRequest
             createAnnotationDetails;
 
     /**
-     * A token that uniquely identifies a request so it can be retried in case of a timeout or
-     * server error without risk of executing that same action again. Retry tokens expire after 24
-     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * A token that uniquely identifies a request so it can be retried, without risk of executing that same action again, if there is a timeout or
+     * server error. Retry tokens expire after 24
+     * hours, but can be invalidated before then if there are conflicting operations. For example, if a resource
      * has been deleted and purged from the system, then a retry of the original creation request
      * might be rejected.
      *

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/CreateRecordRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/CreateRecordRequest.java
@@ -22,15 +22,15 @@ public class CreateRecordRequest
                 com.oracle.bmc.datalabelingservicedataplane.model.CreateRecordDetails> {
 
     /**
-     * Details for the new Record.
+     * The details for the new record.
      */
     private com.oracle.bmc.datalabelingservicedataplane.model.CreateRecordDetails
             createRecordDetails;
 
     /**
-     * A token that uniquely identifies a request so it can be retried in case of a timeout or
-     * server error without risk of executing that same action again. Retry tokens expire after 24
-     * hours, but can be invalidated before then due to conflicting operations. For example, if a resource
+     * A token that uniquely identifies a request so it can be retried, without risk of executing that same action again, if there is a timeout or
+     * server error. Retry tokens expire after 24
+     * hours, but can be invalidated before then if there are conflicting operations. For example, if a resource
      * has been deleted and purged from the system, then a retry of the original creation request
      * might be rejected.
      *

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/DeleteAnnotationRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/DeleteAnnotationRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 public class DeleteAnnotationRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * unique Annotation identifier
+     * A unique annotation identifier.
      */
     private String annotationId;
 
@@ -28,7 +28,7 @@ public class DeleteAnnotationRequest extends com.oracle.bmc.requests.BmcRequest<
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the {@code if-match} parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the etag you
+     * The resource is updated or deleted only if the etag you
      * provide matches the resource's current etag value.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/DeleteRecordRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/DeleteRecordRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 public class DeleteRecordRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the record annotated
+     * The OCID of the record annotated.
      */
     private String recordId;
 
@@ -28,7 +28,7 @@ public class DeleteRecordRequest extends com.oracle.bmc.requests.BmcRequest<java
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the {@code if-match} parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the etag you
+     * The resource is updated or deleted only if the etag you
      * provide matches the resource's current etag value.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetAnnotationRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetAnnotationRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 public class GetAnnotationRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * unique Annotation identifier
+     * A unique annotation identifier.
      */
     private String annotationId;
 

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetDatasetRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetDatasetRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 public class GetDatasetRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * Unique Dataset OCID
+     * A unique dataset OCID.
      */
     private String datasetId;
 

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetRecordContentRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetRecordContentRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 public class GetRecordContentRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the record annotated
+     * The OCID of the record annotated.
      */
     private String recordId;
 

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetRecordPreviewContentRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetRecordPreviewContentRequest.java
@@ -21,7 +21,7 @@ public class GetRecordPreviewContentRequest
         extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the record annotated
+     * The OCID of the record annotated.
      */
     private String recordId;
 

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetRecordRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/GetRecordRequest.java
@@ -20,7 +20,7 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 public class GetRecordRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
 
     /**
-     * The OCID of the record annotated
+     * The OCID of the record annotated.
      */
     private String recordId;
 

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/ListAnnotationsRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/ListAnnotationsRequest.java
@@ -25,28 +25,28 @@ public class ListAnnotationsRequest extends com.oracle.bmc.requests.BmcRequest<j
     private String compartmentId;
 
     /**
-     * Filter results by the OCID of the dataset.
+     * Filter the results by the OCID of the dataset.
      */
     private String datasetId;
 
     /**
-     * A filter to return only resources their lifecycleState matches the given lifecycleState.
+     * A filter to return only resources whose lifecycleState matches the given lifecycleState.
      */
     private com.oracle.bmc.datalabelingservicedataplane.model.Annotation.LifecycleState
             lifecycleState;
 
     /**
-     * Unique OCID identifier
+     * The unique OCID identifier.
      */
     private String id;
 
     /**
-     * The OCID of the principal who updated the annotation.
+     * The OCID of the principal which updated the annotation.
      */
     private String updatedBy;
 
     /**
-     * The OCID of the record annotated
+     * The OCID of the record annotated.
      */
     private String recordId;
 
@@ -78,12 +78,12 @@ public class ListAnnotationsRequest extends com.oracle.bmc.requests.BmcRequest<j
     private com.oracle.bmc.datalabelingservicedataplane.model.SortOrders sortOrder;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. The default order for timeCreated is descending. If no value is specified timeCreated is used by default.
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. The default order for timeCreated is descending. If no value is specified timeCreated is used by default.
      **/
     public enum SortBy {
         TimeCreated("timeCreated"),

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/ListRecordsRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/ListRecordsRequest.java
@@ -25,22 +25,22 @@ public class ListRecordsRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private String compartmentId;
 
     /**
-     * Filter results by the OCID of the dataset.
+     * Filter the results by the OCID of the dataset.
      */
     private String datasetId;
 
     /**
-     * A filter to return only resources their lifecycleState matches the given lifecycleState.
+     * A filter to return only resources whose lifecycleState matches the given lifecycleState.
      */
     private com.oracle.bmc.datalabelingservicedataplane.model.Record.LifecycleState lifecycleState;
 
     /**
-     * Name of the record
+     * The name of the record.
      */
     private String name;
 
     /**
-     * Unique OCID identifier
+     * The unique OCID identifier.
      */
     private String id;
 
@@ -50,7 +50,7 @@ public class ListRecordsRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private Boolean isLabeled;
 
     /**
-     * Allows the user to filter records based on the related annotations.
+     * Lets the user filter records based on the related annotations.
      *
      */
     private java.util.List<String> annotationLabelsContains;
@@ -71,13 +71,13 @@ public class ListRecordsRequest extends com.oracle.bmc.requests.BmcRequest<java.
     private com.oracle.bmc.datalabelingservicedataplane.model.SortOrders sortOrder;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for name is ascending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. The default order for timeCreated is descending. The default order for name is ascending. If no value is specified, timeCreated is used by default.
      *
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order for timeCreated is descending. Default order for name is ascending. If no value is specified timeCreated is default.
+     * The field to sort by. Only one sort order may be provided. The default order for timeCreated is descending. The default order for name is ascending. If no value is specified, timeCreated is used by default.
      *
      **/
     public enum SortBy {
@@ -127,7 +127,7 @@ public class ListRecordsRequest extends com.oracle.bmc.requests.BmcRequest<java.
         private java.util.List<String> annotationLabelsContains = null;
 
         /**
-         * Allows the user to filter records based on the related annotations.
+         * Lets the user filter records based on the related annotations.
          *
          * @return this builder instance
          */
@@ -137,7 +137,7 @@ public class ListRecordsRequest extends com.oracle.bmc.requests.BmcRequest<java.
         }
 
         /**
-         * Singular setter. Allows the user to filter records based on the related annotations.
+         * Singular setter. Lets the user filter records based on the related annotations.
          *
          * @return this builder instance
          */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/SummarizeAnnotationAnalyticsRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/SummarizeAnnotationAnalyticsRequest.java
@@ -26,18 +26,18 @@ public class SummarizeAnnotationAnalyticsRequest
     private String compartmentId;
 
     /**
-     * Filter results by the OCID of the dataset.
+     * Filter the results by the OCID of the dataset.
      */
     private String datasetId;
 
     /**
-     * A filter to return only resources their lifecycleState matches the given lifecycleState.
+     * A filter to return only resources whose lifecycleState matches the given lifecycleState.
      */
     private com.oracle.bmc.datalabelingservicedataplane.model.Annotation.LifecycleState
             lifecycleState;
 
     /**
-     * This field is used to summarize annotations with specified label.
+     * It summarizes annotations with the specified label.
      */
     private String label;
 
@@ -57,12 +57,12 @@ public class SummarizeAnnotationAnalyticsRequest
     private com.oracle.bmc.datalabelingservicedataplane.model.SortOrders sortOrder;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order is descending. If no value is specified updatedBy is default.
+     * The field to sort by. Only one sort order may be provided. The default order is descending. If no value is specified, updatedBy is used by default.
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order is descending. If no value is specified updatedBy is default.
+     * The field to sort by. Only one sort order may be provided. The default order is descending. If no value is specified, updatedBy is used by default.
      **/
     public enum SortBy {
         Count("count"),
@@ -98,12 +98,12 @@ public class SummarizeAnnotationAnalyticsRequest
         }
     };
     /**
-     * The field to group by. If no value is specified updatedBy is default.
+     * The field to group by. If no value is specified, updatedBy is used by default.
      */
     private AnnotationGroupBy annotationGroupBy;
 
     /**
-     * The field to group by. If no value is specified updatedBy is default.
+     * The field to group by. If no value is specified, updatedBy is used by default.
      **/
     public enum AnnotationGroupBy {
         UpdatedBy("updatedBy"),

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/SummarizeRecordAnalyticsRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/SummarizeRecordAnalyticsRequest.java
@@ -26,12 +26,12 @@ public class SummarizeRecordAnalyticsRequest
     private String compartmentId;
 
     /**
-     * Filter results by the OCID of the dataset.
+     * Filter the results by the OCID of the dataset.
      */
     private String datasetId;
 
     /**
-     * A filter to return only resources their lifecycleState matches the given lifecycleState.
+     * A filter to return only resources whose lifecycleState matches the given lifecycleState.
      */
     private com.oracle.bmc.datalabelingservicedataplane.model.Record.LifecycleState lifecycleState;
 
@@ -51,13 +51,13 @@ public class SummarizeRecordAnalyticsRequest
     private com.oracle.bmc.datalabelingservicedataplane.model.SortOrders sortOrder;
 
     /**
-     * The field to group by. If no value is specified isLabeled is default.
+     * The field to group by. If no value is specified isLabeled is used by default.
      *
      */
     private RecordGroupBy recordGroupBy;
 
     /**
-     * The field to group by. If no value is specified isLabeled is default.
+     * The field to group by. If no value is specified isLabeled is used by default.
      *
      **/
     public enum RecordGroupBy {
@@ -93,12 +93,12 @@ public class SummarizeRecordAnalyticsRequest
         }
     };
     /**
-     * The field to sort by. Only one sort order may be provided. Default order is descending. If no value is specified count is default.
+     * The field to sort by. Only one sort order may be provided. The default order is descending. If no value is specified, count is used by default.
      */
     private SortBy sortBy;
 
     /**
-     * The field to sort by. Only one sort order may be provided. Default order is descending. If no value is specified count is default.
+     * The field to sort by. Only one sort order may be provided. The default order is descending. If no value is specified, count is used by default.
      **/
     public enum SortBy {
         Count("count"),

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/UpdateAnnotationRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/UpdateAnnotationRequest.java
@@ -22,12 +22,12 @@ public class UpdateAnnotationRequest
                 com.oracle.bmc.datalabelingservicedataplane.model.UpdateAnnotationDetails> {
 
     /**
-     * unique Annotation identifier
+     * A unique annotation identifier.
      */
     private String annotationId;
 
     /**
-     * Information to be updated.
+     * The information to be updated.
      */
     private com.oracle.bmc.datalabelingservicedataplane.model.UpdateAnnotationDetails
             updateAnnotationDetails;
@@ -36,7 +36,7 @@ public class UpdateAnnotationRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the {@code if-match} parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the etag you
+     * The resource is updated or deleted only if the etag you
      * provide matches the resource's current etag value.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/UpdateRecordRequest.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/requests/UpdateRecordRequest.java
@@ -22,7 +22,7 @@ public class UpdateRecordRequest
                 com.oracle.bmc.datalabelingservicedataplane.model.UpdateRecordDetails> {
 
     /**
-     * The OCID of the record annotated
+     * The OCID of the record annotated.
      */
     private String recordId;
 
@@ -36,7 +36,7 @@ public class UpdateRecordRequest
      * For optimistic concurrency control. In the PUT or DELETE call
      * for a resource, set the {@code if-match} parameter to the value of the
      * etag from a previous GET or POST response for that resource.
-     * The resource will be updated or deleted only if the etag you
+     * The resource is updated or deleted only if the etag you
      * provide matches the resource's current etag value.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/CreateAnnotationResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/CreateAnnotationResponse.java
@@ -19,7 +19,7 @@ public class CreateAnnotationResponse extends com.oracle.bmc.responses.BmcRespon
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/CreateRecordResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/CreateRecordResponse.java
@@ -19,7 +19,7 @@ public class CreateRecordResponse extends com.oracle.bmc.responses.BmcResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/DeleteAnnotationResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/DeleteAnnotationResponse.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 @lombok.Getter
 public class DeleteAnnotationResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/DeleteRecordResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/DeleteRecordResponse.java
@@ -13,7 +13,7 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 @lombok.Getter
 public class DeleteRecordResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetAnnotationResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetAnnotationResponse.java
@@ -19,7 +19,7 @@ public class GetAnnotationResponse extends com.oracle.bmc.responses.BmcResponse 
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetDatasetResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetDatasetResponse.java
@@ -19,7 +19,7 @@ public class GetDatasetResponse extends com.oracle.bmc.responses.BmcResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetRecordContentResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetRecordContentResponse.java
@@ -19,7 +19,7 @@ public class GetRecordContentResponse extends com.oracle.bmc.responses.BmcRespon
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetRecordPreviewContentResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetRecordPreviewContentResponse.java
@@ -19,7 +19,7 @@ public class GetRecordPreviewContentResponse extends com.oracle.bmc.responses.Bm
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetRecordResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/GetRecordResponse.java
@@ -19,7 +19,7 @@ public class GetRecordResponse extends com.oracle.bmc.responses.BmcResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/ListAnnotationsResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/ListAnnotationsResponse.java
@@ -13,14 +13,14 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 @lombok.Getter
 public class ListAnnotationsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * For the pagination of a list of items. When paging through a list, if this header appears in the response,
      * then a partial list might have been returned. Include this value as the {@code page} parameter for the
      * subsequent GET request to get the next batch of items.
      *

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/ListRecordsResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/ListRecordsResponse.java
@@ -13,14 +13,14 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 @lombok.Getter
 public class ListRecordsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * For the pagination of a list of items. When paging through a list, if this header appears in the response,
      * then a partial list might have been returned. Include this value as the {@code page} parameter for the
      * subsequent GET request to get the next batch of items.
      *

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/SummarizeAnnotationAnalyticsResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/SummarizeAnnotationAnalyticsResponse.java
@@ -13,14 +13,14 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 @lombok.Getter
 public class SummarizeAnnotationAnalyticsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * For the pagination of a list of items. When paging through a list, if this header appears in the response,
      * then a partial list might have been returned. Include this value as the {@code page} parameter for the
      * subsequent GET request to get the next batch of items.
      *

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/SummarizeRecordAnalyticsResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/SummarizeRecordAnalyticsResponse.java
@@ -13,14 +13,14 @@ import com.oracle.bmc.datalabelingservicedataplane.model.*;
 @lombok.Getter
 public class SummarizeRecordAnalyticsResponse extends com.oracle.bmc.responses.BmcResponse {
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */
     private String opcRequestId;
 
     /**
-     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * For the pagination of a list of items. When paging through a list, if this header appears in the response,
      * then a partial list might have been returned. Include this value as the {@code page} parameter for the
      * subsequent GET request to get the next batch of items.
      *

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/UpdateAnnotationResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/UpdateAnnotationResponse.java
@@ -19,7 +19,7 @@ public class UpdateAnnotationResponse extends com.oracle.bmc.responses.BmcRespon
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/UpdateRecordResponse.java
+++ b/bmc-datalabelingservicedataplane/src/main/java/com/oracle/bmc/datalabelingservicedataplane/responses/UpdateRecordResponse.java
@@ -19,7 +19,7 @@ public class UpdateRecordResponse extends com.oracle.bmc.responses.BmcResponse {
     private String etag;
 
     /**
-     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * A unique Oracle-assigned identifier for the request. If you need to contact
      * Oracle about a particular request, please provide the request ID.
      *
      */

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -421,6 +421,10 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-identitydataplane</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-visualbuilder</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.13.0</version>
+        <version>2.13.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -390,6 +390,10 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-identitydataplane</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-visualbuilder</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identitydataplane/pom.xml
+++ b/bmc-identitydataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-identitydataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ospgateway/pom.xml
+++ b/bmc-ospgateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ospgateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemanagerproxy/pom.xml
+++ b/bmc-servicemanagerproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usage/pom.xml
+++ b/bmc-usage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-visualbuilder/pom.xml
+++ b/bmc-visualbuilder/pom.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.oracle.oci.sdk</groupId>
+    <artifactId>oci-java-sdk</artifactId>
+    <version>2.13.1</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>oci-java-sdk-visualbuilder</artifactId>
+  <name>Oracle Cloud Infrastructure SDK - Visual Builder</name>
+  <description>This project contains the SDK used for Oracle Cloud Infrastructure Visual Builder</description>
+  <url>https://docs.cloud.oracle.com/Content/API/SDKDocs/javasdk.htm</url>
+  <dependencies>
+    <dependency>
+      <groupId>com.oracle.oci.sdk</groupId>
+      <artifactId>oci-java-sdk-common</artifactId>
+      <version>2.13.1</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstance.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstance.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder;
+
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+
+/**
+ * Oracle Visual Builder enables developers to quickly build web and mobile applications. With a visual development environment that makes it easy to connect to Oracle data and third-party REST services, developers can build modern, consumer-grade applications in a fraction of the time it would take in other tools.
+ * The Visual Builder Instance Management API allows users to create and manage a Visual Builder instance.
+ *
+ * This service client uses CircuitBreakerUtils.DEFAULT_CIRCUIT_BREAKER for all the operations by default if no circuit breaker configuration is defined by the user.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+public interface VbInstance extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the service.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this Region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Change the compartment for an vb instance
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ChangeVbInstanceCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeVbInstanceCompartment API.
+     */
+    ChangeVbInstanceCompartmentResponse changeVbInstanceCompartment(
+            ChangeVbInstanceCompartmentRequest request);
+
+    /**
+     * Creates a new Vb Instance.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/CreateVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateVbInstance API.
+     */
+    CreateVbInstanceResponse createVbInstance(CreateVbInstanceRequest request);
+
+    /**
+     * Deletes an Vb Instance resource by identifier.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/DeleteVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteVbInstance API.
+     */
+    DeleteVbInstanceResponse deleteVbInstance(DeleteVbInstanceRequest request);
+
+    /**
+     * Gets a VbInstance by identifier
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/GetVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetVbInstance API.
+     */
+    GetVbInstanceResponse getVbInstance(GetVbInstanceRequest request);
+
+    /**
+     * Gets the status of the work request with the given ID.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
+     */
+    GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request);
+
+    /**
+     * Returns a list of Vb Instances.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListVbInstancesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListVbInstances API.
+     */
+    ListVbInstancesResponse listVbInstances(ListVbInstancesRequest request);
+
+    /**
+     * Get the errors of a work request.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestErrors API.
+     */
+    ListWorkRequestErrorsResponse listWorkRequestErrors(ListWorkRequestErrorsRequest request);
+
+    /**
+     * Get the logs of a work request.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestLogs API.
+     */
+    ListWorkRequestLogsResponse listWorkRequestLogs(ListWorkRequestLogsRequest request);
+
+    /**
+     * Lists the work requests in a compartment.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.
+     */
+    ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request);
+
+    /**
+     * Summarizes the applications for a vb instance.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/RequestSummarizedApplicationsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RequestSummarizedApplications API.
+     */
+    RequestSummarizedApplicationsResponse requestSummarizedApplications(
+            RequestSummarizedApplicationsRequest request);
+
+    /**
+     * Start an vb instance that was previously in an INACTIVE state. If the previous state is not
+     * INACTIVE, then the state of the vbInstance will not be changed and a 409 response returned.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/StartVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use StartVbInstance API.
+     */
+    StartVbInstanceResponse startVbInstance(StartVbInstanceRequest request);
+
+    /**
+     * Stop an vb instance that was previously in an ACTIVE state. If the previous state is not
+     * ACTIVE, then the state of the vbInstance will not be changed and a 409 response returned.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/StopVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use StopVbInstance API.
+     */
+    StopVbInstanceResponse stopVbInstance(StopVbInstanceRequest request);
+
+    /**
+     * Updates the Vb Instance.
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/UpdateVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateVbInstance API.
+     */
+    UpdateVbInstanceResponse updateVbInstance(UpdateVbInstanceRequest request);
+
+    /**
+     * Gets the pre-configured waiters available for resources for this service.
+     *
+     * @return The service waiters.
+     */
+    VbInstanceWaiters getWaiters();
+
+    /**
+     * Gets the pre-configured paginators available for list operations in this service which may return multiple
+     * pages of data. These paginators provide an {@link java.lang.Iterable} interface so that service responses, or
+     * resources/records, can be iterated through without having to manually deal with pagination and page tokens.
+     *
+     * @return The service paginators.
+     */
+    VbInstancePaginators getPaginators();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceAsync.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceAsync.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder;
+
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+
+/**
+ * Oracle Visual Builder enables developers to quickly build web and mobile applications. With a visual development environment that makes it easy to connect to Oracle data and third-party REST services, developers can build modern, consumer-grade applications in a fraction of the time it would take in other tools.
+ * The Visual Builder Instance Management API allows users to create and manage a Visual Builder instance.
+ *
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+public interface VbInstanceAsync extends AutoCloseable {
+
+    /**
+     * Sets the endpoint to call (ex, https://www.example.com).
+     * @param endpoint The endpoint of the serice.
+     */
+    void setEndpoint(String endpoint);
+
+    /**
+     * Gets the set endpoint for REST call (ex, https://www.example.com)
+     */
+    String getEndpoint();
+
+    /**
+     * Sets the region to call (ex, Region.US_PHOENIX_1).
+     * <p>
+     * Note, this will call {@link #setEndpoint(String) setEndpoint} after resolving the endpoint.  If the service is not available in this region, however, an IllegalArgumentException will be raised.
+     * @param region The region of the service.
+     */
+    void setRegion(com.oracle.bmc.Region region);
+
+    /**
+     * Sets the region to call (ex, 'us-phoenix-1').
+     * <p>
+     * Note, this will first try to map the region ID to a known Region and call
+     * {@link #setRegion(Region) setRegion}.
+     * <p>
+     * If no known Region could be determined, it will create an endpoint based on the
+     * default endpoint format ({@link com.oracle.bmc.Region#formatDefaultRegionEndpoint(Service, String)}
+     * and then call {@link #setEndpoint(String) setEndpoint}.
+     * @param regionId The public region ID.
+     */
+    void setRegion(String regionId);
+
+    /**
+     * Change the compartment for an vb instance
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ChangeVbInstanceCompartmentResponse> changeVbInstanceCompartment(
+            ChangeVbInstanceCompartmentRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ChangeVbInstanceCompartmentRequest, ChangeVbInstanceCompartmentResponse>
+                    handler);
+
+    /**
+     * Creates a new Vb Instance.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<CreateVbInstanceResponse> createVbInstance(
+            CreateVbInstanceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<CreateVbInstanceRequest, CreateVbInstanceResponse>
+                    handler);
+
+    /**
+     * Deletes an Vb Instance resource by identifier.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<DeleteVbInstanceResponse> deleteVbInstance(
+            DeleteVbInstanceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<DeleteVbInstanceRequest, DeleteVbInstanceResponse>
+                    handler);
+
+    /**
+     * Gets a VbInstance by identifier
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetVbInstanceResponse> getVbInstance(
+            GetVbInstanceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetVbInstanceRequest, GetVbInstanceResponse>
+                    handler);
+
+    /**
+     * Gets the status of the work request with the given ID.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<GetWorkRequestResponse> getWorkRequest(
+            GetWorkRequestRequest request,
+            com.oracle.bmc.responses.AsyncHandler<GetWorkRequestRequest, GetWorkRequestResponse>
+                    handler);
+
+    /**
+     * Returns a list of Vb Instances.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListVbInstancesResponse> listVbInstances(
+            ListVbInstancesRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListVbInstancesRequest, ListVbInstancesResponse>
+                    handler);
+
+    /**
+     * Get the errors of a work request.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListWorkRequestErrorsResponse> listWorkRequestErrors(
+            ListWorkRequestErrorsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>
+                    handler);
+
+    /**
+     * Get the logs of a work request.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListWorkRequestLogsResponse> listWorkRequestLogs(
+            ListWorkRequestLogsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>
+                    handler);
+
+    /**
+     * Lists the work requests in a compartment.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListWorkRequestsResponse> listWorkRequests(
+            ListWorkRequestsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<ListWorkRequestsRequest, ListWorkRequestsResponse>
+                    handler);
+
+    /**
+     * Summarizes the applications for a vb instance.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RequestSummarizedApplicationsResponse>
+            requestSummarizedApplications(
+                    RequestSummarizedApplicationsRequest request,
+                    com.oracle.bmc.responses.AsyncHandler<
+                                    RequestSummarizedApplicationsRequest,
+                                    RequestSummarizedApplicationsResponse>
+                            handler);
+
+    /**
+     * Start an vb instance that was previously in an INACTIVE state. If the previous state is not
+     * INACTIVE, then the state of the vbInstance will not be changed and a 409 response returned.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<StartVbInstanceResponse> startVbInstance(
+            StartVbInstanceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<StartVbInstanceRequest, StartVbInstanceResponse>
+                    handler);
+
+    /**
+     * Stop an vb instance that was previously in an ACTIVE state. If the previous state is not
+     * ACTIVE, then the state of the vbInstance will not be changed and a 409 response returned.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<StopVbInstanceResponse> stopVbInstance(
+            StopVbInstanceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<StopVbInstanceRequest, StopVbInstanceResponse>
+                    handler);
+
+    /**
+     * Updates the Vb Instance.
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<UpdateVbInstanceResponse> updateVbInstance(
+            UpdateVbInstanceRequest request,
+            com.oracle.bmc.responses.AsyncHandler<UpdateVbInstanceRequest, UpdateVbInstanceResponse>
+                    handler);
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceAsyncClient.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceAsyncClient.java
@@ -1,0 +1,924 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder;
+
+import com.oracle.bmc.visualbuilder.internal.http.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+
+/**
+ * Async client implementation for VbInstance service. <br/>
+ * There are two ways to use async client:
+ * 1. Use AsyncHandler: using AsyncHandler, if the response to the call is an {@link java.io.InputStream}, like
+ * getObject Api in object storage service, developers need to process the stream in AsyncHandler, and not anywhere else,
+ * because the stream will be closed right after the AsyncHandler is invoked. <br/>
+ * 2. Use Java Future: using Java Future, developers need to close the stream after they are done with the Java Future.<br/>
+ * Accessing the result should be done in a mutually exclusive manner, either through the Future or the AsyncHandler,
+ * but not both.  If the Future is used, the caller should pass in null as the AsyncHandler.  If the AsyncHandler
+ * is used, it is still safe to use the Future to determine whether or not the request was completed via
+ * Future.isDone/isCancelled.<br/>
+ * Please refer to https://github.com/oracle/oci-java-sdk/blob/master/bmc-examples/src/main/java/ResteasyClientWithObjectStorageExample.java
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class VbInstanceAsyncClient implements VbInstanceAsync {
+    /**
+     * Service instance for VbInstance.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("VBINSTANCE")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate(
+                            "https://visualbuilder.{region}.ocp.{secondLevelDomain}")
+                    .build();
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+
+    private final org.glassfish.jersey.apache.connector.ApacheConnectionClosingStrategy
+            apacheConnectionClosingStrategy;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public VbInstanceAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public VbInstanceAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public VbInstanceAsyncClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public VbInstanceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public VbInstanceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public VbInstanceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public VbInstanceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    public VbInstanceAsyncClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        boolean isNonBufferingApacheClient =
+                com.oracle.bmc.http.ApacheUtils.isNonBufferingClientConfigurator(
+                        restClientFactory.getClientConfigurator());
+        this.apacheConnectionClosingStrategy =
+                com.oracle.bmc.http.ApacheUtils.getApacheConnectionClosingStrategy(
+                        restClientFactory.getClientConfigurator());
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner,
+                        requestSigners,
+                        configuration,
+                        isNonBufferingApacheClient);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, VbInstanceAsyncClient> {
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public VbInstanceAsyncClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new VbInstanceAsyncClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public java.util.concurrent.Future<ChangeVbInstanceCompartmentResponse>
+            changeVbInstanceCompartment(
+                    ChangeVbInstanceCompartmentRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    ChangeVbInstanceCompartmentRequest,
+                                    ChangeVbInstanceCompartmentResponse>
+                            handler) {
+        LOG.trace("Called async changeVbInstanceCompartment");
+        final ChangeVbInstanceCompartmentRequest interceptedRequest =
+                ChangeVbInstanceCompartmentConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeVbInstanceCompartmentConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeVbInstanceCompartmentResponse>
+                transformer = ChangeVbInstanceCompartmentConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ChangeVbInstanceCompartmentRequest, ChangeVbInstanceCompartmentResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ChangeVbInstanceCompartmentRequest,
+                                ChangeVbInstanceCompartmentResponse>,
+                        java.util.concurrent.Future<ChangeVbInstanceCompartmentResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getChangeVbInstanceCompartmentDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ChangeVbInstanceCompartmentRequest, ChangeVbInstanceCompartmentResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<CreateVbInstanceResponse> createVbInstance(
+            CreateVbInstanceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            CreateVbInstanceRequest, CreateVbInstanceResponse>
+                    handler) {
+        LOG.trace("Called async createVbInstance");
+        final CreateVbInstanceRequest interceptedRequest =
+                CreateVbInstanceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateVbInstanceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, CreateVbInstanceResponse>
+                transformer = CreateVbInstanceConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<CreateVbInstanceRequest, CreateVbInstanceResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                CreateVbInstanceRequest, CreateVbInstanceResponse>,
+                        java.util.concurrent.Future<CreateVbInstanceResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getCreateVbInstanceDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    CreateVbInstanceRequest, CreateVbInstanceResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<DeleteVbInstanceResponse> deleteVbInstance(
+            DeleteVbInstanceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            DeleteVbInstanceRequest, DeleteVbInstanceResponse>
+                    handler) {
+        LOG.trace("Called async deleteVbInstance");
+        final DeleteVbInstanceRequest interceptedRequest =
+                DeleteVbInstanceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteVbInstanceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, DeleteVbInstanceResponse>
+                transformer = DeleteVbInstanceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<DeleteVbInstanceRequest, DeleteVbInstanceResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                DeleteVbInstanceRequest, DeleteVbInstanceResponse>,
+                        java.util.concurrent.Future<DeleteVbInstanceResponse>>
+                futureSupplier = client.deleteFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    DeleteVbInstanceRequest, DeleteVbInstanceResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetVbInstanceResponse> getVbInstance(
+            GetVbInstanceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<GetVbInstanceRequest, GetVbInstanceResponse>
+                    handler) {
+        LOG.trace("Called async getVbInstance");
+        final GetVbInstanceRequest interceptedRequest =
+                GetVbInstanceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVbInstanceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetVbInstanceResponse>
+                transformer = GetVbInstanceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetVbInstanceRequest, GetVbInstanceResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetVbInstanceRequest, GetVbInstanceResponse>,
+                        java.util.concurrent.Future<GetVbInstanceResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetVbInstanceRequest, GetVbInstanceResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<GetWorkRequestResponse> getWorkRequest(
+            GetWorkRequestRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            GetWorkRequestRequest, GetWorkRequestResponse>
+                    handler) {
+        LOG.trace("Called async getWorkRequest");
+        final GetWorkRequestRequest interceptedRequest =
+                GetWorkRequestConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetWorkRequestConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, GetWorkRequestResponse>
+                transformer = GetWorkRequestConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<GetWorkRequestRequest, GetWorkRequestResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                GetWorkRequestRequest, GetWorkRequestResponse>,
+                        java.util.concurrent.Future<GetWorkRequestResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    GetWorkRequestRequest, GetWorkRequestResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListVbInstancesResponse> listVbInstances(
+            ListVbInstancesRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListVbInstancesRequest, ListVbInstancesResponse>
+                    handler) {
+        LOG.trace("Called async listVbInstances");
+        final ListVbInstancesRequest interceptedRequest =
+                ListVbInstancesConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVbInstancesConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListVbInstancesResponse>
+                transformer = ListVbInstancesConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListVbInstancesRequest, ListVbInstancesResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListVbInstancesRequest, ListVbInstancesResponse>,
+                        java.util.concurrent.Future<ListVbInstancesResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListVbInstancesRequest, ListVbInstancesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListWorkRequestErrorsResponse> listWorkRequestErrors(
+            ListWorkRequestErrorsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>
+                    handler) {
+        LOG.trace("Called async listWorkRequestErrors");
+        final ListWorkRequestErrorsRequest interceptedRequest =
+                ListWorkRequestErrorsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestErrorsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListWorkRequestErrorsResponse>
+                transformer = ListWorkRequestErrorsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>,
+                        java.util.concurrent.Future<ListWorkRequestErrorsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListWorkRequestLogsResponse> listWorkRequestLogs(
+            ListWorkRequestLogsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>
+                    handler) {
+        LOG.trace("Called async listWorkRequestLogs");
+        final ListWorkRequestLogsRequest interceptedRequest =
+                ListWorkRequestLogsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestLogsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListWorkRequestLogsResponse>
+                transformer = ListWorkRequestLogsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>,
+                        java.util.concurrent.Future<ListWorkRequestLogsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListWorkRequestsResponse> listWorkRequests(
+            ListWorkRequestsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListWorkRequestsRequest, ListWorkRequestsResponse>
+                    handler) {
+        LOG.trace("Called async listWorkRequests");
+        final ListWorkRequestsRequest interceptedRequest =
+                ListWorkRequestsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkRequestsResponse>
+                transformer = ListWorkRequestsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<ListWorkRequestsRequest, ListWorkRequestsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListWorkRequestsRequest, ListWorkRequestsResponse>,
+                        java.util.concurrent.Future<ListWorkRequestsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListWorkRequestsRequest, ListWorkRequestsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<RequestSummarizedApplicationsResponse>
+            requestSummarizedApplications(
+                    RequestSummarizedApplicationsRequest request,
+                    final com.oracle.bmc.responses.AsyncHandler<
+                                    RequestSummarizedApplicationsRequest,
+                                    RequestSummarizedApplicationsResponse>
+                            handler) {
+        LOG.trace("Called async requestSummarizedApplications");
+        final RequestSummarizedApplicationsRequest interceptedRequest =
+                RequestSummarizedApplicationsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RequestSummarizedApplicationsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RequestSummarizedApplicationsResponse>
+                transformer = RequestSummarizedApplicationsConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        RequestSummarizedApplicationsRequest, RequestSummarizedApplicationsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RequestSummarizedApplicationsRequest,
+                                RequestSummarizedApplicationsResponse>,
+                        java.util.concurrent.Future<RequestSummarizedApplicationsResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getRequestSummarizedApplicationsDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RequestSummarizedApplicationsRequest, RequestSummarizedApplicationsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<StartVbInstanceResponse> startVbInstance(
+            StartVbInstanceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            StartVbInstanceRequest, StartVbInstanceResponse>
+                    handler) {
+        LOG.trace("Called async startVbInstance");
+        final StartVbInstanceRequest interceptedRequest =
+                StartVbInstanceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                StartVbInstanceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, StartVbInstanceResponse>
+                transformer = StartVbInstanceConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<StartVbInstanceRequest, StartVbInstanceResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                StartVbInstanceRequest, StartVbInstanceResponse>,
+                        java.util.concurrent.Future<StartVbInstanceResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    StartVbInstanceRequest, StartVbInstanceResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<StopVbInstanceResponse> stopVbInstance(
+            StopVbInstanceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            StopVbInstanceRequest, StopVbInstanceResponse>
+                    handler) {
+        LOG.trace("Called async stopVbInstance");
+        final StopVbInstanceRequest interceptedRequest =
+                StopVbInstanceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                StopVbInstanceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, StopVbInstanceResponse>
+                transformer = StopVbInstanceConverter.fromResponse();
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+
+        com.oracle.bmc.responses.AsyncHandler<StopVbInstanceRequest, StopVbInstanceResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                StopVbInstanceRequest, StopVbInstanceResponse>,
+                        java.util.concurrent.Future<StopVbInstanceResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    StopVbInstanceRequest, StopVbInstanceResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<UpdateVbInstanceResponse> updateVbInstance(
+            UpdateVbInstanceRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            UpdateVbInstanceRequest, UpdateVbInstanceResponse>
+                    handler) {
+        LOG.trace("Called async updateVbInstance");
+        final UpdateVbInstanceRequest interceptedRequest =
+                UpdateVbInstanceConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateVbInstanceConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<javax.ws.rs.core.Response, UpdateVbInstanceResponse>
+                transformer = UpdateVbInstanceConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<UpdateVbInstanceRequest, UpdateVbInstanceResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                UpdateVbInstanceRequest, UpdateVbInstanceResponse>,
+                        java.util.concurrent.Future<UpdateVbInstanceResponse>>
+                futureSupplier =
+                        client.putFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getUpdateVbInstanceDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    UpdateVbInstanceRequest, UpdateVbInstanceResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceClient.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceClient.java
@@ -1,0 +1,880 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder;
+
+import com.oracle.bmc.visualbuilder.internal.http.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import com.oracle.bmc.circuitbreaker.JaxRsCircuitBreaker;
+import com.oracle.bmc.util.CircuitBreakerUtils;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class VbInstanceClient implements VbInstance {
+    /**
+     * Service instance for VbInstance.
+     */
+    public static final com.oracle.bmc.Service SERVICE =
+            com.oracle.bmc.Services.serviceBuilder()
+                    .serviceName("VBINSTANCE")
+                    .serviceEndpointPrefix("")
+                    .serviceEndpointTemplate(
+                            "https://visualbuilder.{region}.ocp.{secondLevelDomain}")
+                    .build();
+    // attempt twice if it's instance principals, immediately failures will try to refresh the token
+    private static final int MAX_IMMEDIATE_RETRIES_IF_USING_INSTANCE_PRINCIPALS = 2;
+
+    private final VbInstanceWaiters waiters;
+
+    private final VbInstancePaginators paginators;
+
+    @lombok.Getter(value = lombok.AccessLevel.PACKAGE)
+    private final com.oracle.bmc.http.internal.RestClient client;
+
+    private final com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+            authenticationDetailsProvider;
+    private final com.oracle.bmc.retrier.RetryConfiguration retryConfiguration;
+    private final org.glassfish.jersey.apache.connector.ApacheConnectionClosingStrategy
+            apacheConnectionClosingStrategy;
+
+    /**
+     * Creates a new service instance using the given authentication provider.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     */
+    public VbInstanceClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider) {
+        this(authenticationDetailsProvider, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     */
+    public VbInstanceClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration) {
+        this(authenticationDetailsProvider, configuration, null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     */
+    public VbInstanceClient(
+            com.oracle.bmc.auth.BasicAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                        com.oracle.bmc.http.signing.SigningStrategy.STANDARD));
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     */
+    public VbInstanceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                new java.util.ArrayList<com.oracle.bmc.http.ClientConfigurator>());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     */
+    public VbInstanceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                additionalClientConfigurators,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public VbInstanceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory
+                        .createDefaultRequestSignerFactories(),
+                additionalClientConfigurators,
+                endpoint);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     */
+    public VbInstanceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                null);
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     */
+    public VbInstanceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService) {
+        this(
+                authenticationDetailsProvider,
+                configuration,
+                clientConfigurator,
+                defaultRequestSignerFactory,
+                signingStrategyRequestSignerFactories,
+                additionalClientConfigurators,
+                endpoint,
+                executorService,
+                com.oracle.bmc.http.internal.RestClientFactoryBuilder.builder());
+    }
+
+    /**
+     * Creates a new service instance using the given authentication provider and client configuration.  Additionally,
+     * a Consumer can be provided that will be invoked whenever a REST Client is created to allow for additional configuration/customization.
+     * <p>
+     * This is an advanced constructor for clients that want to take control over how requests are signed.
+     * Use the {@link Builder} to get access to all these parameters.
+     *
+     * @param authenticationDetailsProvider The authentication details provider, required.
+     * @param configuration The client configuration, optional.
+     * @param clientConfigurator ClientConfigurator that will be invoked for additional configuration of a REST client, optional.
+     * @param defaultRequestSignerFactory The request signer factory used to create the request signer for this service.
+     * @param signingStrategyRequestSignerFactories The request signer factories for each signing strategy used to create the request signer
+     * @param additionalClientConfigurators Additional client configurators to be run after the primary configurator.
+     * @param endpoint Endpoint, or null to leave unset (note, may be overridden by {@code authenticationDetailsProvider})
+     * @param executorService ExecutorService used by the client, or null to use the default configured ThreadPoolExecutor
+     * @param restClientFactoryBuilder the builder for the {@link com.oracle.bmc.http.internal.RestClientFactory}
+     */
+    protected VbInstanceClient(
+            com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider authenticationDetailsProvider,
+            com.oracle.bmc.ClientConfiguration configuration,
+            com.oracle.bmc.http.ClientConfigurator clientConfigurator,
+            com.oracle.bmc.http.signing.RequestSignerFactory defaultRequestSignerFactory,
+            java.util.Map<
+                            com.oracle.bmc.http.signing.SigningStrategy,
+                            com.oracle.bmc.http.signing.RequestSignerFactory>
+                    signingStrategyRequestSignerFactories,
+            java.util.List<com.oracle.bmc.http.ClientConfigurator> additionalClientConfigurators,
+            String endpoint,
+            java.util.concurrent.ExecutorService executorService,
+            com.oracle.bmc.http.internal.RestClientFactoryBuilder restClientFactoryBuilder) {
+        this.authenticationDetailsProvider = authenticationDetailsProvider;
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> authenticationDetailsConfigurators =
+                new java.util.ArrayList<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.ProvidesClientConfigurators) {
+            authenticationDetailsConfigurators.addAll(
+                    ((com.oracle.bmc.auth.ProvidesClientConfigurators)
+                                    this.authenticationDetailsProvider)
+                            .getClientConfigurators());
+        }
+        java.util.List<com.oracle.bmc.http.ClientConfigurator> allConfigurators =
+                new java.util.ArrayList<>(additionalClientConfigurators);
+        allConfigurators.addAll(authenticationDetailsConfigurators);
+        com.oracle.bmc.http.internal.RestClientFactory restClientFactory =
+                restClientFactoryBuilder
+                        .clientConfigurator(clientConfigurator)
+                        .additionalClientConfigurators(allConfigurators)
+                        .build();
+        boolean isNonBufferingApacheClient =
+                com.oracle.bmc.http.ApacheUtils.isNonBufferingClientConfigurator(
+                        restClientFactory.getClientConfigurator());
+        com.oracle.bmc.http.signing.RequestSigner defaultRequestSigner =
+                defaultRequestSignerFactory.createRequestSigner(
+                        SERVICE, this.authenticationDetailsProvider);
+        this.apacheConnectionClosingStrategy =
+                com.oracle.bmc.http.ApacheUtils.getApacheConnectionClosingStrategy(
+                        restClientFactory.getClientConfigurator());
+        java.util.Map<
+                        com.oracle.bmc.http.signing.SigningStrategy,
+                        com.oracle.bmc.http.signing.RequestSigner>
+                requestSigners = new java.util.HashMap<>();
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.BasicAuthenticationDetailsProvider) {
+            for (com.oracle.bmc.http.signing.SigningStrategy s :
+                    com.oracle.bmc.http.signing.SigningStrategy.values()) {
+                requestSigners.put(
+                        s,
+                        signingStrategyRequestSignerFactories
+                                .get(s)
+                                .createRequestSigner(SERVICE, authenticationDetailsProvider));
+            }
+        }
+
+        final com.oracle.bmc.ClientConfiguration clientConfigurationToUse =
+                (configuration != null)
+                        ? configuration
+                        : com.oracle.bmc.ClientConfiguration.builder().build();
+        this.retryConfiguration = clientConfigurationToUse.getRetryConfiguration();
+        JaxRsCircuitBreaker circuitBreaker =
+                CircuitBreakerUtils.getUserDefinedCircuitBreaker(configuration);
+        if (circuitBreaker == null) {
+            circuitBreaker = CircuitBreakerUtils.DEFAULT_CIRCUIT_BREAKER;
+        }
+        this.client =
+                restClientFactory.create(
+                        defaultRequestSigner,
+                        requestSigners,
+                        clientConfigurationToUse,
+                        isNonBufferingApacheClient,
+                        circuitBreaker);
+
+        if (executorService == null) {
+            // up to 50 (core) threads, time out after 60s idle, all daemon
+            java.util.concurrent.ThreadPoolExecutor threadPoolExecutor =
+                    new java.util.concurrent.ThreadPoolExecutor(
+                            50,
+                            50,
+                            60L,
+                            java.util.concurrent.TimeUnit.SECONDS,
+                            new java.util.concurrent.LinkedBlockingQueue<Runnable>(),
+                            new com.google.common.util.concurrent.ThreadFactoryBuilder()
+                                    .setDaemon(true)
+                                    .setNameFormat("VbInstance-waiters-%d")
+                                    .build());
+            threadPoolExecutor.allowCoreThreadTimeOut(true);
+
+            executorService = threadPoolExecutor;
+        }
+        this.waiters = new VbInstanceWaiters(executorService, this);
+
+        this.paginators = new VbInstancePaginators(this);
+
+        if (this.authenticationDetailsProvider instanceof com.oracle.bmc.auth.RegionProvider) {
+            com.oracle.bmc.auth.RegionProvider provider =
+                    (com.oracle.bmc.auth.RegionProvider) this.authenticationDetailsProvider;
+
+            if (provider.getRegion() != null) {
+                this.setRegion(provider.getRegion());
+                if (endpoint != null) {
+                    LOG.info(
+                            "Authentication details provider configured for region '{}', but endpoint specifically set to '{}'. Using endpoint setting instead of region.",
+                            provider.getRegion(),
+                            endpoint);
+                }
+            }
+        }
+        if (endpoint != null) {
+            setEndpoint(endpoint);
+        }
+    }
+
+    /**
+     * Create a builder for this client.
+     * @return builder
+     */
+    public static Builder builder() {
+        return new Builder(SERVICE);
+    }
+
+    /**
+     * Builder class for this client. The "authenticationDetailsProvider" is required and must be passed to the
+     * {@link #build(AbstractAuthenticationDetailsProvider)} method.
+     */
+    public static class Builder
+            extends com.oracle.bmc.common.RegionalClientBuilder<Builder, VbInstanceClient> {
+        private java.util.concurrent.ExecutorService executorService;
+
+        private Builder(com.oracle.bmc.Service service) {
+            super(service);
+            requestSignerFactory =
+                    new com.oracle.bmc.http.signing.internal.DefaultRequestSignerFactory(
+                            com.oracle.bmc.http.signing.SigningStrategy.STANDARD);
+        }
+
+        /**
+         * Set the ExecutorService for the client to be created.
+         * @param executorService executorService
+         * @return this builder
+         */
+        public Builder executorService(java.util.concurrent.ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        /**
+         * Build the client.
+         * @param authenticationDetailsProvider authentication details provider
+         * @return the client
+         */
+        public VbInstanceClient build(
+                @lombok.NonNull
+                com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+                        authenticationDetailsProvider) {
+            return new VbInstanceClient(
+                    authenticationDetailsProvider,
+                    configuration,
+                    clientConfigurator,
+                    requestSignerFactory,
+                    signingStrategyRequestSignerFactories,
+                    additionalClientConfigurators,
+                    endpoint,
+                    executorService);
+        }
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        LOG.info("Setting endpoint to {}", endpoint);
+        client.setEndpoint(endpoint);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint = null;
+        java.net.URI uri = client.getBaseTarget().getUri();
+        if (uri != null) {
+            endpoint = uri.toString();
+        }
+        return endpoint;
+    }
+
+    @Override
+    public void setRegion(com.oracle.bmc.Region region) {
+        com.google.common.base.Optional<String> endpoint = region.getEndpoint(SERVICE);
+        if (endpoint.isPresent()) {
+            setEndpoint(endpoint.get());
+        } else {
+            throw new IllegalArgumentException(
+                    "Endpoint for " + SERVICE + " is not known in region " + region);
+        }
+    }
+
+    @Override
+    public void setRegion(String regionId) {
+        regionId = regionId.toLowerCase(java.util.Locale.ENGLISH);
+        try {
+            com.oracle.bmc.Region region = com.oracle.bmc.Region.fromRegionId(regionId);
+            setRegion(region);
+        } catch (IllegalArgumentException e) {
+            LOG.info("Unknown regionId '{}', falling back to default endpoint format", regionId);
+            String endpoint = com.oracle.bmc.Region.formatDefaultRegionEndpoint(SERVICE, regionId);
+            setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public ChangeVbInstanceCompartmentResponse changeVbInstanceCompartment(
+            ChangeVbInstanceCompartmentRequest request) {
+        LOG.trace("Called changeVbInstanceCompartment");
+        final ChangeVbInstanceCompartmentRequest interceptedRequest =
+                ChangeVbInstanceCompartmentConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ChangeVbInstanceCompartmentConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ChangeVbInstanceCompartmentResponse>
+                transformer = ChangeVbInstanceCompartmentConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getChangeVbInstanceCompartmentDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public CreateVbInstanceResponse createVbInstance(CreateVbInstanceRequest request) {
+        LOG.trace("Called createVbInstance");
+        final CreateVbInstanceRequest interceptedRequest =
+                CreateVbInstanceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                CreateVbInstanceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, CreateVbInstanceResponse>
+                transformer = CreateVbInstanceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getCreateVbInstanceDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public DeleteVbInstanceResponse deleteVbInstance(DeleteVbInstanceRequest request) {
+        LOG.trace("Called deleteVbInstance");
+        final DeleteVbInstanceRequest interceptedRequest =
+                DeleteVbInstanceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                DeleteVbInstanceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, DeleteVbInstanceResponse>
+                transformer = DeleteVbInstanceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.delete(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetVbInstanceResponse getVbInstance(GetVbInstanceRequest request) {
+        LOG.trace("Called getVbInstance");
+        final GetVbInstanceRequest interceptedRequest =
+                GetVbInstanceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetVbInstanceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetVbInstanceResponse>
+                transformer = GetVbInstanceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public GetWorkRequestResponse getWorkRequest(GetWorkRequestRequest request) {
+        LOG.trace("Called getWorkRequest");
+        final GetWorkRequestRequest interceptedRequest =
+                GetWorkRequestConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                GetWorkRequestConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, GetWorkRequestResponse>
+                transformer = GetWorkRequestConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListVbInstancesResponse listVbInstances(ListVbInstancesRequest request) {
+        LOG.trace("Called listVbInstances");
+        final ListVbInstancesRequest interceptedRequest =
+                ListVbInstancesConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListVbInstancesConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListVbInstancesResponse>
+                transformer = ListVbInstancesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListWorkRequestErrorsResponse listWorkRequestErrors(
+            ListWorkRequestErrorsRequest request) {
+        LOG.trace("Called listWorkRequestErrors");
+        final ListWorkRequestErrorsRequest interceptedRequest =
+                ListWorkRequestErrorsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestErrorsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkRequestErrorsResponse>
+                transformer = ListWorkRequestErrorsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListWorkRequestLogsResponse listWorkRequestLogs(ListWorkRequestLogsRequest request) {
+        LOG.trace("Called listWorkRequestLogs");
+        final ListWorkRequestLogsRequest interceptedRequest =
+                ListWorkRequestLogsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestLogsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkRequestLogsResponse>
+                transformer = ListWorkRequestLogsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request) {
+        LOG.trace("Called listWorkRequests");
+        final ListWorkRequestsRequest interceptedRequest =
+                ListWorkRequestsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListWorkRequestsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListWorkRequestsResponse>
+                transformer = ListWorkRequestsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public RequestSummarizedApplicationsResponse requestSummarizedApplications(
+            RequestSummarizedApplicationsRequest request) {
+        LOG.trace("Called requestSummarizedApplications");
+        final RequestSummarizedApplicationsRequest interceptedRequest =
+                RequestSummarizedApplicationsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RequestSummarizedApplicationsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RequestSummarizedApplicationsResponse>
+                transformer = RequestSummarizedApplicationsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest
+                                                        .getRequestSummarizedApplicationsDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public StartVbInstanceResponse startVbInstance(StartVbInstanceRequest request) {
+        LOG.trace("Called startVbInstance");
+        final StartVbInstanceRequest interceptedRequest =
+                StartVbInstanceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                StartVbInstanceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, StartVbInstanceResponse>
+                transformer = StartVbInstanceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public StopVbInstanceResponse stopVbInstance(StopVbInstanceRequest request) {
+        LOG.trace("Called stopVbInstance");
+        final StopVbInstanceRequest interceptedRequest =
+                StopVbInstanceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                StopVbInstanceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, StopVbInstanceResponse>
+                transformer = StopVbInstanceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public UpdateVbInstanceResponse updateVbInstance(UpdateVbInstanceRequest request) {
+        LOG.trace("Called updateVbInstance");
+        final UpdateVbInstanceRequest interceptedRequest =
+                UpdateVbInstanceConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                UpdateVbInstanceConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, UpdateVbInstanceResponse>
+                transformer = UpdateVbInstanceConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.put(
+                                                ib,
+                                                retriedRequest.getUpdateVbInstanceDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public VbInstanceWaiters getWaiters() {
+        return waiters;
+    }
+
+    @Override
+    public VbInstancePaginators getPaginators() {
+        return paginators;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstancePaginators.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstancePaginators.java
@@ -1,0 +1,485 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder;
+
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+
+/**
+ * Collection of helper methods that can be used to provide an {@link java.lang.Iterable} interface
+ * to any list operations of VbInstance where multiple pages of data may be fetched.
+ * Two styles of iteration are supported:
+ *
+ * <ul>
+ *   <li>Iterating over the Response objects returned by the list operation. These are referred to as ResponseIterators, and the methods are suffixed with ResponseIterator. For example: <i>listUsersResponseIterator</i></li>
+ *   <li>Iterating over the resources/records being listed. These are referred to as RecordIterators, and the methods are suffixed with RecordIterator. For example: <i>listUsersRecordIterator</i></li>
+ * </ul>
+ *
+ * These iterables abstract away the need to write code to manually handle pagination via looping and using the page tokens.
+ * They will automatically fetch more data from the service when required.
+ *
+ * As an example, if we were using the ListUsers operation in IdentityService, then the {@link java.lang.Iterable} returned by calling a
+ * ResponseIterator method would iterate over the ListUsersResponse objects returned by each ListUsers call, whereas the {@link java.lang.Iterable}
+ * returned by calling a RecordIterator method would iterate over the User records and we don't have to deal with ListUsersResponse objects at all.
+ * In either case, pagination will be automatically handled so we can iterate until there are no more responses or no more resources/records available.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.RequiredArgsConstructor
+public class VbInstancePaginators {
+    private final VbInstance client;
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listVbInstances operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListVbInstancesResponse> listVbInstancesResponseIterator(
+            final ListVbInstancesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListVbInstancesRequest.Builder, ListVbInstancesRequest, ListVbInstancesResponse>(
+                new com.google.common.base.Supplier<ListVbInstancesRequest.Builder>() {
+                    @Override
+                    public ListVbInstancesRequest.Builder get() {
+                        return ListVbInstancesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVbInstancesResponse, String>() {
+                    @Override
+                    public String apply(ListVbInstancesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVbInstancesRequest.Builder>,
+                        ListVbInstancesRequest>() {
+                    @Override
+                    public ListVbInstancesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVbInstancesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVbInstancesRequest, ListVbInstancesResponse>() {
+                    @Override
+                    public ListVbInstancesResponse apply(ListVbInstancesRequest request) {
+                        return client.listVbInstances(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.visualbuilder.model.VbInstanceSummary} objects
+     * contained in responses from the listVbInstances operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.visualbuilder.model.VbInstanceSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.visualbuilder.model.VbInstanceSummary>
+            listVbInstancesRecordIterator(final ListVbInstancesRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListVbInstancesRequest.Builder, ListVbInstancesRequest, ListVbInstancesResponse,
+                com.oracle.bmc.visualbuilder.model.VbInstanceSummary>(
+                new com.google.common.base.Supplier<ListVbInstancesRequest.Builder>() {
+                    @Override
+                    public ListVbInstancesRequest.Builder get() {
+                        return ListVbInstancesRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListVbInstancesResponse, String>() {
+                    @Override
+                    public String apply(ListVbInstancesResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListVbInstancesRequest.Builder>,
+                        ListVbInstancesRequest>() {
+                    @Override
+                    public ListVbInstancesRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListVbInstancesRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVbInstancesRequest, ListVbInstancesResponse>() {
+                    @Override
+                    public ListVbInstancesResponse apply(ListVbInstancesRequest request) {
+                        return client.listVbInstances(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListVbInstancesResponse,
+                        java.util.List<com.oracle.bmc.visualbuilder.model.VbInstanceSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.visualbuilder.model.VbInstanceSummary>
+                            apply(ListVbInstancesResponse response) {
+                        return response.getVbInstanceSummaryCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listWorkRequestErrors operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListWorkRequestErrorsResponse> listWorkRequestErrorsResponseIterator(
+            final ListWorkRequestErrorsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListWorkRequestErrorsRequest.Builder, ListWorkRequestErrorsRequest,
+                ListWorkRequestErrorsResponse>(
+                new com.google.common.base.Supplier<ListWorkRequestErrorsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestErrorsRequest.Builder get() {
+                        return ListWorkRequestErrorsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestErrorsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestErrorsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestErrorsRequest.Builder>,
+                        ListWorkRequestErrorsRequest>() {
+                    @Override
+                    public ListWorkRequestErrorsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestErrorsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>() {
+                    @Override
+                    public ListWorkRequestErrorsResponse apply(
+                            ListWorkRequestErrorsRequest request) {
+                        return client.listWorkRequestErrors(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.visualbuilder.model.WorkRequestError} objects
+     * contained in responses from the listWorkRequestErrors operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.visualbuilder.model.WorkRequestError} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.visualbuilder.model.WorkRequestError>
+            listWorkRequestErrorsRecordIterator(final ListWorkRequestErrorsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListWorkRequestErrorsRequest.Builder, ListWorkRequestErrorsRequest,
+                ListWorkRequestErrorsResponse, com.oracle.bmc.visualbuilder.model.WorkRequestError>(
+                new com.google.common.base.Supplier<ListWorkRequestErrorsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestErrorsRequest.Builder get() {
+                        return ListWorkRequestErrorsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestErrorsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestErrorsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestErrorsRequest.Builder>,
+                        ListWorkRequestErrorsRequest>() {
+                    @Override
+                    public ListWorkRequestErrorsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestErrorsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestErrorsRequest, ListWorkRequestErrorsResponse>() {
+                    @Override
+                    public ListWorkRequestErrorsResponse apply(
+                            ListWorkRequestErrorsRequest request) {
+                        return client.listWorkRequestErrors(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestErrorsResponse,
+                        java.util.List<com.oracle.bmc.visualbuilder.model.WorkRequestError>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.visualbuilder.model.WorkRequestError>
+                            apply(ListWorkRequestErrorsResponse response) {
+                        return response.getWorkRequestErrorCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listWorkRequestLogs operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListWorkRequestLogsResponse> listWorkRequestLogsResponseIterator(
+            final ListWorkRequestLogsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListWorkRequestLogsRequest.Builder, ListWorkRequestLogsRequest,
+                ListWorkRequestLogsResponse>(
+                new com.google.common.base.Supplier<ListWorkRequestLogsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestLogsRequest.Builder get() {
+                        return ListWorkRequestLogsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestLogsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestLogsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestLogsRequest.Builder>,
+                        ListWorkRequestLogsRequest>() {
+                    @Override
+                    public ListWorkRequestLogsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestLogsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>() {
+                    @Override
+                    public ListWorkRequestLogsResponse apply(ListWorkRequestLogsRequest request) {
+                        return client.listWorkRequestLogs(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.visualbuilder.model.WorkRequestLogEntry} objects
+     * contained in responses from the listWorkRequestLogs operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.visualbuilder.model.WorkRequestLogEntry} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.visualbuilder.model.WorkRequestLogEntry>
+            listWorkRequestLogsRecordIterator(final ListWorkRequestLogsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListWorkRequestLogsRequest.Builder, ListWorkRequestLogsRequest,
+                ListWorkRequestLogsResponse,
+                com.oracle.bmc.visualbuilder.model.WorkRequestLogEntry>(
+                new com.google.common.base.Supplier<ListWorkRequestLogsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestLogsRequest.Builder get() {
+                        return ListWorkRequestLogsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestLogsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestLogsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestLogsRequest.Builder>,
+                        ListWorkRequestLogsRequest>() {
+                    @Override
+                    public ListWorkRequestLogsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestLogsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestLogsRequest, ListWorkRequestLogsResponse>() {
+                    @Override
+                    public ListWorkRequestLogsResponse apply(ListWorkRequestLogsRequest request) {
+                        return client.listWorkRequestLogs(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestLogsResponse,
+                        java.util.List<com.oracle.bmc.visualbuilder.model.WorkRequestLogEntry>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.visualbuilder.model.WorkRequestLogEntry>
+                            apply(ListWorkRequestLogsResponse response) {
+                        return response.getWorkRequestLogEntryCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listWorkRequests operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListWorkRequestsResponse> listWorkRequestsResponseIterator(
+            final ListWorkRequestsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListWorkRequestsRequest.Builder, ListWorkRequestsRequest, ListWorkRequestsResponse>(
+                new com.google.common.base.Supplier<ListWorkRequestsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestsRequest.Builder get() {
+                        return ListWorkRequestsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestsRequest.Builder>,
+                        ListWorkRequestsRequest>() {
+                    @Override
+                    public ListWorkRequestsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestsRequest, ListWorkRequestsResponse>() {
+                    @Override
+                    public ListWorkRequestsResponse apply(ListWorkRequestsRequest request) {
+                        return client.listWorkRequests(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.visualbuilder.model.WorkRequestSummary} objects
+     * contained in responses from the listWorkRequests operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.visualbuilder.model.WorkRequestSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.visualbuilder.model.WorkRequestSummary>
+            listWorkRequestsRecordIterator(final ListWorkRequestsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListWorkRequestsRequest.Builder, ListWorkRequestsRequest, ListWorkRequestsResponse,
+                com.oracle.bmc.visualbuilder.model.WorkRequestSummary>(
+                new com.google.common.base.Supplier<ListWorkRequestsRequest.Builder>() {
+                    @Override
+                    public ListWorkRequestsRequest.Builder get() {
+                        return ListWorkRequestsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListWorkRequestsResponse, String>() {
+                    @Override
+                    public String apply(ListWorkRequestsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListWorkRequestsRequest.Builder>,
+                        ListWorkRequestsRequest>() {
+                    @Override
+                    public ListWorkRequestsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListWorkRequestsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestsRequest, ListWorkRequestsResponse>() {
+                    @Override
+                    public ListWorkRequestsResponse apply(ListWorkRequestsRequest request) {
+                        return client.listWorkRequests(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListWorkRequestsResponse,
+                        java.util.List<com.oracle.bmc.visualbuilder.model.WorkRequestSummary>>() {
+                    @Override
+                    public java.util.List<com.oracle.bmc.visualbuilder.model.WorkRequestSummary>
+                            apply(ListWorkRequestsResponse response) {
+                        return response.getWorkRequestSummaryCollection().getItems();
+                    }
+                });
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceWaiters.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/VbInstanceWaiters.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder;
+
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+
+/**
+ * Collection of helper methods to produce {@link com.oracle.bmc.waiter.Waiter}s for different
+ * resources of VbInstance.
+ * <p>
+ * The default configuration used is defined by {@link com.oracle.bmc.waiter.Waiters.Waiters#DEFAULT_POLLING_WAITER}.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.RequiredArgsConstructor
+public class VbInstanceWaiters {
+    private final java.util.concurrent.ExecutorService executorService;
+    private final VbInstance client;
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVbInstanceRequest, GetVbInstanceResponse> forVbInstance(
+            GetVbInstanceRequest request,
+            com.oracle.bmc.visualbuilder.model.VbInstance.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one targetState must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null targetState values are not permitted");
+
+        return forVbInstance(
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request, targetStates);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param targetState the desired state to wait for
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVbInstanceRequest, GetVbInstanceResponse> forVbInstance(
+            GetVbInstanceRequest request,
+            com.oracle.bmc.visualbuilder.model.VbInstance.LifecycleState targetState,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
+
+        return forVbInstance(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetState);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetVbInstanceRequest, GetVbInstanceResponse> forVbInstance(
+            GetVbInstanceRequest request,
+            com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+            com.oracle.bmc.waiter.DelayStrategy delayStrategy,
+            com.oracle.bmc.visualbuilder.model.VbInstance.LifecycleState... targetStates) {
+        org.apache.commons.lang3.Validate.notEmpty(
+                targetStates, "At least one target state must be provided");
+        org.apache.commons.lang3.Validate.noNullElements(
+                targetStates, "Null target states are not permitted");
+
+        return forVbInstance(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request,
+                targetStates);
+    }
+
+    // Helper method to create a new Waiter for VbInstance.
+    private com.oracle.bmc.waiter.Waiter<GetVbInstanceRequest, GetVbInstanceResponse> forVbInstance(
+            com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+            final GetVbInstanceRequest request,
+            final com.oracle.bmc.visualbuilder.model.VbInstance.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.visualbuilder.model.VbInstance.LifecycleState>
+                targetStatesSet = new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetVbInstanceRequest, GetVbInstanceResponse>() {
+                            @Override
+                            public GetVbInstanceResponse apply(GetVbInstanceRequest request) {
+                                return client.getVbInstance(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetVbInstanceResponse>() {
+                            @Override
+                            public boolean apply(GetVbInstanceResponse response) {
+                                return targetStatesSet.contains(
+                                        response.getVbInstance().getLifecycleState());
+                            }
+                        },
+                        targetStatesSet.contains(
+                                com.oracle.bmc.visualbuilder.model.VbInstance.LifecycleState
+                                        .Deleted)),
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@code Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetWorkRequestRequest, GetWorkRequestResponse>
+            forWorkRequest(GetWorkRequestRequest request) {
+        return forWorkRequest(com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_WAITER, request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@linkcom.oracle.bmc.waiter. DelayStrategy} to use
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<GetWorkRequestRequest, GetWorkRequestResponse>
+            forWorkRequest(
+                    GetWorkRequestRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        return forWorkRequest(
+                com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
+                request);
+    }
+
+    // Helper method to create a new Waiter for WorkRequest.
+    private com.oracle.bmc.waiter.Waiter<GetWorkRequestRequest, GetWorkRequestResponse>
+            forWorkRequest(
+                    com.oracle.bmc.waiter.BmcGenericWaiter waiter,
+                    final GetWorkRequestRequest request) {
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                waiter.toCallable(
+                        com.google.common.base.Suppliers.ofInstance(request),
+                        new com.google.common.base.Function<
+                                GetWorkRequestRequest, GetWorkRequestResponse>() {
+                            @Override
+                            public GetWorkRequestResponse apply(GetWorkRequestRequest request) {
+                                return client.getWorkRequest(request);
+                            }
+                        },
+                        new com.google.common.base.Predicate<GetWorkRequestResponse>() {
+                            @Override
+                            public boolean apply(GetWorkRequestResponse response) {
+                                // work requests are complete once the time finished is available
+                                return response.getWorkRequest().getTimeFinished() != null;
+                            }
+                        },
+                        false),
+                request);
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ChangeVbInstanceCompartmentConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ChangeVbInstanceCompartmentConverter.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class ChangeVbInstanceCompartmentConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.ChangeVbInstanceCompartmentRequest
+            interceptRequest(
+                    com.oracle.bmc.visualbuilder.requests.ChangeVbInstanceCompartmentRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.ChangeVbInstanceCompartmentRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVbInstanceId(), "vbInstanceId must not be blank");
+        Validate.notNull(
+                request.getChangeVbInstanceCompartmentDetails(),
+                "changeVbInstanceCompartmentDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("vbInstances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVbInstanceId()))
+                        .path("actions")
+                        .path("changeCompartment");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.ChangeVbInstanceCompartmentResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.ChangeVbInstanceCompartmentResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses
+                                        .ChangeVbInstanceCompartmentResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses
+                                            .ChangeVbInstanceCompartmentResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.ChangeVbInstanceCompartmentResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses
+                                                .ChangeVbInstanceCompartmentResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .ChangeVbInstanceCompartmentResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses
+                                                .ChangeVbInstanceCompartmentResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/CreateVbInstanceConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/CreateVbInstanceConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class CreateVbInstanceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.CreateVbInstanceRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.CreateVbInstanceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.CreateVbInstanceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getCreateVbInstanceDetails(), "createVbInstanceDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20210601").path("vbInstances");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.CreateVbInstanceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.CreateVbInstanceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses.CreateVbInstanceResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses.CreateVbInstanceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.CreateVbInstanceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.CreateVbInstanceResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .CreateVbInstanceResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.CreateVbInstanceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/DeleteVbInstanceConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/DeleteVbInstanceConverter.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class DeleteVbInstanceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.DeleteVbInstanceRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.DeleteVbInstanceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.DeleteVbInstanceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVbInstanceId(), "vbInstanceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("vbInstances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVbInstanceId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.DeleteVbInstanceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.DeleteVbInstanceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses.DeleteVbInstanceResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses.DeleteVbInstanceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.DeleteVbInstanceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.DeleteVbInstanceResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .DeleteVbInstanceResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.DeleteVbInstanceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/GetVbInstanceConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/GetVbInstanceConverter.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class GetVbInstanceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.GetVbInstanceRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.GetVbInstanceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.GetVbInstanceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVbInstanceId(), "vbInstanceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("vbInstances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVbInstanceId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.GetVbInstanceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.GetVbInstanceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses.GetVbInstanceResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses.GetVbInstanceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.GetVbInstanceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                .VbInstance>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                        .VbInstance
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.visualbuilder.model.VbInstance>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.GetVbInstanceResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .GetVbInstanceResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.vbInstance(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.GetVbInstanceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/GetWorkRequestConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/GetWorkRequestConverter.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class GetWorkRequestConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.GetWorkRequestRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.GetWorkRequestRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.GetWorkRequestRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getWorkRequestId(), "workRequestId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("workRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkRequestId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.GetWorkRequestResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.GetWorkRequestResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses.GetWorkRequestResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses.GetWorkRequestResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.GetWorkRequestResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                .WorkRequest>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                        .WorkRequest
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.visualbuilder.model.WorkRequest>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.GetWorkRequestResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .GetWorkRequestResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.workRequest(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        retryAfterHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "retry-after");
+                                if (retryAfterHeader.isPresent()) {
+                                    builder.retryAfter(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "retry-after",
+                                                    retryAfterHeader.get().get(0),
+                                                    Float.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.GetWorkRequestResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ListVbInstancesConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ListVbInstancesConverter.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class ListVbInstancesConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.ListVbInstancesRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.ListVbInstancesRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.ListVbInstancesRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20210601").path("vbInstances");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getDisplayName() != null) {
+            target =
+                    target.queryParam(
+                            "displayName",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getDisplayName()));
+        }
+
+        if (request.getLifecycleState() != null) {
+            target =
+                    target.queryParam(
+                            "lifecycleState",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLifecycleState().getValue()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.ListVbInstancesResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.ListVbInstancesResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses.ListVbInstancesResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses.ListVbInstancesResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.ListVbInstancesResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                .VbInstanceSummaryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                        .VbInstanceSummaryCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.visualbuilder.model
+                                                        .VbInstanceSummaryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.ListVbInstancesResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .ListVbInstancesResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.vbInstanceSummaryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPreviousPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-previous-page");
+                                if (opcPreviousPageHeader.isPresent()) {
+                                    builder.opcPreviousPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-previous-page",
+                                                    opcPreviousPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.ListVbInstancesResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ListWorkRequestErrorsConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ListWorkRequestErrorsConverter.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class ListWorkRequestErrorsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.ListWorkRequestErrorsRequest
+            interceptRequest(
+                    com.oracle.bmc.visualbuilder.requests.ListWorkRequestErrorsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.ListWorkRequestErrorsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+        Validate.notBlank(request.getWorkRequestId(), "workRequestId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("workRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkRequestId()))
+                        .path("errors");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.ListWorkRequestErrorsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.ListWorkRequestErrorsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses
+                                        .ListWorkRequestErrorsResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses
+                                            .ListWorkRequestErrorsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.ListWorkRequestErrorsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                .WorkRequestErrorCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                        .WorkRequestErrorCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.visualbuilder.model
+                                                        .WorkRequestErrorCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.ListWorkRequestErrorsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .ListWorkRequestErrorsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.workRequestErrorCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPreviousPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-previous-page");
+                                if (opcPreviousPageHeader.isPresent()) {
+                                    builder.opcPreviousPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-previous-page",
+                                                    opcPreviousPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.ListWorkRequestErrorsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ListWorkRequestLogsConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ListWorkRequestLogsConverter.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class ListWorkRequestLogsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.ListWorkRequestLogsRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.ListWorkRequestLogsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.ListWorkRequestLogsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+        Validate.notBlank(request.getWorkRequestId(), "workRequestId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("workRequests")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getWorkRequestId()))
+                        .path("logs");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.ListWorkRequestLogsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.ListWorkRequestLogsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses
+                                        .ListWorkRequestLogsResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses
+                                            .ListWorkRequestLogsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.ListWorkRequestLogsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                .WorkRequestLogEntryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                        .WorkRequestLogEntryCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.visualbuilder.model
+                                                        .WorkRequestLogEntryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.ListWorkRequestLogsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .ListWorkRequestLogsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.workRequestLogEntryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPreviousPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-previous-page");
+                                if (opcPreviousPageHeader.isPresent()) {
+                                    builder.opcPreviousPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-previous-page",
+                                                    opcPreviousPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.ListWorkRequestLogsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ListWorkRequestsConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/ListWorkRequestsConverter.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class ListWorkRequestsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.ListWorkRequestsRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.ListWorkRequestsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.ListWorkRequestsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(request.getCompartmentId(), "compartmentId is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget().path("/20210601").path("workRequests");
+
+        target =
+                target.queryParam(
+                        "compartmentId",
+                        com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                request.getCompartmentId()));
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getVbInstanceId() != null) {
+            target =
+                    target.queryParam(
+                            "vbInstanceId",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getVbInstanceId()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.ListWorkRequestsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.ListWorkRequestsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses.ListWorkRequestsResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses.ListWorkRequestsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.ListWorkRequestsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                .WorkRequestSummaryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                        .WorkRequestSummaryCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.visualbuilder.model
+                                                        .WorkRequestSummaryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.ListWorkRequestsResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .ListWorkRequestsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.workRequestSummaryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcPreviousPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-previous-page");
+                                if (opcPreviousPageHeader.isPresent()) {
+                                    builder.opcPreviousPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-previous-page",
+                                                    opcPreviousPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.ListWorkRequestsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/RequestSummarizedApplicationsConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/RequestSummarizedApplicationsConverter.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class RequestSummarizedApplicationsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.RequestSummarizedApplicationsRequest
+            interceptRequest(
+                    com.oracle.bmc.visualbuilder.requests.RequestSummarizedApplicationsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.RequestSummarizedApplicationsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notNull(
+                request.getRequestSummarizedApplicationsDetails(),
+                "requestSummarizedApplicationsDetails is required");
+        Validate.notBlank(request.getVbInstanceId(), "vbInstanceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("vbInstances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVbInstanceId()))
+                        .path("actions")
+                        .path("applications");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.RequestSummarizedApplicationsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses
+                                .RequestSummarizedApplicationsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses
+                                        .RequestSummarizedApplicationsResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses
+                                            .RequestSummarizedApplicationsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.RequestSummarizedApplicationsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                .ApplicationSummaryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.visualbuilder.model
+                                                                        .ApplicationSummaryCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.visualbuilder.model
+                                                        .ApplicationSummaryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses
+                                                .RequestSummarizedApplicationsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .RequestSummarizedApplicationsResponse
+                                                        .builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.applicationSummaryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses
+                                                .RequestSummarizedApplicationsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/StartVbInstanceConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/StartVbInstanceConverter.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class StartVbInstanceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.StartVbInstanceRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.StartVbInstanceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.StartVbInstanceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVbInstanceId(), "vbInstanceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("vbInstances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVbInstanceId()))
+                        .path("actions")
+                        .path("start");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.StartVbInstanceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.StartVbInstanceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses.StartVbInstanceResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses.StartVbInstanceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.StartVbInstanceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.StartVbInstanceResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .StartVbInstanceResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.StartVbInstanceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/StopVbInstanceConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/StopVbInstanceConverter.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class StopVbInstanceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.StopVbInstanceRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.StopVbInstanceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.StopVbInstanceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVbInstanceId(), "vbInstanceId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("vbInstances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVbInstanceId()))
+                        .path("actions")
+                        .path("stop");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getOpcRetryToken() != null) {
+            ib.header("opc-retry-token", request.getOpcRetryToken());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.StopVbInstanceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.StopVbInstanceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses.StopVbInstanceResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses.StopVbInstanceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.StopVbInstanceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.StopVbInstanceResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .StopVbInstanceResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.StopVbInstanceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/UpdateVbInstanceConverter.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/internal/http/UpdateVbInstanceConverter.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.visualbuilder.model.*;
+import com.oracle.bmc.visualbuilder.requests.*;
+import com.oracle.bmc.visualbuilder.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.extern.slf4j.Slf4j
+public class UpdateVbInstanceConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.visualbuilder.requests.UpdateVbInstanceRequest interceptRequest(
+            com.oracle.bmc.visualbuilder.requests.UpdateVbInstanceRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.visualbuilder.requests.UpdateVbInstanceRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getVbInstanceId(), "vbInstanceId must not be blank");
+        Validate.notNull(
+                request.getUpdateVbInstanceDetails(), "updateVbInstanceDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210601")
+                        .path("vbInstances")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getVbInstanceId()));
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.visualbuilder.responses.UpdateVbInstanceResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.visualbuilder.responses.UpdateVbInstanceResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.visualbuilder.responses.UpdateVbInstanceResponse>() {
+                            @Override
+                            public com.oracle.bmc.visualbuilder.responses.UpdateVbInstanceResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.visualbuilder.responses.UpdateVbInstanceResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.visualbuilder.responses.UpdateVbInstanceResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.visualbuilder.responses
+                                                        .UpdateVbInstanceResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.visualbuilder.responses.UpdateVbInstanceResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/ApplicationSummary.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/ApplicationSummary.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Summary of the Vb Instance's applications.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ApplicationSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ApplicationSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+        private String projectId;
+
+        public Builder projectId(String projectId) {
+            this.projectId = projectId;
+            this.__explicitlySet__.add("projectId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("version")
+        private String version;
+
+        public Builder version(String version) {
+            this.version = version;
+            this.__explicitlySet__.add("version");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("state")
+        private State state;
+
+        public Builder state(State state) {
+            this.state = state;
+            this.__explicitlySet__.add("state");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApplicationSummary build() {
+            ApplicationSummary __instance__ = new ApplicationSummary(id, projectId, version, state);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApplicationSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .projectId(o.getProjectId())
+                            .version(o.getVersion())
+                            .state(o.getState());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique identifier of the application.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Project identifier.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("projectId")
+    String projectId;
+
+    /**
+     * Version of deployed application.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    String version;
+    /**
+     * Represents the deployment state of the application.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum State {
+        Stage("STAGE"),
+        Live("LIVE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, State> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (State v : State.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        State(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static State create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'State', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Represents the deployment state of the application.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("state")
+    State state;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/ApplicationSummaryCollection.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/ApplicationSummaryCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Result of listing VbInstance's applications. Contains ApplicationSummary items.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ApplicationSummaryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ApplicationSummaryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<ApplicationSummary> items;
+
+        public Builder items(java.util.List<ApplicationSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ApplicationSummaryCollection build() {
+            ApplicationSummaryCollection __instance__ = new ApplicationSummaryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ApplicationSummaryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The collection of ApplicationSummary objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<ApplicationSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/ChangeVbInstanceCompartmentDetails.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/ChangeVbInstanceCompartmentDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Compartment the VbInstance will be moved to
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ChangeVbInstanceCompartmentDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ChangeVbInstanceCompartmentDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ChangeVbInstanceCompartmentDetails build() {
+            ChangeVbInstanceCompartmentDetails __instance__ =
+                    new ChangeVbInstanceCompartmentDetails(compartmentId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ChangeVbInstanceCompartmentDetails o) {
+            Builder copiedBuilder = compartmentId(o.getCompartmentId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Compartment Identifier.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/CreateCustomEndpointDetails.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/CreateCustomEndpointDetails.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Details for a custom endpoint for the vb instance (update).
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateCustomEndpointDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateCustomEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("certificateSecretId")
+        private String certificateSecretId;
+
+        public Builder certificateSecretId(String certificateSecretId) {
+            this.certificateSecretId = certificateSecretId;
+            this.__explicitlySet__.add("certificateSecretId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateCustomEndpointDetails build() {
+            CreateCustomEndpointDetails __instance__ =
+                    new CreateCustomEndpointDetails(hostname, certificateSecretId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateCustomEndpointDetails o) {
+            Builder copiedBuilder =
+                    hostname(o.getHostname()).certificateSecretId(o.getCertificateSecretId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A custom hostname to be used for the vb instance URL, in FQDN format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+    String hostname;
+
+    /**
+     * Optional OCID of a vault/secret containing a private SSL certificate bundle to be used for the custom hostname.
+     * All certificates should be stored in a single base64 encoded secret
+     * Note the update will fail if this is not a valid certificate.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("certificateSecretId")
+    String certificateSecretId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/CreateVbInstanceDetails.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/CreateVbInstanceDetails.java
@@ -1,0 +1,269 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * The information about new VbInstance.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateVbInstanceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateVbInstanceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("idcsOpenId")
+        private String idcsOpenId;
+
+        public Builder idcsOpenId(String idcsOpenId) {
+            this.idcsOpenId = idcsOpenId;
+            this.__explicitlySet__.add("idcsOpenId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeCount")
+        private Integer nodeCount;
+
+        public Builder nodeCount(Integer nodeCount) {
+            this.nodeCount = nodeCount;
+            this.__explicitlySet__.add("nodeCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isVisualBuilderEnabled")
+        private Boolean isVisualBuilderEnabled;
+
+        public Builder isVisualBuilderEnabled(Boolean isVisualBuilderEnabled) {
+            this.isVisualBuilderEnabled = isVisualBuilderEnabled;
+            this.__explicitlySet__.add("isVisualBuilderEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customEndpoint")
+        private CreateCustomEndpointDetails customEndpoint;
+
+        public Builder customEndpoint(CreateCustomEndpointDetails customEndpoint) {
+            this.customEndpoint = customEndpoint;
+            this.__explicitlySet__.add("customEndpoint");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("alternateCustomEndpoints")
+        private java.util.List<CreateCustomEndpointDetails> alternateCustomEndpoints;
+
+        public Builder alternateCustomEndpoints(
+                java.util.List<CreateCustomEndpointDetails> alternateCustomEndpoints) {
+            this.alternateCustomEndpoints = alternateCustomEndpoints;
+            this.__explicitlySet__.add("alternateCustomEndpoints");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("consumptionModel")
+        private ConsumptionModel consumptionModel;
+
+        public Builder consumptionModel(ConsumptionModel consumptionModel) {
+            this.consumptionModel = consumptionModel;
+            this.__explicitlySet__.add("consumptionModel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateVbInstanceDetails build() {
+            CreateVbInstanceDetails __instance__ =
+                    new CreateVbInstanceDetails(
+                            displayName,
+                            compartmentId,
+                            freeformTags,
+                            definedTags,
+                            idcsOpenId,
+                            nodeCount,
+                            isVisualBuilderEnabled,
+                            customEndpoint,
+                            alternateCustomEndpoints,
+                            consumptionModel);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateVbInstanceDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .idcsOpenId(o.getIdcsOpenId())
+                            .nodeCount(o.getNodeCount())
+                            .isVisualBuilderEnabled(o.getIsVisualBuilderEnabled())
+                            .customEndpoint(o.getCustomEndpoint())
+                            .alternateCustomEndpoints(o.getAlternateCustomEndpoints())
+                            .consumptionModel(o.getConsumptionModel());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Vb Instance Identifier.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Compartment Identifier.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name,
+     * type or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to
+     * namespaces.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Encrypted IDCS Open ID token. This is required for pre-UCPIS cloud accounts, but not UCPIS, hence not a required parameter
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("idcsOpenId")
+    String idcsOpenId;
+
+    /**
+     * The number of Nodes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeCount")
+    Integer nodeCount;
+
+    /**
+     * Visual Builder is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isVisualBuilderEnabled")
+    Boolean isVisualBuilderEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("customEndpoint")
+    CreateCustomEndpointDetails customEndpoint;
+
+    /**
+     * A list of alternate custom endpoints to be used for the vb instance URL
+     * (contact Oracle for alternateCustomEndpoints availability for a specific instance).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("alternateCustomEndpoints")
+    java.util.List<CreateCustomEndpointDetails> alternateCustomEndpoints;
+    /**
+     * Optional parameter specifying which entitlement to use for billing purposes. Only required if the account possesses more than one entitlement.
+     **/
+    public enum ConsumptionModel {
+        Ucm("UCM"),
+        Gov("GOV"),
+        Vb4Saas("VB4SAAS"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, ConsumptionModel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ConsumptionModel v : ConsumptionModel.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        ConsumptionModel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ConsumptionModel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid ConsumptionModel: " + key);
+        }
+    };
+    /**
+     * Optional parameter specifying which entitlement to use for billing purposes. Only required if the account possesses more than one entitlement.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("consumptionModel")
+    ConsumptionModel consumptionModel;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/CustomEndpointDetails.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/CustomEndpointDetails.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Details for a custom endpoint for the vb instance.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CustomEndpointDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CustomEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("certificateSecretId")
+        private String certificateSecretId;
+
+        public Builder certificateSecretId(String certificateSecretId) {
+            this.certificateSecretId = certificateSecretId;
+            this.__explicitlySet__.add("certificateSecretId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("certificateSecretVersion")
+        private Integer certificateSecretVersion;
+
+        public Builder certificateSecretVersion(Integer certificateSecretVersion) {
+            this.certificateSecretVersion = certificateSecretVersion;
+            this.__explicitlySet__.add("certificateSecretVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CustomEndpointDetails build() {
+            CustomEndpointDetails __instance__ =
+                    new CustomEndpointDetails(
+                            hostname, certificateSecretId, certificateSecretVersion);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CustomEndpointDetails o) {
+            Builder copiedBuilder =
+                    hostname(o.getHostname())
+                            .certificateSecretId(o.getCertificateSecretId())
+                            .certificateSecretVersion(o.getCertificateSecretVersion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A custom hostname to be used for the vb instance URL, in FQDN format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+    String hostname;
+
+    /**
+     * Optional OCID of a vault/secret containing a private SSL certificate bundle to be used for the custom hostname.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("certificateSecretId")
+    String certificateSecretId;
+
+    /**
+     * The secret version used for the certificate-secret-id (if certificate-secret-id is specified).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("certificateSecretVersion")
+    Integer certificateSecretVersion;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/RequestSummarizedApplicationsDetails.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/RequestSummarizedApplicationsDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * The information to summarize the applications.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = RequestSummarizedApplicationsDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class RequestSummarizedApplicationsDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("idcsOpenId")
+        private String idcsOpenId;
+
+        public Builder idcsOpenId(String idcsOpenId) {
+            this.idcsOpenId = idcsOpenId;
+            this.__explicitlySet__.add("idcsOpenId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public RequestSummarizedApplicationsDetails build() {
+            RequestSummarizedApplicationsDetails __instance__ =
+                    new RequestSummarizedApplicationsDetails(idcsOpenId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(RequestSummarizedApplicationsDetails o) {
+            Builder copiedBuilder = idcsOpenId(o.getIdcsOpenId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Encrypted IDCS Open ID token. This is required for pre-UCPIS cloud accounts, but not UCPIS, hence not a required parameter
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("idcsOpenId")
+    String idcsOpenId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/UpdateCustomEndpointDetails.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/UpdateCustomEndpointDetails.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Details for a custom endpoint for the vb instance (update).
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateCustomEndpointDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateCustomEndpointDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+        private String hostname;
+
+        public Builder hostname(String hostname) {
+            this.hostname = hostname;
+            this.__explicitlySet__.add("hostname");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("certificateSecretId")
+        private String certificateSecretId;
+
+        public Builder certificateSecretId(String certificateSecretId) {
+            this.certificateSecretId = certificateSecretId;
+            this.__explicitlySet__.add("certificateSecretId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateCustomEndpointDetails build() {
+            UpdateCustomEndpointDetails __instance__ =
+                    new UpdateCustomEndpointDetails(hostname, certificateSecretId);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateCustomEndpointDetails o) {
+            Builder copiedBuilder =
+                    hostname(o.getHostname()).certificateSecretId(o.getCertificateSecretId());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A custom hostname to be used for the vb instance URL, in FQDN format.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("hostname")
+    String hostname;
+
+    /**
+     * Optional OCID of a vault/secret containing a private SSL certificate bundle to be used for the custom hostname.
+     * All certificates should be stored in a single base64 encoded secret.
+     * Note the update will fail if this is not a valid certificate.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("certificateSecretId")
+    String certificateSecretId;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/UpdateVbInstanceDetails.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/UpdateVbInstanceDetails.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Information about updating a VbInstance.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateVbInstanceDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateVbInstanceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("idcsOpenId")
+        private String idcsOpenId;
+
+        public Builder idcsOpenId(String idcsOpenId) {
+            this.idcsOpenId = idcsOpenId;
+            this.__explicitlySet__.add("idcsOpenId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeCount")
+        private Integer nodeCount;
+
+        public Builder nodeCount(Integer nodeCount) {
+            this.nodeCount = nodeCount;
+            this.__explicitlySet__.add("nodeCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isVisualBuilderEnabled")
+        private Boolean isVisualBuilderEnabled;
+
+        public Builder isVisualBuilderEnabled(Boolean isVisualBuilderEnabled) {
+            this.isVisualBuilderEnabled = isVisualBuilderEnabled;
+            this.__explicitlySet__.add("isVisualBuilderEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customEndpoint")
+        private UpdateCustomEndpointDetails customEndpoint;
+
+        public Builder customEndpoint(UpdateCustomEndpointDetails customEndpoint) {
+            this.customEndpoint = customEndpoint;
+            this.__explicitlySet__.add("customEndpoint");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("alternateCustomEndpoints")
+        private java.util.List<UpdateCustomEndpointDetails> alternateCustomEndpoints;
+
+        public Builder alternateCustomEndpoints(
+                java.util.List<UpdateCustomEndpointDetails> alternateCustomEndpoints) {
+            this.alternateCustomEndpoints = alternateCustomEndpoints;
+            this.__explicitlySet__.add("alternateCustomEndpoints");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateVbInstanceDetails build() {
+            UpdateVbInstanceDetails __instance__ =
+                    new UpdateVbInstanceDetails(
+                            displayName,
+                            freeformTags,
+                            definedTags,
+                            idcsOpenId,
+                            nodeCount,
+                            isVisualBuilderEnabled,
+                            customEndpoint,
+                            alternateCustomEndpoints);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateVbInstanceDetails o) {
+            Builder copiedBuilder =
+                    displayName(o.getDisplayName())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .idcsOpenId(o.getIdcsOpenId())
+                            .nodeCount(o.getNodeCount())
+                            .isVisualBuilderEnabled(o.getIsVisualBuilderEnabled())
+                            .customEndpoint(o.getCustomEndpoint())
+                            .alternateCustomEndpoints(o.getAlternateCustomEndpoints());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Vb Instance Identifier.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name,
+     * type or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Usage of predefined tag keys. These predefined keys are scoped to
+     * namespaces.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Encrypted IDCS Open ID token. This is required for pre-UCPIS cloud accounts, but not UCPIS, hence not a required parameter
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("idcsOpenId")
+    String idcsOpenId;
+
+    /**
+     * The number of Nodes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeCount")
+    Integer nodeCount;
+
+    /**
+     * Enable Visual Builder. If Visual Builder is enabled alredy, then it cannot be disabled.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isVisualBuilderEnabled")
+    Boolean isVisualBuilderEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("customEndpoint")
+    UpdateCustomEndpointDetails customEndpoint;
+
+    /**
+     * A list of alternate custom endpoints to be used for the vb instance URL
+     * (contact Oracle for alternateCustomEndpoints availability for a specific instance).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("alternateCustomEndpoints")
+    java.util.List<UpdateCustomEndpointDetails> alternateCustomEndpoints;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/VbInstance.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/VbInstance.java
@@ -1,0 +1,429 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Description of Vb Instance.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = VbInstance.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VbInstance {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stateMessage")
+        private String stateMessage;
+
+        public Builder stateMessage(String stateMessage) {
+            this.stateMessage = stateMessage;
+            this.__explicitlySet__.add("stateMessage");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceUrl")
+        private String instanceUrl;
+
+        public Builder instanceUrl(String instanceUrl) {
+            this.instanceUrl = instanceUrl;
+            this.__explicitlySet__.add("instanceUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeCount")
+        private Integer nodeCount;
+
+        public Builder nodeCount(Integer nodeCount) {
+            this.nodeCount = nodeCount;
+            this.__explicitlySet__.add("nodeCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isVisualBuilderEnabled")
+        private Boolean isVisualBuilderEnabled;
+
+        public Builder isVisualBuilderEnabled(Boolean isVisualBuilderEnabled) {
+            this.isVisualBuilderEnabled = isVisualBuilderEnabled;
+            this.__explicitlySet__.add("isVisualBuilderEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customEndpoint")
+        private CustomEndpointDetails customEndpoint;
+
+        public Builder customEndpoint(CustomEndpointDetails customEndpoint) {
+            this.customEndpoint = customEndpoint;
+            this.__explicitlySet__.add("customEndpoint");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("alternateCustomEndpoints")
+        private java.util.List<CustomEndpointDetails> alternateCustomEndpoints;
+
+        public Builder alternateCustomEndpoints(
+                java.util.List<CustomEndpointDetails> alternateCustomEndpoints) {
+            this.alternateCustomEndpoints = alternateCustomEndpoints;
+            this.__explicitlySet__.add("alternateCustomEndpoints");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("consumptionModel")
+        private ConsumptionModel consumptionModel;
+
+        public Builder consumptionModel(ConsumptionModel consumptionModel) {
+            this.consumptionModel = consumptionModel;
+            this.__explicitlySet__.add("consumptionModel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VbInstance build() {
+            VbInstance __instance__ =
+                    new VbInstance(
+                            id,
+                            displayName,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            stateMessage,
+                            freeformTags,
+                            definedTags,
+                            systemTags,
+                            instanceUrl,
+                            nodeCount,
+                            isVisualBuilderEnabled,
+                            customEndpoint,
+                            alternateCustomEndpoints,
+                            consumptionModel);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VbInstance o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .stateMessage(o.getStateMessage())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags())
+                            .instanceUrl(o.getInstanceUrl())
+                            .nodeCount(o.getNodeCount())
+                            .isVisualBuilderEnabled(o.getIsVisualBuilderEnabled())
+                            .customEndpoint(o.getCustomEndpoint())
+                            .alternateCustomEndpoints(o.getAlternateCustomEndpoints())
+                            .consumptionModel(o.getConsumptionModel());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique identifier that is immutable on creation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Vb Instance Identifier, can be renamed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Compartment Identifier.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The time the the VbInstance was created. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the VbInstance was updated. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the vb instance.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Updating("UPDATING"),
+        Active("ACTIVE"),
+        Inactive("INACTIVE"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the vb instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("stateMessage")
+    String stateMessage;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Usage of system tag keys. These predefined keys are scoped to namespaces.
+     * Example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    /**
+     * The Vb Instance URL.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceUrl")
+    String instanceUrl;
+
+    /**
+     * The number of Nodes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeCount")
+    Integer nodeCount;
+
+    /**
+     * Visual Builder is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isVisualBuilderEnabled")
+    Boolean isVisualBuilderEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("customEndpoint")
+    CustomEndpointDetails customEndpoint;
+
+    /**
+     * A list of alternate custom endpoints used for the vb instance URL.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("alternateCustomEndpoints")
+    java.util.List<CustomEndpointDetails> alternateCustomEndpoints;
+    /**
+     * The entitlement used for billing purposes.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ConsumptionModel {
+        Ucm("UCM"),
+        Gov("GOV"),
+        Vb4Saas("VB4SAAS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ConsumptionModel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ConsumptionModel v : ConsumptionModel.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ConsumptionModel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ConsumptionModel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ConsumptionModel', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The entitlement used for billing purposes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("consumptionModel")
+    ConsumptionModel consumptionModel;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/VbInstanceSummary.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/VbInstanceSummary.java
@@ -1,0 +1,431 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Summary of the Vb Instance.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VbInstanceSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VbInstanceSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+        private String displayName;
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            this.__explicitlySet__.add("displayName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+        private java.util.Date timeCreated;
+
+        public Builder timeCreated(java.util.Date timeCreated) {
+            this.timeCreated = timeCreated;
+            this.__explicitlySet__.add("timeCreated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+        private java.util.Date timeUpdated;
+
+        public Builder timeUpdated(java.util.Date timeUpdated) {
+            this.timeUpdated = timeUpdated;
+            this.__explicitlySet__.add("timeUpdated");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+        private LifecycleState lifecycleState;
+
+        public Builder lifecycleState(LifecycleState lifecycleState) {
+            this.lifecycleState = lifecycleState;
+            this.__explicitlySet__.add("lifecycleState");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("stateMessage")
+        private String stateMessage;
+
+        public Builder stateMessage(String stateMessage) {
+            this.stateMessage = stateMessage;
+            this.__explicitlySet__.add("stateMessage");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("instanceUrl")
+        private String instanceUrl;
+
+        public Builder instanceUrl(String instanceUrl) {
+            this.instanceUrl = instanceUrl;
+            this.__explicitlySet__.add("instanceUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeCount")
+        private Integer nodeCount;
+
+        public Builder nodeCount(Integer nodeCount) {
+            this.nodeCount = nodeCount;
+            this.__explicitlySet__.add("nodeCount");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isVisualBuilderEnabled")
+        private Boolean isVisualBuilderEnabled;
+
+        public Builder isVisualBuilderEnabled(Boolean isVisualBuilderEnabled) {
+            this.isVisualBuilderEnabled = isVisualBuilderEnabled;
+            this.__explicitlySet__.add("isVisualBuilderEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customEndpoint")
+        private CustomEndpointDetails customEndpoint;
+
+        public Builder customEndpoint(CustomEndpointDetails customEndpoint) {
+            this.customEndpoint = customEndpoint;
+            this.__explicitlySet__.add("customEndpoint");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("alternateCustomEndpoints")
+        private java.util.List<CustomEndpointDetails> alternateCustomEndpoints;
+
+        public Builder alternateCustomEndpoints(
+                java.util.List<CustomEndpointDetails> alternateCustomEndpoints) {
+            this.alternateCustomEndpoints = alternateCustomEndpoints;
+            this.__explicitlySet__.add("alternateCustomEndpoints");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("consumptionModel")
+        private ConsumptionModel consumptionModel;
+
+        public Builder consumptionModel(ConsumptionModel consumptionModel) {
+            this.consumptionModel = consumptionModel;
+            this.__explicitlySet__.add("consumptionModel");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+        private java.util.Map<String, String> freeformTags;
+
+        public Builder freeformTags(java.util.Map<String, String> freeformTags) {
+            this.freeformTags = freeformTags;
+            this.__explicitlySet__.add("freeformTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+        private java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+        public Builder definedTags(
+                java.util.Map<String, java.util.Map<String, Object>> definedTags) {
+            this.definedTags = definedTags;
+            this.__explicitlySet__.add("definedTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+        private java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+        public Builder systemTags(java.util.Map<String, java.util.Map<String, Object>> systemTags) {
+            this.systemTags = systemTags;
+            this.__explicitlySet__.add("systemTags");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VbInstanceSummary build() {
+            VbInstanceSummary __instance__ =
+                    new VbInstanceSummary(
+                            id,
+                            displayName,
+                            compartmentId,
+                            timeCreated,
+                            timeUpdated,
+                            lifecycleState,
+                            stateMessage,
+                            instanceUrl,
+                            nodeCount,
+                            isVisualBuilderEnabled,
+                            customEndpoint,
+                            alternateCustomEndpoints,
+                            consumptionModel,
+                            freeformTags,
+                            definedTags,
+                            systemTags);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VbInstanceSummary o) {
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .displayName(o.getDisplayName())
+                            .compartmentId(o.getCompartmentId())
+                            .timeCreated(o.getTimeCreated())
+                            .timeUpdated(o.getTimeUpdated())
+                            .lifecycleState(o.getLifecycleState())
+                            .stateMessage(o.getStateMessage())
+                            .instanceUrl(o.getInstanceUrl())
+                            .nodeCount(o.getNodeCount())
+                            .isVisualBuilderEnabled(o.getIsVisualBuilderEnabled())
+                            .customEndpoint(o.getCustomEndpoint())
+                            .alternateCustomEndpoints(o.getAlternateCustomEndpoints())
+                            .consumptionModel(o.getConsumptionModel())
+                            .freeformTags(o.getFreeformTags())
+                            .definedTags(o.getDefinedTags())
+                            .systemTags(o.getSystemTags());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Unique identifier that is immutable on creation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * Vb Instance Identifier, can be renamed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    String displayName;
+
+    /**
+     * Compartment Identifier.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The time the the Vb Instance was created. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
+    java.util.Date timeCreated;
+
+    /**
+     * The time the VbInstance was updated. An RFC3339 formatted datetime string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
+    java.util.Date timeUpdated;
+    /**
+     * The current state of the Vb Instance.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Updating("UPDATING"),
+        Active("ACTIVE"),
+        Inactive("INACTIVE"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Failed("FAILED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The current state of the Vb Instance.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
+    LifecycleState lifecycleState;
+
+    /**
+     * An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("stateMessage")
+    String stateMessage;
+
+    /**
+     * The Vb Instance URL.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceUrl")
+    String instanceUrl;
+
+    /**
+     * The number of Nodes
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeCount")
+    Integer nodeCount;
+
+    /**
+     * Visual Builder is enabled or not.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isVisualBuilderEnabled")
+    Boolean isVisualBuilderEnabled;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("customEndpoint")
+    CustomEndpointDetails customEndpoint;
+
+    /**
+     * A list of alternate custom endpoints used for the vb instance URL.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("alternateCustomEndpoints")
+    java.util.List<CustomEndpointDetails> alternateCustomEndpoints;
+    /**
+     * The entitlement used for billing purposes.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ConsumptionModel {
+        Ucm("UCM"),
+        Gov("GOV"),
+        Vb4Saas("VB4SAAS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ConsumptionModel> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ConsumptionModel v : ConsumptionModel.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ConsumptionModel(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ConsumptionModel create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ConsumptionModel', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The entitlement used for billing purposes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("consumptionModel")
+    ConsumptionModel consumptionModel;
+
+    /**
+     * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.
+     * Example: {@code {"bar-key": "value"}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
+    java.util.Map<String, String> freeformTags;
+
+    /**
+     * Defined tags for this resource. Each key is predefined and scoped to a namespace.
+     * Example: {@code {"foo-namespace": {"bar-key": "value"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
+    java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * Usage of system tag keys. These predefined keys are scoped to namespaces.
+     * Example: {@code {"orcl-cloud": {"free-tier-retained": "true"}}}
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("systemTags")
+    java.util.Map<String, java.util.Map<String, Object>> systemTags;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/VbInstanceSummaryCollection.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/VbInstanceSummaryCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Result of a VbInstance Summary request. Contains VbInstanceSummary items.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = VbInstanceSummaryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class VbInstanceSummaryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<VbInstanceSummary> items;
+
+        public Builder items(java.util.List<VbInstanceSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public VbInstanceSummaryCollection build() {
+            VbInstanceSummaryCollection __instance__ = new VbInstanceSummaryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(VbInstanceSummaryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The collection of VbInstanceSummary objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<VbInstanceSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequest.java
@@ -1,0 +1,319 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * A description of work request status.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = WorkRequest.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequest {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("operationType")
+        private OperationType operationType;
+
+        public Builder operationType(OperationType operationType) {
+            this.operationType = operationType;
+            this.__explicitlySet__.add("operationType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resources")
+        private java.util.List<WorkRequestResource> resources;
+
+        public Builder resources(java.util.List<WorkRequestResource> resources) {
+            this.resources = resources;
+            this.__explicitlySet__.add("resources");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
+        private Float percentComplete;
+
+        public Builder percentComplete(Float percentComplete) {
+            this.percentComplete = percentComplete;
+            this.__explicitlySet__.add("percentComplete");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
+        private java.util.Date timeAccepted;
+
+        public Builder timeAccepted(java.util.Date timeAccepted) {
+            this.timeAccepted = timeAccepted;
+            this.__explicitlySet__.add("timeAccepted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequest build() {
+            WorkRequest __instance__ =
+                    new WorkRequest(
+                            operationType,
+                            status,
+                            id,
+                            compartmentId,
+                            resources,
+                            percentComplete,
+                            timeAccepted,
+                            timeStarted,
+                            timeFinished);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequest o) {
+            Builder copiedBuilder =
+                    operationType(o.getOperationType())
+                            .status(o.getStatus())
+                            .id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .resources(o.getResources())
+                            .percentComplete(o.getPercentComplete())
+                            .timeAccepted(o.getTimeAccepted())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Type of the work request.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum OperationType {
+        CreateVbInstance("CREATE_VB_INSTANCE"),
+        UpdateVbInstance("UPDATE_VB_INSTANCE"),
+        StopVbInstance("STOP_VB_INSTANCE"),
+        StartVbInstance("START_VB_INSTANCE"),
+        DeleteVbInstance("DELETE_VB_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, OperationType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (OperationType v : OperationType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        OperationType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static OperationType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'OperationType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Type of the work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("operationType")
+    OperationType operationType;
+    /**
+     * Status of current work request.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Status {
+        Accepted("ACCEPTED"),
+        InProgress("IN_PROGRESS"),
+        Failed("FAILED"),
+        Succeeded("SUCCEEDED"),
+        Canceling("CANCELING"),
+        Canceled("CANCELED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Status> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Status v : Status.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Status(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Status create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Status', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Status of current work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    Status status;
+
+    /**
+     * The id of the work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The ocid of the compartment that contains the work request. Work
+     * requests should be scoped to the same compartment as the resource the
+     * work request affects. If the work request affects multiple resources,
+     * and those resources are not in the same compartment, it is up to the
+     * service team to pick the primary resource whose compartment should be
+     * used.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The resources affected by this work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    java.util.List<WorkRequestResource> resources;
+
+    /**
+     * Percentage of the request completed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
+    Float percentComplete;
+
+    /**
+     * The date and time the request was created, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
+    java.util.Date timeAccepted;
+
+    /**
+     * The date and time the request was started, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339),
+     * section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+    java.util.Date timeStarted;
+
+    /**
+     * The date and time the object was finished, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+    java.util.Date timeFinished;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestError.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestError.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Errors related to a specific work request.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = WorkRequestError.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestError {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("code")
+        private String code;
+
+        public Builder code(String code) {
+            this.code = code;
+            this.__explicitlySet__.add("code");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("message")
+        private String message;
+
+        public Builder message(String message) {
+            this.message = message;
+            this.__explicitlySet__.add("message");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+        private java.util.Date timestamp;
+
+        public Builder timestamp(java.util.Date timestamp) {
+            this.timestamp = timestamp;
+            this.__explicitlySet__.add("timestamp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestError build() {
+            WorkRequestError __instance__ = new WorkRequestError(code, message, timestamp);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestError o) {
+            Builder copiedBuilder =
+                    code(o.getCode()).message(o.getMessage()).timestamp(o.getTimestamp());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A short error code that defines the error, meant for programmatic parsing
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("code")
+    String code;
+
+    /**
+     * A human-readable error string.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    String message;
+
+    /**
+     * The date and time the error occurred.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+    java.util.Date timestamp;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestErrorCollection.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestErrorCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Result of a WorkRequest Error request. Contains list of WorkRequestError items.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestErrorCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestErrorCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<WorkRequestError> items;
+
+        public Builder items(java.util.List<WorkRequestError> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestErrorCollection build() {
+            WorkRequestErrorCollection __instance__ = new WorkRequestErrorCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestErrorCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of objects containing errors related to a specific work request..
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<WorkRequestError> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestLogEntry.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestLogEntry.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Log entries related to a specific work request.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestLogEntry.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestLogEntry {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("message")
+        private String message;
+
+        public Builder message(String message) {
+            this.message = message;
+            this.__explicitlySet__.add("message");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+        private java.util.Date timestamp;
+
+        public Builder timestamp(java.util.Date timestamp) {
+            this.timestamp = timestamp;
+            this.__explicitlySet__.add("timestamp");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestLogEntry build() {
+            WorkRequestLogEntry __instance__ = new WorkRequestLogEntry(message, timestamp);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestLogEntry o) {
+            Builder copiedBuilder = message(o.getMessage()).timestamp(o.getTimestamp());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The description of an action that occurred.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    String message;
+
+    /**
+     * The date and time the log entry occurred.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timestamp")
+    java.util.Date timestamp;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestLogEntryCollection.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestLogEntryCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Result of a WorkRequest Log request. Contains list of WorkRequestLog items.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestLogEntryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestLogEntryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<WorkRequestLogEntry> items;
+
+        public Builder items(java.util.List<WorkRequestLogEntry> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestLogEntryCollection build() {
+            WorkRequestLogEntryCollection __instance__ = new WorkRequestLogEntryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestLogEntryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * List of objects containing logs related to a specific work request..
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<WorkRequestLogEntry> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestResource.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestResource.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * A resource created or operated on by a work request.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestResource.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestResource {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("entityType")
+        private String entityType;
+
+        public Builder entityType(String entityType) {
+            this.entityType = entityType;
+            this.__explicitlySet__.add("entityType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("actionType")
+        private ActionType actionType;
+
+        public Builder actionType(ActionType actionType) {
+            this.actionType = actionType;
+            this.__explicitlySet__.add("actionType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+        private String identifier;
+
+        public Builder identifier(String identifier) {
+            this.identifier = identifier;
+            this.__explicitlySet__.add("identifier");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("entityUri")
+        private String entityUri;
+
+        public Builder entityUri(String entityUri) {
+            this.entityUri = entityUri;
+            this.__explicitlySet__.add("entityUri");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestResource build() {
+            WorkRequestResource __instance__ =
+                    new WorkRequestResource(entityType, actionType, identifier, entityUri);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestResource o) {
+            Builder copiedBuilder =
+                    entityType(o.getEntityType())
+                            .actionType(o.getActionType())
+                            .identifier(o.getIdentifier())
+                            .entityUri(o.getEntityUri());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The resource type the work request is affects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("entityType")
+    String entityType;
+    /**
+     * The way in which this resource is affected by the work tracked in the
+     * work request. A resource being created, updated, or deleted will
+     * remain in the IN_PROGRESS state until work is complete for that
+     * resource at which point it will transition to CREATED, UPDATED,
+     * or DELETED, respectively.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum ActionType {
+        Created("CREATED"),
+        Updated("UPDATED"),
+        Stopped("STOPPED"),
+        Started("STARTED"),
+        Deleted("DELETED"),
+        InProgress("IN_PROGRESS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, ActionType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (ActionType v : ActionType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        ActionType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static ActionType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'ActionType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The way in which this resource is affected by the work tracked in the
+     * work request. A resource being created, updated, or deleted will
+     * remain in the IN_PROGRESS state until work is complete for that
+     * resource at which point it will transition to CREATED, UPDATED,
+     * or DELETED, respectively.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("actionType")
+    ActionType actionType;
+
+    /**
+     * The identifier of the resource the work request affects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("identifier")
+    String identifier;
+
+    /**
+     * The URI path that the user can do a GET on to access the resource metadata.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("entityUri")
+    String entityUri;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestSummary.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestSummary.java
@@ -1,0 +1,321 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * A description of work request status.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("operationType")
+        private OperationType operationType;
+
+        public Builder operationType(OperationType operationType) {
+            this.operationType = operationType;
+            this.__explicitlySet__.add("operationType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("status")
+        private Status status;
+
+        public Builder status(Status status) {
+            this.status = status;
+            this.__explicitlySet__.add("status");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("id")
+        private String id;
+
+        public Builder id(String id) {
+            this.id = id;
+            this.__explicitlySet__.add("id");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+        private String compartmentId;
+
+        public Builder compartmentId(String compartmentId) {
+            this.compartmentId = compartmentId;
+            this.__explicitlySet__.add("compartmentId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("resources")
+        private java.util.List<WorkRequestResource> resources;
+
+        public Builder resources(java.util.List<WorkRequestResource> resources) {
+            this.resources = resources;
+            this.__explicitlySet__.add("resources");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
+        private Float percentComplete;
+
+        public Builder percentComplete(Float percentComplete) {
+            this.percentComplete = percentComplete;
+            this.__explicitlySet__.add("percentComplete");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
+        private java.util.Date timeAccepted;
+
+        public Builder timeAccepted(java.util.Date timeAccepted) {
+            this.timeAccepted = timeAccepted;
+            this.__explicitlySet__.add("timeAccepted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+        private java.util.Date timeStarted;
+
+        public Builder timeStarted(java.util.Date timeStarted) {
+            this.timeStarted = timeStarted;
+            this.__explicitlySet__.add("timeStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+        private java.util.Date timeFinished;
+
+        public Builder timeFinished(java.util.Date timeFinished) {
+            this.timeFinished = timeFinished;
+            this.__explicitlySet__.add("timeFinished");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestSummary build() {
+            WorkRequestSummary __instance__ =
+                    new WorkRequestSummary(
+                            operationType,
+                            status,
+                            id,
+                            compartmentId,
+                            resources,
+                            percentComplete,
+                            timeAccepted,
+                            timeStarted,
+                            timeFinished);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestSummary o) {
+            Builder copiedBuilder =
+                    operationType(o.getOperationType())
+                            .status(o.getStatus())
+                            .id(o.getId())
+                            .compartmentId(o.getCompartmentId())
+                            .resources(o.getResources())
+                            .percentComplete(o.getPercentComplete())
+                            .timeAccepted(o.getTimeAccepted())
+                            .timeStarted(o.getTimeStarted())
+                            .timeFinished(o.getTimeFinished());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Type of the work request.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum OperationType {
+        CreateVbInstance("CREATE_VB_INSTANCE"),
+        UpdateVbInstance("UPDATE_VB_INSTANCE"),
+        StopVbInstance("STOP_VB_INSTANCE"),
+        StartVbInstance("START_VB_INSTANCE"),
+        DeleteVbInstance("DELETE_VB_INSTANCE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, OperationType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (OperationType v : OperationType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        OperationType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static OperationType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'OperationType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Type of the work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("operationType")
+    OperationType operationType;
+    /**
+     * Status of current work request.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum Status {
+        Accepted("ACCEPTED"),
+        InProgress("IN_PROGRESS"),
+        Failed("FAILED"),
+        Succeeded("SUCCEEDED"),
+        Canceling("CANCELING"),
+        Canceled("CANCELED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, Status> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (Status v : Status.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        Status(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static Status create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'Status', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Status of current work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("status")
+    Status status;
+
+    /**
+     * The id of the work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    String id;
+
+    /**
+     * The ocid of the compartment that contains the work request. Work
+     * requests should be scoped to the same compartment as the resource the
+     * work request affects. If the work request affects multiple resources,
+     * and those resources are not in the same compartment, it is up to the
+     * service team to pick the primary resource whose compartment should be
+     * used.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("compartmentId")
+    String compartmentId;
+
+    /**
+     * The resources affected by this work request.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    java.util.List<WorkRequestResource> resources;
+
+    /**
+     * Percentage of the request completed.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("percentComplete")
+    Float percentComplete;
+
+    /**
+     * The date and time the request was created, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339), section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeAccepted")
+    java.util.Date timeAccepted;
+
+    /**
+     * The date and time the request was started, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339),
+     * section 14.29.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeStarted")
+    java.util.Date timeStarted;
+
+    /**
+     * The date and time the object was finished, as described in
+     * [RFC 3339](https://tools.ietf.org/rfc/rfc3339).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timeFinished")
+    java.util.Date timeFinished;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestSummaryCollection.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/model/WorkRequestSummaryCollection.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.model;
+
+/**
+ * Result of a WorkRequest Summary request. Contains WorkRequestSummary items.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = WorkRequestSummaryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class WorkRequestSummaryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<WorkRequestSummary> items;
+
+        public Builder items(java.util.List<WorkRequestSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public WorkRequestSummaryCollection build() {
+            WorkRequestSummaryCollection __instance__ = new WorkRequestSummaryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(WorkRequestSummaryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The collection of WorkRequestSummary objects.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<WorkRequestSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ChangeVbInstanceCompartmentRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ChangeVbInstanceCompartmentRequest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ChangeVbInstanceCompartmentExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ChangeVbInstanceCompartmentRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ChangeVbInstanceCompartmentRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.visualbuilder.model.ChangeVbInstanceCompartmentDetails> {
+
+    /**
+     * Unique Vb Instance identifier.
+     */
+    private String vbInstanceId;
+
+    /**
+     * Details for the update vb instance
+     */
+    private com.oracle.bmc.visualbuilder.model.ChangeVbInstanceCompartmentDetails
+            changeVbInstanceCompartmentDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations. For example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.visualbuilder.model.ChangeVbInstanceCompartmentDetails getBody$() {
+        return changeVbInstanceCompartmentDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ChangeVbInstanceCompartmentRequest,
+                    com.oracle.bmc.visualbuilder.model.ChangeVbInstanceCompartmentDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeVbInstanceCompartmentRequest o) {
+            vbInstanceId(o.getVbInstanceId());
+            changeVbInstanceCompartmentDetails(o.getChangeVbInstanceCompartmentDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ChangeVbInstanceCompartmentRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ChangeVbInstanceCompartmentRequest
+         */
+        public ChangeVbInstanceCompartmentRequest build() {
+            ChangeVbInstanceCompartmentRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.visualbuilder.model.ChangeVbInstanceCompartmentDetails body) {
+            changeVbInstanceCompartmentDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/CreateVbInstanceRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/CreateVbInstanceRequest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/CreateVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use CreateVbInstanceRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateVbInstanceRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.visualbuilder.model.CreateVbInstanceDetails> {
+
+    /**
+     * Details for the new Vb Instance.
+     */
+    private com.oracle.bmc.visualbuilder.model.CreateVbInstanceDetails createVbInstanceDetails;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations. For example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.visualbuilder.model.CreateVbInstanceDetails getBody$() {
+        return createVbInstanceDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    CreateVbInstanceRequest,
+                    com.oracle.bmc.visualbuilder.model.CreateVbInstanceDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateVbInstanceRequest o) {
+            createVbInstanceDetails(o.getCreateVbInstanceDetails());
+            opcRetryToken(o.getOpcRetryToken());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of CreateVbInstanceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of CreateVbInstanceRequest
+         */
+        public CreateVbInstanceRequest build() {
+            CreateVbInstanceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(com.oracle.bmc.visualbuilder.model.CreateVbInstanceDetails body) {
+            createVbInstanceDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/DeleteVbInstanceRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/DeleteVbInstanceRequest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/DeleteVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use DeleteVbInstanceRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteVbInstanceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique Vb Instance identifier.
+     */
+    private String vbInstanceId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    DeleteVbInstanceRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteVbInstanceRequest o) {
+            vbInstanceId(o.getVbInstanceId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of DeleteVbInstanceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of DeleteVbInstanceRequest
+         */
+        public DeleteVbInstanceRequest build() {
+            DeleteVbInstanceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/GetVbInstanceRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/GetVbInstanceRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/GetVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetVbInstanceRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetVbInstanceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique Vb Instance identifier.
+     */
+    private String vbInstanceId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetVbInstanceRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVbInstanceRequest o) {
+            vbInstanceId(o.getVbInstanceId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetVbInstanceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetVbInstanceRequest
+         */
+        public GetVbInstanceRequest build() {
+            GetVbInstanceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/GetWorkRequestRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/GetWorkRequestRequest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use GetWorkRequestRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetWorkRequestRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ID of the asynchronous request.
+     */
+    private String workRequestId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    GetWorkRequestRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetWorkRequestRequest o) {
+            workRequestId(o.getWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of GetWorkRequestRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of GetWorkRequestRequest
+         */
+        public GetWorkRequestRequest build() {
+            GetWorkRequestRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ListVbInstancesRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ListVbInstancesRequest.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListVbInstancesExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListVbInstancesRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListVbInstancesRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ID of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * A user-friendly name. Does not have to be unique, and it's changeable.
+     * <p>
+     * Example: {@code My new resource}
+     *
+     */
+    private String displayName;
+
+    /**
+     * Life cycle state to query on.
+     */
+    private LifecycleState lifecycleState;
+
+    /**
+     * Life cycle state to query on.
+     **/
+    public enum LifecycleState {
+        Creating("CREATING"),
+        Updating("UPDATING"),
+        Active("ACTIVE"),
+        Inactive("INACTIVE"),
+        Deleting("DELETING"),
+        Deleted("DELETED"),
+        Failed("FAILED"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, LifecycleState> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (LifecycleState v : LifecycleState.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        LifecycleState(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static LifecycleState create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid LifecycleState: " + key);
+        }
+    };
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     */
+    private SortOrder sortOrder;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     **/
+    public enum SortOrder {
+        Asc("ASC"),
+        Desc("DESC"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortOrder> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortOrder v : SortOrder.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortOrder(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortOrder create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortOrder: " + key);
+        }
+    };
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order
+     * for timeCreated is descending. Default order for displayName is
+     * ascending. If no value is specified timeCreated is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided. Default order
+     * for timeCreated is descending. Default order for displayName is
+     * ascending. If no value is specified timeCreated is default.
+     *
+     **/
+    public enum SortBy {
+        TimeCreated("timeCreated"),
+        DisplayName("displayName"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListVbInstancesRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVbInstancesRequest o) {
+            compartmentId(o.getCompartmentId());
+            displayName(o.getDisplayName());
+            lifecycleState(o.getLifecycleState());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListVbInstancesRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListVbInstancesRequest
+         */
+        public ListVbInstancesRequest build() {
+            ListVbInstancesRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ListWorkRequestErrorsRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ListWorkRequestErrorsRequest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkRequestErrorsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkRequestErrorsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ID of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * The ID of the asynchronous request.
+     */
+    private String workRequestId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListWorkRequestErrorsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestErrorsRequest o) {
+            compartmentId(o.getCompartmentId());
+            workRequestId(o.getWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListWorkRequestErrorsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListWorkRequestErrorsRequest
+         */
+        public ListWorkRequestErrorsRequest build() {
+            ListWorkRequestErrorsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ListWorkRequestLogsRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ListWorkRequestLogsRequest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkRequestLogsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkRequestLogsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ID of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * The ID of the asynchronous request.
+     */
+    private String workRequestId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListWorkRequestLogsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestLogsRequest o) {
+            compartmentId(o.getCompartmentId());
+            workRequestId(o.getWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListWorkRequestLogsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListWorkRequestLogsRequest
+         */
+        public ListWorkRequestLogsRequest build() {
+            ListWorkRequestLogsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ListWorkRequestsRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/ListWorkRequestsRequest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListWorkRequestsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkRequestsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The ID of the compartment in which to list resources.
+     */
+    private String compartmentId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     */
+    private String page;
+
+    /**
+     * The maximum number of items to return.
+     */
+    private Integer limit;
+
+    /**
+     * The Vb Instance identifier to use to filter results
+     */
+    private String vbInstanceId;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListWorkRequestsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestsRequest o) {
+            compartmentId(o.getCompartmentId());
+            opcRequestId(o.getOpcRequestId());
+            page(o.getPage());
+            limit(o.getLimit());
+            vbInstanceId(o.getVbInstanceId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListWorkRequestsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListWorkRequestsRequest
+         */
+        public ListWorkRequestsRequest build() {
+            ListWorkRequestsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/RequestSummarizedApplicationsRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/RequestSummarizedApplicationsRequest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/RequestSummarizedApplicationsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use RequestSummarizedApplicationsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RequestSummarizedApplicationsRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.visualbuilder.model.RequestSummarizedApplicationsDetails> {
+
+    /**
+     * The parameter holding information to request the summarized applications for a Vb instance
+     */
+    private com.oracle.bmc.visualbuilder.model.RequestSummarizedApplicationsDetails
+            requestSummarizedApplicationsDetails;
+
+    /**
+     * Unique Vb Instance identifier.
+     */
+    private String vbInstanceId;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations. For example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.visualbuilder.model.RequestSummarizedApplicationsDetails getBody$() {
+        return requestSummarizedApplicationsDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RequestSummarizedApplicationsRequest,
+                    com.oracle.bmc.visualbuilder.model.RequestSummarizedApplicationsDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RequestSummarizedApplicationsRequest o) {
+            requestSummarizedApplicationsDetails(o.getRequestSummarizedApplicationsDetails());
+            vbInstanceId(o.getVbInstanceId());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RequestSummarizedApplicationsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RequestSummarizedApplicationsRequest
+         */
+        public RequestSummarizedApplicationsRequest build() {
+            RequestSummarizedApplicationsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.visualbuilder.model.RequestSummarizedApplicationsDetails body) {
+            requestSummarizedApplicationsDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/StartVbInstanceRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/StartVbInstanceRequest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/StartVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use StartVbInstanceRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class StartVbInstanceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique Vb Instance identifier.
+     */
+    private String vbInstanceId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations. For example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    StartVbInstanceRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(StartVbInstanceRequest o) {
+            vbInstanceId(o.getVbInstanceId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of StartVbInstanceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of StartVbInstanceRequest
+         */
+        public StartVbInstanceRequest build() {
+            StartVbInstanceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/StopVbInstanceRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/StopVbInstanceRequest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/StopVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use StopVbInstanceRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class StopVbInstanceRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * Unique Vb Instance identifier.
+     */
+    private String vbInstanceId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * A token that uniquely identifies a request so it can be retried in case
+     * of a timeout or server error without risk of executing that same action
+     * again. Retry tokens expire after 24 hours, but can be invalidated before
+     * then due to conflicting operations. For example, if a resource has been
+     * deleted and purged from the system, then a retry of the original creation
+     * request might be rejected.
+     *
+     */
+    private String opcRetryToken;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    StopVbInstanceRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(StopVbInstanceRequest o) {
+            vbInstanceId(o.getVbInstanceId());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            opcRetryToken(o.getOpcRetryToken());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of StopVbInstanceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of StopVbInstanceRequest
+         */
+        public StopVbInstanceRequest build() {
+            StopVbInstanceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/UpdateVbInstanceRequest.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/requests/UpdateVbInstanceRequest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.requests;
+
+import com.oracle.bmc.visualbuilder.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/visualbuilder/UpdateVbInstanceExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use UpdateVbInstanceRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateVbInstanceRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.visualbuilder.model.UpdateVbInstanceDetails> {
+
+    /**
+     * Unique Vb Instance identifier.
+     */
+    private String vbInstanceId;
+
+    /**
+     * The information to be updated.
+     */
+    private com.oracle.bmc.visualbuilder.model.UpdateVbInstanceDetails updateVbInstanceDetails;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The client request ID for tracing.
+     */
+    private String opcRequestId;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.visualbuilder.model.UpdateVbInstanceDetails getBody$() {
+        return updateVbInstanceDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    UpdateVbInstanceRequest,
+                    com.oracle.bmc.visualbuilder.model.UpdateVbInstanceDetails> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateVbInstanceRequest o) {
+            vbInstanceId(o.getVbInstanceId());
+            updateVbInstanceDetails(o.getUpdateVbInstanceDetails());
+            ifMatch(o.getIfMatch());
+            opcRequestId(o.getOpcRequestId());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of UpdateVbInstanceRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of UpdateVbInstanceRequest
+         */
+        public UpdateVbInstanceRequest build() {
+            UpdateVbInstanceRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(com.oracle.bmc.visualbuilder.model.UpdateVbInstanceDetails body) {
+            updateVbInstanceDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ChangeVbInstanceCompartmentResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ChangeVbInstanceCompartmentResponse.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ChangeVbInstanceCompartmentResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private ChangeVbInstanceCompartmentResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ChangeVbInstanceCompartmentResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public ChangeVbInstanceCompartmentResponse build() {
+            return new ChangeVbInstanceCompartmentResponse(
+                    __httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/CreateVbInstanceResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/CreateVbInstanceResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class CreateVbInstanceResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private CreateVbInstanceResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(CreateVbInstanceResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public CreateVbInstanceResponse build() {
+            return new CreateVbInstanceResponse(__httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/DeleteVbInstanceResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/DeleteVbInstanceResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class DeleteVbInstanceResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private DeleteVbInstanceResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(DeleteVbInstanceResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public DeleteVbInstanceResponse build() {
+            return new DeleteVbInstanceResponse(__httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/GetVbInstanceResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/GetVbInstanceResponse.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetVbInstanceResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned VbInstance instance.
+     */
+    private com.oracle.bmc.visualbuilder.model.VbInstance vbInstance;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "etag", "opcRequestId", "vbInstance"})
+    private GetVbInstanceResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.visualbuilder.model.VbInstance vbInstance) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.vbInstance = vbInstance;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetVbInstanceResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            vbInstance(o.getVbInstance());
+
+            return this;
+        }
+
+        public GetVbInstanceResponse build() {
+            return new GetVbInstanceResponse(__httpStatusCode__, etag, opcRequestId, vbInstance);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/GetWorkRequestResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/GetWorkRequestResponse.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class GetWorkRequestResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * some decimal number representing the number of seconds the client should wait before polling this endpoint again.
+     */
+    private Float retryAfter;
+
+    /**
+     * The returned WorkRequest instance.
+     */
+    private com.oracle.bmc.visualbuilder.model.WorkRequest workRequest;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "etag",
+        "opcRequestId",
+        "retryAfter",
+        "workRequest"
+    })
+    private GetWorkRequestResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            Float retryAfter,
+            com.oracle.bmc.visualbuilder.model.WorkRequest workRequest) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.retryAfter = retryAfter;
+        this.workRequest = workRequest;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(GetWorkRequestResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            retryAfter(o.getRetryAfter());
+            workRequest(o.getWorkRequest());
+
+            return this;
+        }
+
+        public GetWorkRequestResponse build() {
+            return new GetWorkRequestResponse(
+                    __httpStatusCode__, etag, opcRequestId, retryAfter, workRequest);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ListVbInstancesResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ListVbInstancesResponse.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListVbInstancesResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results remain
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results have been previously returned
+     *
+     */
+    private String opcPreviousPage;
+
+    /**
+     * The returned VbInstanceSummaryCollection instance.
+     */
+    private com.oracle.bmc.visualbuilder.model.VbInstanceSummaryCollection
+            vbInstanceSummaryCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "opcPreviousPage",
+        "vbInstanceSummaryCollection"
+    })
+    private ListVbInstancesResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            String opcPreviousPage,
+            com.oracle.bmc.visualbuilder.model.VbInstanceSummaryCollection
+                    vbInstanceSummaryCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.opcPreviousPage = opcPreviousPage;
+        this.vbInstanceSummaryCollection = vbInstanceSummaryCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListVbInstancesResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            opcPreviousPage(o.getOpcPreviousPage());
+            vbInstanceSummaryCollection(o.getVbInstanceSummaryCollection());
+
+            return this;
+        }
+
+        public ListVbInstancesResponse build() {
+            return new ListVbInstancesResponse(
+                    __httpStatusCode__,
+                    opcRequestId,
+                    opcNextPage,
+                    opcPreviousPage,
+                    vbInstanceSummaryCollection);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ListWorkRequestErrorsResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ListWorkRequestErrorsResponse.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkRequestErrorsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results remain
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results have been previously returned
+     *
+     */
+    private String opcPreviousPage;
+
+    /**
+     * The returned WorkRequestErrorCollection instance.
+     */
+    private com.oracle.bmc.visualbuilder.model.WorkRequestErrorCollection
+            workRequestErrorCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "opcPreviousPage",
+        "workRequestErrorCollection"
+    })
+    private ListWorkRequestErrorsResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            String opcPreviousPage,
+            com.oracle.bmc.visualbuilder.model.WorkRequestErrorCollection
+                    workRequestErrorCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.opcPreviousPage = opcPreviousPage;
+        this.workRequestErrorCollection = workRequestErrorCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestErrorsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            opcPreviousPage(o.getOpcPreviousPage());
+            workRequestErrorCollection(o.getWorkRequestErrorCollection());
+
+            return this;
+        }
+
+        public ListWorkRequestErrorsResponse build() {
+            return new ListWorkRequestErrorsResponse(
+                    __httpStatusCode__,
+                    opcRequestId,
+                    opcNextPage,
+                    opcPreviousPage,
+                    workRequestErrorCollection);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ListWorkRequestLogsResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ListWorkRequestLogsResponse.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkRequestLogsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results remain
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results have been previously returned
+     *
+     */
+    private String opcPreviousPage;
+
+    /**
+     * The returned WorkRequestLogEntryCollection instance.
+     */
+    private com.oracle.bmc.visualbuilder.model.WorkRequestLogEntryCollection
+            workRequestLogEntryCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "opcPreviousPage",
+        "workRequestLogEntryCollection"
+    })
+    private ListWorkRequestLogsResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            String opcPreviousPage,
+            com.oracle.bmc.visualbuilder.model.WorkRequestLogEntryCollection
+                    workRequestLogEntryCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.opcPreviousPage = opcPreviousPage;
+        this.workRequestLogEntryCollection = workRequestLogEntryCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestLogsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            opcPreviousPage(o.getOpcPreviousPage());
+            workRequestLogEntryCollection(o.getWorkRequestLogEntryCollection());
+
+            return this;
+        }
+
+        public ListWorkRequestLogsResponse build() {
+            return new ListWorkRequestLogsResponse(
+                    __httpStatusCode__,
+                    opcRequestId,
+                    opcNextPage,
+                    opcPreviousPage,
+                    workRequestLogEntryCollection);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ListWorkRequestsResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/ListWorkRequestsResponse.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListWorkRequestsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results remain
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * For list pagination. When this header appears in the response, additional pages of results have been previously returned
+     *
+     */
+    private String opcPreviousPage;
+
+    /**
+     * The returned WorkRequestSummaryCollection instance.
+     */
+    private com.oracle.bmc.visualbuilder.model.WorkRequestSummaryCollection
+            workRequestSummaryCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "opcPreviousPage",
+        "workRequestSummaryCollection"
+    })
+    private ListWorkRequestsResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            String opcPreviousPage,
+            com.oracle.bmc.visualbuilder.model.WorkRequestSummaryCollection
+                    workRequestSummaryCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.opcPreviousPage = opcPreviousPage;
+        this.workRequestSummaryCollection = workRequestSummaryCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListWorkRequestsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            opcPreviousPage(o.getOpcPreviousPage());
+            workRequestSummaryCollection(o.getWorkRequestSummaryCollection());
+
+            return this;
+        }
+
+        public ListWorkRequestsResponse build() {
+            return new ListWorkRequestsResponse(
+                    __httpStatusCode__,
+                    opcRequestId,
+                    opcNextPage,
+                    opcPreviousPage,
+                    workRequestSummaryCollection);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/RequestSummarizedApplicationsResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/RequestSummarizedApplicationsResponse.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RequestSummarizedApplicationsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The returned ApplicationSummaryCollection instance.
+     */
+    private com.oracle.bmc.visualbuilder.model.ApplicationSummaryCollection
+            applicationSummaryCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "etag",
+        "opcRequestId",
+        "applicationSummaryCollection"
+    })
+    private RequestSummarizedApplicationsResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            com.oracle.bmc.visualbuilder.model.ApplicationSummaryCollection
+                    applicationSummaryCollection) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.applicationSummaryCollection = applicationSummaryCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RequestSummarizedApplicationsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            applicationSummaryCollection(o.getApplicationSummaryCollection());
+
+            return this;
+        }
+
+        public RequestSummarizedApplicationsResponse build() {
+            return new RequestSummarizedApplicationsResponse(
+                    __httpStatusCode__, etag, opcRequestId, applicationSummaryCollection);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/StartVbInstanceResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/StartVbInstanceResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class StartVbInstanceResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private StartVbInstanceResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(StartVbInstanceResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public StartVbInstanceResponse build() {
+            return new StartVbInstanceResponse(__httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/StopVbInstanceResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/StopVbInstanceResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class StopVbInstanceResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private StopVbInstanceResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(StopVbInstanceResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public StopVbInstanceResponse build() {
+            return new StopVbInstanceResponse(__httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/UpdateVbInstanceResponse.java
+++ b/bmc-visualbuilder/src/main/java/com/oracle/bmc/visualbuilder/responses/UpdateVbInstanceResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.visualbuilder.responses;
+
+import com.oracle.bmc.visualbuilder.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210601")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class UpdateVbInstanceResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the asynchronous request.
+     * You can use this to query status of the asynchronous operation.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If
+     * you need to contact Oracle about a particular request,
+     * please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcWorkRequestId", "opcRequestId"})
+    private UpdateVbInstanceResponse(
+            int __httpStatusCode__, String opcWorkRequestId, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(UpdateVbInstanceResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public UpdateVbInstanceResponse build() {
+            return new UpdateVbInstanceResponse(__httpStatusCode__, opcWorkRequestId, opcRequestId);
+        }
+    }
+}

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.13.0</version>
+  <version>2.13.1</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>
@@ -718,6 +718,7 @@
     <module>bmc-appmgmtcontrol</module>
     <module>bmc-ospgateway</module>
     <module>bmc-identitydataplane</module>
+    <module>bmc-visualbuilder</module>
     <module>bmc-full</module>
     <module>bmc-shaded</module>
   </modules>


### PR DESCRIPTION
### Added

- Support for calling Oracle Cloud Infrastructure services in the me-dcc-muscat-1 region

- Support for the Visual Builder service

- Support for cross-region replication of volume groups in the Block Storage service

- Support for boot volume encryption in the Container Engine for Kubernetes service

- Support for adding metadata to records when creating and updating records in the Data Labeling service

- Support for global export formats in snapshot datasets in the Data Labeling service

- Support for adding labeling instructions to datasets in the Data Labeling service

- Support for updating autonomous dataguard associations for autonomous container databases in the Database service

- Support for setting up automatic failover when creating autonomous container databases in the Database service

- Support for setting the RECO storage size when updating a database system in the Database service

- Support for reconnecting refreshable clones to source for autonomous databases on shared infrastructure in the Database service

- Support for checking if an autonomous database on shared infrastructure can be reconnected to source, in the Database service