### PR TITLE
Releasing version 2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.18.0 - 2022-03-01
+### Added
+- Support for DRG route distribution statements to be specified with a new match type `MATCH_ALL` for matching criteria in the Networking service
+- Support for VCN route types on DRG attachments for deciding whether to import VCN CIDRs or subnet CIDRs into route rules in the Networking service
+- Support for CPS offline reports in the Database service
+- Support for infrastructure patching v2 features in the Database service
+- Support for auto-scaling the storage of an autonomous database, as well as shrinking an autonomous database, in the Database service
+- Support for managed egress via a default networking option on jobs and notebooks in the Data Science service
+- Support for more types of saved search enums in the Management Dashboard service
+
+### Breaking Changes
+- Support for retries enabled by default on some operations in the AI Vision service
+
 ## 2.17.0 - 2022-02-22
 ### Added
 - Support for the Data Connectivity Management service

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aispeech/pom.xml
+++ b/bmc-aispeech/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aispeech</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aivision/pom.xml
+++ b/bmc-aivision/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aivision</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aivision/src/main/java/com/oracle/bmc/aivision/AIServiceVision.java
+++ b/bmc-aivision/src/main/java/com/oracle/bmc/aivision/AIServiceVision.java
@@ -52,7 +52,7 @@ public interface AIServiceVision extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/aivision/AnalyzeDocumentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use AnalyzeDocument API.
@@ -65,7 +65,7 @@ public interface AIServiceVision extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/aivision/AnalyzeImageExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use AnalyzeImage API.

--- a/bmc-aivision/src/main/java/com/oracle/bmc/aivision/AIServiceVisionClient.java
+++ b/bmc-aivision/src/main/java/com/oracle/bmc/aivision/AIServiceVisionClient.java
@@ -473,7 +473,7 @@ public class AIServiceVisionClient implements AIServiceVision {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -506,7 +506,7 @@ public class AIServiceVisionClient implements AIServiceVision {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-appmgmtcontrol/pom.xml
+++ b/bmc-appmgmtcontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,636 +19,636 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificates</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usage</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasetools</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ospgateway</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identitydataplane</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-visualbuilder</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubusage</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubsubscription</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dashboardservice</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-threatintelligence</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aivision</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aispeech</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataconnectivity</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificates/pom.xml
+++ b/bmc-certificates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificates</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificatesmanagement/pom.xml
+++ b/bmc-certificatesmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.core.model;
+
+/**
+ * No match criteria is applied.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "matchType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria
+        extends DrgRouteDistributionMatchCriteria {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria build() {
+            DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria __instance__ =
+                    new DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgRouteDistributionMatchCriteria.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/DrgRouteDistributionMatchCriteria.java
@@ -37,6 +37,10 @@ package com.oracle.bmc.core.model;
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = DrgAttachmentTypeDrgRouteDistributionMatchCriteria.class,
         name = "DRG_ATTACHMENT_TYPE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = DrgAttachmentMatchAllDrgRouteDistributionMatchCriteria.class,
+        name = "MATCH_ALL"
     )
 })
 @com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
@@ -50,6 +54,7 @@ public class DrgRouteDistributionMatchCriteria {
     public enum MatchType {
         DrgAttachmentType("DRG_ATTACHMENT_TYPE"),
         DrgAttachmentId("DRG_ATTACHMENT_ID"),
+        MatchAll("MATCH_ALL"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkCreateDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkCreateDetails.java
@@ -50,19 +50,31 @@ public class VcnDrgAttachmentNetworkCreateDetails extends DrgAttachmentNetworkCr
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnRouteType")
+        private VcnDrgAttachmentNetworkDetails.VcnRouteType vcnRouteType;
+
+        public Builder vcnRouteType(VcnDrgAttachmentNetworkDetails.VcnRouteType vcnRouteType) {
+            this.vcnRouteType = vcnRouteType;
+            this.__explicitlySet__.add("vcnRouteType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public VcnDrgAttachmentNetworkCreateDetails build() {
             VcnDrgAttachmentNetworkCreateDetails __instance__ =
-                    new VcnDrgAttachmentNetworkCreateDetails(id, routeTableId);
+                    new VcnDrgAttachmentNetworkCreateDetails(id, routeTableId, vcnRouteType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(VcnDrgAttachmentNetworkCreateDetails o) {
-            Builder copiedBuilder = id(o.getId()).routeTableId(o.getRouteTableId());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .routeTableId(o.getRouteTableId())
+                            .vcnRouteType(o.getVcnRouteType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -77,9 +89,13 @@ public class VcnDrgAttachmentNetworkCreateDetails extends DrgAttachmentNetworkCr
     }
 
     @Deprecated
-    public VcnDrgAttachmentNetworkCreateDetails(String id, String routeTableId) {
+    public VcnDrgAttachmentNetworkCreateDetails(
+            String id,
+            String routeTableId,
+            VcnDrgAttachmentNetworkDetails.VcnRouteType vcnRouteType) {
         super(id);
         this.routeTableId = routeTableId;
+        this.vcnRouteType = vcnRouteType;
     }
 
     /**
@@ -95,6 +111,14 @@ public class VcnDrgAttachmentNetworkCreateDetails extends DrgAttachmentNetworkCr
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")
     String routeTableId;
+
+    /**
+     * Indicates whether the VCN CIDR(s) or the individual Subnet CIDR(s) are imported from the attachment.
+     * Routes from the VCN Ingress Route Table are always imported.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnRouteType")
+    VcnDrgAttachmentNetworkDetails.VcnRouteType vcnRouteType;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkDetails.java
@@ -50,19 +50,31 @@ public class VcnDrgAttachmentNetworkDetails extends DrgAttachmentNetworkDetails 
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnRouteType")
+        private VcnRouteType vcnRouteType;
+
+        public Builder vcnRouteType(VcnRouteType vcnRouteType) {
+            this.vcnRouteType = vcnRouteType;
+            this.__explicitlySet__.add("vcnRouteType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public VcnDrgAttachmentNetworkDetails build() {
             VcnDrgAttachmentNetworkDetails __instance__ =
-                    new VcnDrgAttachmentNetworkDetails(id, routeTableId);
+                    new VcnDrgAttachmentNetworkDetails(id, routeTableId, vcnRouteType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(VcnDrgAttachmentNetworkDetails o) {
-            Builder copiedBuilder = id(o.getId()).routeTableId(o.getRouteTableId());
+            Builder copiedBuilder =
+                    id(o.getId())
+                            .routeTableId(o.getRouteTableId())
+                            .vcnRouteType(o.getVcnRouteType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -77,9 +89,11 @@ public class VcnDrgAttachmentNetworkDetails extends DrgAttachmentNetworkDetails 
     }
 
     @Deprecated
-    public VcnDrgAttachmentNetworkDetails(String id, String routeTableId) {
+    public VcnDrgAttachmentNetworkDetails(
+            String id, String routeTableId, VcnRouteType vcnRouteType) {
         super(id);
         this.routeTableId = routeTableId;
+        this.vcnRouteType = vcnRouteType;
     }
 
     /**
@@ -93,6 +107,61 @@ public class VcnDrgAttachmentNetworkDetails extends DrgAttachmentNetworkDetails 
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")
     String routeTableId;
+    /**
+     * Indicates whether the VCN CIDR(s) or the individual Subnet CIDR(s) are imported from the attachment.
+     * Routes from the VCN Ingress Route Table are always imported.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum VcnRouteType {
+        VcnCidrs("VCN_CIDRS"),
+        SubnetCidrs("SUBNET_CIDRS"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, VcnRouteType> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (VcnRouteType v : VcnRouteType.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        VcnRouteType(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static VcnRouteType create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'VcnRouteType', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Indicates whether the VCN CIDR(s) or the individual Subnet CIDR(s) are imported from the attachment.
+     * Routes from the VCN Ingress Route Table are always imported.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnRouteType")
+    VcnRouteType vcnRouteType;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkUpdateDetails.java
+++ b/bmc-core/src/main/java/com/oracle/bmc/core/model/VcnDrgAttachmentNetworkUpdateDetails.java
@@ -41,19 +41,29 @@ public class VcnDrgAttachmentNetworkUpdateDetails extends DrgAttachmentNetworkUp
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnRouteType")
+        private VcnDrgAttachmentNetworkDetails.VcnRouteType vcnRouteType;
+
+        public Builder vcnRouteType(VcnDrgAttachmentNetworkDetails.VcnRouteType vcnRouteType) {
+            this.vcnRouteType = vcnRouteType;
+            this.__explicitlySet__.add("vcnRouteType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public VcnDrgAttachmentNetworkUpdateDetails build() {
             VcnDrgAttachmentNetworkUpdateDetails __instance__ =
-                    new VcnDrgAttachmentNetworkUpdateDetails(routeTableId);
+                    new VcnDrgAttachmentNetworkUpdateDetails(routeTableId, vcnRouteType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
 
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(VcnDrgAttachmentNetworkUpdateDetails o) {
-            Builder copiedBuilder = routeTableId(o.getRouteTableId());
+            Builder copiedBuilder =
+                    routeTableId(o.getRouteTableId()).vcnRouteType(o.getVcnRouteType());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -68,9 +78,11 @@ public class VcnDrgAttachmentNetworkUpdateDetails extends DrgAttachmentNetworkUp
     }
 
     @Deprecated
-    public VcnDrgAttachmentNetworkUpdateDetails(String routeTableId) {
+    public VcnDrgAttachmentNetworkUpdateDetails(
+            String routeTableId, VcnDrgAttachmentNetworkDetails.VcnRouteType vcnRouteType) {
         super();
         this.routeTableId = routeTableId;
+        this.vcnRouteType = vcnRouteType;
     }
 
     /**
@@ -84,6 +96,14 @@ public class VcnDrgAttachmentNetworkUpdateDetails extends DrgAttachmentNetworkUp
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("routeTableId")
     String routeTableId;
+
+    /**
+     * Indicates whether the VCN CIDR(s) or the individual Subnet CIDR(s) are imported from the attachment.
+     * Routes from the VCN Ingress Route Table are always imported.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnRouteType")
+    VcnDrgAttachmentNetworkDetails.VcnRouteType vcnRouteType;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-dashboardservice/pom.xml
+++ b/bmc-dashboardservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dashboardservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/Database.java
@@ -3116,6 +3116,20 @@ public interface Database extends AutoCloseable {
                     ScanExternalContainerDatabasePluggableDatabasesRequest request);
 
     /**
+     * This operation shrinks the current allocated storage down to the current actual used data storage (actualUsedDataStorageSizeInTBs). The if the base storage value for the database (dataStorageSizeInTBs) is larger than the actualUsedDataStorageSizeInTBs value, you are billed for the base storage value.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ShrinkAutonomousDatabaseExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ShrinkAutonomousDatabase API.
+     */
+    ShrinkAutonomousDatabaseResponse shrinkAutonomousDatabase(
+            ShrinkAutonomousDatabaseRequest request);
+
+    /**
      * Starts the specified Autonomous Database.
      *
      * @param request The request object containing the details to send

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsync.java
@@ -3977,6 +3977,23 @@ public interface DatabaseAsync extends AutoCloseable {
                             handler);
 
     /**
+     * This operation shrinks the current allocated storage down to the current actual used data storage (actualUsedDataStorageSizeInTBs). The if the base storage value for the database (dataStorageSizeInTBs) is larger than the actualUsedDataStorageSizeInTBs value, you are billed for the base storage value.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ShrinkAutonomousDatabaseResponse> shrinkAutonomousDatabase(
+            ShrinkAutonomousDatabaseRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ShrinkAutonomousDatabaseRequest, ShrinkAutonomousDatabaseResponse>
+                    handler);
+
+    /**
      * Starts the specified Autonomous Database.
      *
      *

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseAsyncClient.java
@@ -10313,6 +10313,47 @@ public class DatabaseAsyncClient implements DatabaseAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ShrinkAutonomousDatabaseResponse> shrinkAutonomousDatabase(
+            ShrinkAutonomousDatabaseRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ShrinkAutonomousDatabaseRequest, ShrinkAutonomousDatabaseResponse>
+                    handler) {
+        LOG.trace("Called async shrinkAutonomousDatabase");
+        final ShrinkAutonomousDatabaseRequest interceptedRequest =
+                ShrinkAutonomousDatabaseConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ShrinkAutonomousDatabaseConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ShrinkAutonomousDatabaseResponse>
+                transformer = ShrinkAutonomousDatabaseConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ShrinkAutonomousDatabaseRequest, ShrinkAutonomousDatabaseResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ShrinkAutonomousDatabaseRequest, ShrinkAutonomousDatabaseResponse>,
+                        java.util.concurrent.Future<ShrinkAutonomousDatabaseResponse>>
+                futureSupplier = client.postFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ShrinkAutonomousDatabaseRequest, ShrinkAutonomousDatabaseResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<StartAutonomousDatabaseResponse> startAutonomousDatabase(
             StartAutonomousDatabaseRequest request,
             final com.oracle.bmc.responses.AsyncHandler<

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseClient.java
@@ -7668,6 +7668,37 @@ public class DatabaseClient implements Database {
     }
 
     @Override
+    public ShrinkAutonomousDatabaseResponse shrinkAutonomousDatabase(
+            ShrinkAutonomousDatabaseRequest request) {
+        LOG.trace("Called shrinkAutonomousDatabase");
+        final ShrinkAutonomousDatabaseRequest interceptedRequest =
+                ShrinkAutonomousDatabaseConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ShrinkAutonomousDatabaseConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ShrinkAutonomousDatabaseResponse>
+                transformer = ShrinkAutonomousDatabaseConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public StartAutonomousDatabaseResponse startAutonomousDatabase(
             StartAutonomousDatabaseRequest request) {
         LOG.trace("Called startAutonomousDatabase");

--- a/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/DatabaseWaiters.java
@@ -10446,6 +10446,65 @@ public class DatabaseWaiters {
      * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<
+                    ShrinkAutonomousDatabaseRequest, ShrinkAutonomousDatabaseResponse>
+            forShrinkAutonomousDatabase(ShrinkAutonomousDatabaseRequest request) {
+        return forShrinkAutonomousDatabase(
+                request,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_TERMINATION_STRATEGY,
+                com.oracle.bmc.waiter.Waiters.DEFAULT_POLLING_DELAY_STRATEGY);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the provided configuration.
+     *
+     * @param request the request to send
+     * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
+     * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
+                    ShrinkAutonomousDatabaseRequest, ShrinkAutonomousDatabaseResponse>
+            forShrinkAutonomousDatabase(
+                    ShrinkAutonomousDatabaseRequest request,
+                    com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
+                    com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
+        if (workRequestClient == null) {
+            throw new IllegalStateException(
+                    "A WorkRequestClient must be supplied to this waiter for this operation");
+        }
+
+        return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
+                executorService,
+                new java.util.concurrent.Callable<ShrinkAutonomousDatabaseResponse>() {
+                    @Override
+                    public ShrinkAutonomousDatabaseResponse call() throws Exception {
+                        final ShrinkAutonomousDatabaseResponse response =
+                                client.shrinkAutonomousDatabase(request);
+
+                        final com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                getWorkRequestRequest =
+                                        com.oracle.bmc.workrequests.requests.GetWorkRequestRequest
+                                                .builder()
+                                                .workRequestId(response.getOpcWorkRequestId())
+                                                .build();
+                        workRequestClient
+                                .getWaiters()
+                                .forWorkRequest(
+                                        getWorkRequestRequest, terminationStrategy, delayStrategy)
+                                .execute();
+                        return response;
+                    }
+                },
+                request);
+    }
+
+    /**
+     * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
+     *
+     * @param request the request to send
+     * @return a new {@link com.oracle.bmc.waiter.Waiter} instance
+     */
+    public com.oracle.bmc.waiter.Waiter<
                     StartAutonomousDatabaseRequest, StartAutonomousDatabaseResponse>
             forStartAutonomousDatabase(StartAutonomousDatabaseRequest request) {
         return forStartAutonomousDatabase(

--- a/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ShrinkAutonomousDatabaseConverter.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/internal/http/ShrinkAutonomousDatabaseConverter.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.database.model.*;
+import com.oracle.bmc.database.requests.*;
+import com.oracle.bmc.database.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.extern.slf4j.Slf4j
+public class ShrinkAutonomousDatabaseConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.database.requests.ShrinkAutonomousDatabaseRequest interceptRequest(
+            com.oracle.bmc.database.requests.ShrinkAutonomousDatabaseRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.database.requests.ShrinkAutonomousDatabaseRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(
+                request.getAutonomousDatabaseId(), "autonomousDatabaseId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20160918")
+                        .path("autonomousDatabases")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getAutonomousDatabaseId()))
+                        .path("actions")
+                        .path("shrink");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.database.responses.ShrinkAutonomousDatabaseResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.database.responses.ShrinkAutonomousDatabaseResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.database.responses
+                                        .ShrinkAutonomousDatabaseResponse>() {
+                            @Override
+                            public com.oracle.bmc.database.responses
+                                            .ShrinkAutonomousDatabaseResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.database.responses.ShrinkAutonomousDatabaseResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.database.model
+                                                                .AutonomousDatabase>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.database.model
+                                                                        .AutonomousDatabase
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.database.model.AutonomousDatabase>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.database.responses.ShrinkAutonomousDatabaseResponse
+                                                .Builder
+                                        builder =
+                                                com.oracle.bmc.database.responses
+                                                        .ShrinkAutonomousDatabaseResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.autonomousDatabase(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>> etagHeader =
+                                        com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                headers, "etag");
+                                if (etagHeader.isPresent()) {
+                                    builder.etag(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "etag", etagHeader.get().get(0), String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcWorkRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-work-request-id");
+                                if (opcWorkRequestIdHeader.isPresent()) {
+                                    builder.opcWorkRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-work-request-id",
+                                                    opcWorkRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.database.responses.ShrinkAutonomousDatabaseResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabase.java
@@ -745,6 +745,33 @@ public class AutonomousDatabase {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+        private Boolean isAutoScalingForStorageEnabled;
+
+        public Builder isAutoScalingForStorageEnabled(Boolean isAutoScalingForStorageEnabled) {
+            this.isAutoScalingForStorageEnabled = isAutoScalingForStorageEnabled;
+            this.__explicitlySet__.add("isAutoScalingForStorageEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("allocatedStorageSizeInTBs")
+        private Double allocatedStorageSizeInTBs;
+
+        public Builder allocatedStorageSizeInTBs(Double allocatedStorageSizeInTBs) {
+            this.allocatedStorageSizeInTBs = allocatedStorageSizeInTBs;
+            this.__explicitlySet__.add("allocatedStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("actualUsedDataStorageSizeInTBs")
+        private Double actualUsedDataStorageSizeInTBs;
+
+        public Builder actualUsedDataStorageSizeInTBs(Double actualUsedDataStorageSizeInTBs) {
+            this.actualUsedDataStorageSizeInTBs = actualUsedDataStorageSizeInTBs;
+            this.__explicitlySet__.add("actualUsedDataStorageSizeInTBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -829,7 +856,10 @@ public class AutonomousDatabase {
                             isReconnectCloneEnabled,
                             timeUntilReconnectCloneEnabled,
                             autonomousMaintenanceScheduleType,
-                            scheduledOperations);
+                            scheduledOperations,
+                            isAutoScalingForStorageEnabled,
+                            allocatedStorageSizeInTBs,
+                            actualUsedDataStorageSizeInTBs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -918,7 +948,10 @@ public class AutonomousDatabase {
                             .timeUntilReconnectCloneEnabled(o.getTimeUntilReconnectCloneEnabled())
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
-                            .scheduledOperations(o.getScheduledOperations());
+                            .scheduledOperations(o.getScheduledOperations())
+                            .isAutoScalingForStorageEnabled(o.getIsAutoScalingForStorageEnabled())
+                            .allocatedStorageSizeInTBs(o.getAllocatedStorageSizeInTBs())
+                            .actualUsedDataStorageSizeInTBs(o.getActualUsedDataStorageSizeInTBs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -2155,6 +2188,29 @@ public class AutonomousDatabase {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scheduledOperations")
     java.util.List<ScheduledOperationDetails> scheduledOperations;
+
+    /**
+     * Indicates if auto scaling is enabled for the Autonomous Database storage. The default value is {@code FALSE}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+    Boolean isAutoScalingForStorageEnabled;
+
+    /**
+     * The amount of storage currently allocated for the database tables and billed for, rounded up. When auto-scaling is not enabled, this value is equal to the {@code dataStorageSizeInTBs} value. You can compare this value to the {@code actualUsedDataStorageSizeInTBs} value to determine if a manual shrink operation is appropriate for your allocated storage.
+     * <p>
+     **Note:** Auto-scaling does not automatically decrease allocated storage when data is deleted from the database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allocatedStorageSizeInTBs")
+    Double allocatedStorageSizeInTBs;
+
+    /**
+     * The current amount of storage in use for user and system data, in terabytes (TB).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("actualUsedDataStorageSizeInTBs")
+    Double actualUsedDataStorageSizeInTBs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/AutonomousDatabaseSummary.java
@@ -747,6 +747,33 @@ public class AutonomousDatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+        private Boolean isAutoScalingForStorageEnabled;
+
+        public Builder isAutoScalingForStorageEnabled(Boolean isAutoScalingForStorageEnabled) {
+            this.isAutoScalingForStorageEnabled = isAutoScalingForStorageEnabled;
+            this.__explicitlySet__.add("isAutoScalingForStorageEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("allocatedStorageSizeInTBs")
+        private Double allocatedStorageSizeInTBs;
+
+        public Builder allocatedStorageSizeInTBs(Double allocatedStorageSizeInTBs) {
+            this.allocatedStorageSizeInTBs = allocatedStorageSizeInTBs;
+            this.__explicitlySet__.add("allocatedStorageSizeInTBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("actualUsedDataStorageSizeInTBs")
+        private Double actualUsedDataStorageSizeInTBs;
+
+        public Builder actualUsedDataStorageSizeInTBs(Double actualUsedDataStorageSizeInTBs) {
+            this.actualUsedDataStorageSizeInTBs = actualUsedDataStorageSizeInTBs;
+            this.__explicitlySet__.add("actualUsedDataStorageSizeInTBs");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -831,7 +858,10 @@ public class AutonomousDatabaseSummary {
                             isReconnectCloneEnabled,
                             timeUntilReconnectCloneEnabled,
                             autonomousMaintenanceScheduleType,
-                            scheduledOperations);
+                            scheduledOperations,
+                            isAutoScalingForStorageEnabled,
+                            allocatedStorageSizeInTBs,
+                            actualUsedDataStorageSizeInTBs);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -920,7 +950,10 @@ public class AutonomousDatabaseSummary {
                             .timeUntilReconnectCloneEnabled(o.getTimeUntilReconnectCloneEnabled())
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
-                            .scheduledOperations(o.getScheduledOperations());
+                            .scheduledOperations(o.getScheduledOperations())
+                            .isAutoScalingForStorageEnabled(o.getIsAutoScalingForStorageEnabled())
+                            .allocatedStorageSizeInTBs(o.getAllocatedStorageSizeInTBs())
+                            .actualUsedDataStorageSizeInTBs(o.getActualUsedDataStorageSizeInTBs());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -2157,6 +2190,29 @@ public class AutonomousDatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scheduledOperations")
     java.util.List<ScheduledOperationDetails> scheduledOperations;
+
+    /**
+     * Indicates if auto scaling is enabled for the Autonomous Database storage. The default value is {@code FALSE}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+    Boolean isAutoScalingForStorageEnabled;
+
+    /**
+     * The amount of storage currently allocated for the database tables and billed for, rounded up. When auto-scaling is not enabled, this value is equal to the {@code dataStorageSizeInTBs} value. You can compare this value to the {@code actualUsedDataStorageSizeInTBs} value to determine if a manual shrink operation is appropriate for your allocated storage.
+     * <p>
+     **Note:** Auto-scaling does not automatically decrease allocated storage when data is deleted from the database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("allocatedStorageSizeInTBs")
+    Double allocatedStorageSizeInTBs;
+
+    /**
+     * The current amount of storage in use for user and system data, in terabytes (TB).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("actualUsedDataStorageSizeInTBs")
+    Double actualUsedDataStorageSizeInTBs;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseBase.java
@@ -460,6 +460,13 @@ public class CreateAutonomousDatabaseBase {
     java.util.List<ScheduledOperationDetails> scheduledOperations;
 
     /**
+     * Indicates if auto scaling is enabled for the Autonomous Database storage. The default value is {@code FALSE}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+    Boolean isAutoScalingForStorageEnabled;
+
+    /**
      * The source of the database: Use {@code NONE} for creating a new Autonomous Database. Use {@code DATABASE} for creating a new Autonomous Database by cloning an existing Autonomous Database. Use {@code CROSS_REGION_DATAGUARD} to create a standby Data Guard database in another region.
      * <p>
      * For Autonomous Databases on [shared Exadata infrastructure](https://docs.oracle.com/en/cloud/paas/autonomous-database/index.html), the following cloning options are available: Use {@code BACKUP_FROM_ID} for creating a new Autonomous Database from a specified backup. Use {@code BACKUP_FROM_TIMESTAMP} for creating a point-in-time Autonomous Database clone using backups. For more information, see [Cloning and Moving an Autonomous Database](https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/clone-autonomous-database.html#GUID-D771796F-5081-4CFB-A7FF-0F893EABD7BC).

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseCloneDetails.java
@@ -326,6 +326,15 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+        private Boolean isAutoScalingForStorageEnabled;
+
+        public Builder isAutoScalingForStorageEnabled(Boolean isAutoScalingForStorageEnabled) {
+            this.isAutoScalingForStorageEnabled = isAutoScalingForStorageEnabled;
+            this.__explicitlySet__.add("isAutoScalingForStorageEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
         private String sourceId;
 
@@ -382,6 +391,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             isMtlsConnectionRequired,
                             autonomousMaintenanceScheduleType,
                             scheduledOperations,
+                            isAutoScalingForStorageEnabled,
                             sourceId,
                             cloneType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -425,6 +435,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
                             .scheduledOperations(o.getScheduledOperations())
+                            .isAutoScalingForStorageEnabled(o.getIsAutoScalingForStorageEnabled())
                             .sourceId(o.getSourceId())
                             .cloneType(o.getCloneType());
 
@@ -474,6 +485,7 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
             Boolean isMtlsConnectionRequired,
             AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             java.util.List<ScheduledOperationDetails> scheduledOperations,
+            Boolean isAutoScalingForStorageEnabled,
             String sourceId,
             CloneType cloneType) {
         super(
@@ -508,7 +520,8 @@ public class CreateAutonomousDatabaseCloneDetails extends CreateAutonomousDataba
                 customerContacts,
                 isMtlsConnectionRequired,
                 autonomousMaintenanceScheduleType,
-                scheduledOperations);
+                scheduledOperations,
+                isAutoScalingForStorageEnabled);
         this.sourceId = sourceId;
         this.cloneType = cloneType;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseDetails.java
@@ -326,6 +326,15 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+        private Boolean isAutoScalingForStorageEnabled;
+
+        public Builder isAutoScalingForStorageEnabled(Boolean isAutoScalingForStorageEnabled) {
+            this.isAutoScalingForStorageEnabled = isAutoScalingForStorageEnabled;
+            this.__explicitlySet__.add("isAutoScalingForStorageEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -363,7 +372,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             customerContacts,
                             isMtlsConnectionRequired,
                             autonomousMaintenanceScheduleType,
-                            scheduledOperations);
+                            scheduledOperations,
+                            isAutoScalingForStorageEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -404,7 +414,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                             .isMtlsConnectionRequired(o.getIsMtlsConnectionRequired())
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
-                            .scheduledOperations(o.getScheduledOperations());
+                            .scheduledOperations(o.getScheduledOperations())
+                            .isAutoScalingForStorageEnabled(o.getIsAutoScalingForStorageEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -451,7 +462,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
             java.util.List<CustomerContact> customerContacts,
             Boolean isMtlsConnectionRequired,
             AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
-            java.util.List<ScheduledOperationDetails> scheduledOperations) {
+            java.util.List<ScheduledOperationDetails> scheduledOperations,
+            Boolean isAutoScalingForStorageEnabled) {
         super(
                 compartmentId,
                 dbName,
@@ -484,7 +496,8 @@ public class CreateAutonomousDatabaseDetails extends CreateAutonomousDatabaseBas
                 customerContacts,
                 isMtlsConnectionRequired,
                 autonomousMaintenanceScheduleType,
-                scheduledOperations);
+                scheduledOperations,
+                isAutoScalingForStorageEnabled);
     }
 
     @com.fasterxml.jackson.annotation.JsonIgnore

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupDetails.java
@@ -326,6 +326,15 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+        private Boolean isAutoScalingForStorageEnabled;
+
+        public Builder isAutoScalingForStorageEnabled(Boolean isAutoScalingForStorageEnabled) {
+            this.isAutoScalingForStorageEnabled = isAutoScalingForStorageEnabled;
+            this.__explicitlySet__.add("isAutoScalingForStorageEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("autonomousDatabaseBackupId")
         private String autonomousDatabaseBackupId;
 
@@ -382,6 +391,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             isMtlsConnectionRequired,
                             autonomousMaintenanceScheduleType,
                             scheduledOperations,
+                            isAutoScalingForStorageEnabled,
                             autonomousDatabaseBackupId,
                             cloneType);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -425,6 +435,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
                             .scheduledOperations(o.getScheduledOperations())
+                            .isAutoScalingForStorageEnabled(o.getIsAutoScalingForStorageEnabled())
                             .autonomousDatabaseBackupId(o.getAutonomousDatabaseBackupId())
                             .cloneType(o.getCloneType());
 
@@ -474,6 +485,7 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
             Boolean isMtlsConnectionRequired,
             AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             java.util.List<ScheduledOperationDetails> scheduledOperations,
+            Boolean isAutoScalingForStorageEnabled,
             String autonomousDatabaseBackupId,
             CloneType cloneType) {
         super(
@@ -508,7 +520,8 @@ public class CreateAutonomousDatabaseFromBackupDetails extends CreateAutonomousD
                 customerContacts,
                 isMtlsConnectionRequired,
                 autonomousMaintenanceScheduleType,
-                scheduledOperations);
+                scheduledOperations,
+                isAutoScalingForStorageEnabled);
         this.autonomousDatabaseBackupId = autonomousDatabaseBackupId;
         this.cloneType = cloneType;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateAutonomousDatabaseFromBackupTimestampDetails.java
@@ -327,6 +327,15 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+        private Boolean isAutoScalingForStorageEnabled;
+
+        public Builder isAutoScalingForStorageEnabled(Boolean isAutoScalingForStorageEnabled) {
+            this.isAutoScalingForStorageEnabled = isAutoScalingForStorageEnabled;
+            this.__explicitlySet__.add("isAutoScalingForStorageEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("autonomousDatabaseId")
         private String autonomousDatabaseId;
 
@@ -392,6 +401,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             isMtlsConnectionRequired,
                             autonomousMaintenanceScheduleType,
                             scheduledOperations,
+                            isAutoScalingForStorageEnabled,
                             autonomousDatabaseId,
                             timestamp,
                             cloneType);
@@ -436,6 +446,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
                             .scheduledOperations(o.getScheduledOperations())
+                            .isAutoScalingForStorageEnabled(o.getIsAutoScalingForStorageEnabled())
                             .autonomousDatabaseId(o.getAutonomousDatabaseId())
                             .timestamp(o.getTimestamp())
                             .cloneType(o.getCloneType());
@@ -486,6 +497,7 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
             Boolean isMtlsConnectionRequired,
             AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             java.util.List<ScheduledOperationDetails> scheduledOperations,
+            Boolean isAutoScalingForStorageEnabled,
             String autonomousDatabaseId,
             java.util.Date timestamp,
             CloneType cloneType) {
@@ -521,7 +533,8 @@ public class CreateAutonomousDatabaseFromBackupTimestampDetails
                 customerContacts,
                 isMtlsConnectionRequired,
                 autonomousMaintenanceScheduleType,
-                scheduledOperations);
+                scheduledOperations,
+                isAutoScalingForStorageEnabled);
         this.autonomousDatabaseId = autonomousDatabaseId;
         this.timestamp = timestamp;
         this.cloneType = cloneType;

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCrossRegionAutonomousDatabaseDataGuardDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateCrossRegionAutonomousDatabaseDataGuardDetails.java
@@ -364,6 +364,15 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+        private Boolean isAutoScalingForStorageEnabled;
+
+        public Builder isAutoScalingForStorageEnabled(Boolean isAutoScalingForStorageEnabled) {
+            this.isAutoScalingForStorageEnabled = isAutoScalingForStorageEnabled;
+            this.__explicitlySet__.add("isAutoScalingForStorageEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
         private String sourceId;
 
@@ -411,6 +420,7 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
                             isMtlsConnectionRequired,
                             autonomousMaintenanceScheduleType,
                             scheduledOperations,
+                            isAutoScalingForStorageEnabled,
                             sourceId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -453,6 +463,7 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
                             .scheduledOperations(o.getScheduledOperations())
+                            .isAutoScalingForStorageEnabled(o.getIsAutoScalingForStorageEnabled())
                             .sourceId(o.getSourceId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -501,6 +512,7 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
             Boolean isMtlsConnectionRequired,
             AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             java.util.List<ScheduledOperationDetails> scheduledOperations,
+            Boolean isAutoScalingForStorageEnabled,
             String sourceId) {
         super(
                 compartmentId,
@@ -534,7 +546,8 @@ public class CreateCrossRegionAutonomousDatabaseDataGuardDetails
                 customerContacts,
                 isMtlsConnectionRequired,
                 autonomousMaintenanceScheduleType,
-                scheduledOperations);
+                scheduledOperations,
+                isAutoScalingForStorageEnabled);
         this.sourceId = sourceId;
     }
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateExadataInfrastructureDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateExadataInfrastructureDetails.java
@@ -181,6 +181,15 @@ public class CreateExadataInfrastructureDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCpsOfflineReportEnabled")
+        private Boolean isCpsOfflineReportEnabled;
+
+        public Builder isCpsOfflineReportEnabled(Boolean isCpsOfflineReportEnabled) {
+            this.isCpsOfflineReportEnabled = isCpsOfflineReportEnabled;
+            this.__explicitlySet__.add("isCpsOfflineReportEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -223,6 +232,7 @@ public class CreateExadataInfrastructureDetails {
                             computeCount,
                             dnsServer,
                             ntpServer,
+                            isCpsOfflineReportEnabled,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -249,6 +259,7 @@ public class CreateExadataInfrastructureDetails {
                             .computeCount(o.getComputeCount())
                             .dnsServer(o.getDnsServer())
                             .ntpServer(o.getNtpServer())
+                            .isCpsOfflineReportEnabled(o.getIsCpsOfflineReportEnabled())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -368,6 +379,15 @@ public class CreateExadataInfrastructureDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("ntpServer")
     java.util.List<String> ntpServer;
+
+    /**
+     * Indicates whether cps offline diagnostic report is enabled for this Exadata infrastructure. This will allow a customer to quickly check status themselves and fix problems on their end, saving time and frustration
+     * for both Oracle and the customer when they find the CPS in a disconnected state.You can enable offline diagnostic report during Exadata infrastructure provisioning. You can also disable or enable it at any time
+     * using the UpdateExadatainfrastructure API.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCpsOfflineReportEnabled")
+    Boolean isCpsOfflineReportEnabled;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateRefreshableAutonomousDatabaseCloneDetails.java
@@ -326,6 +326,15 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+        private Boolean isAutoScalingForStorageEnabled;
+
+        public Builder isAutoScalingForStorageEnabled(Boolean isAutoScalingForStorageEnabled) {
+            this.isAutoScalingForStorageEnabled = isAutoScalingForStorageEnabled;
+            this.__explicitlySet__.add("isAutoScalingForStorageEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceId")
         private String sourceId;
 
@@ -382,6 +391,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             isMtlsConnectionRequired,
                             autonomousMaintenanceScheduleType,
                             scheduledOperations,
+                            isAutoScalingForStorageEnabled,
                             sourceId,
                             refreshableMode);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -425,6 +435,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                             .autonomousMaintenanceScheduleType(
                                     o.getAutonomousMaintenanceScheduleType())
                             .scheduledOperations(o.getScheduledOperations())
+                            .isAutoScalingForStorageEnabled(o.getIsAutoScalingForStorageEnabled())
                             .sourceId(o.getSourceId())
                             .refreshableMode(o.getRefreshableMode());
 
@@ -474,6 +485,7 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
             Boolean isMtlsConnectionRequired,
             AutonomousMaintenanceScheduleType autonomousMaintenanceScheduleType,
             java.util.List<ScheduledOperationDetails> scheduledOperations,
+            Boolean isAutoScalingForStorageEnabled,
             String sourceId,
             RefreshableMode refreshableMode) {
         super(
@@ -508,7 +520,8 @@ public class CreateRefreshableAutonomousDatabaseCloneDetails extends CreateAuton
                 customerContacts,
                 isMtlsConnectionRequired,
                 autonomousMaintenanceScheduleType,
-                scheduledOperations);
+                scheduledOperations,
+                isAutoScalingForStorageEnabled);
         this.sourceId = sourceId;
         this.refreshableMode = refreshableMode;
     }

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServer.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServer.java
@@ -160,6 +160,15 @@ public class DbServer {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServerPatchingDetails")
+        private DbServerPatchingDetails dbServerPatchingDetails;
+
+        public Builder dbServerPatchingDetails(DbServerPatchingDetails dbServerPatchingDetails) {
+            this.dbServerPatchingDetails = dbServerPatchingDetails;
+            this.__explicitlySet__.add("dbServerPatchingDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -200,6 +209,7 @@ public class DbServer {
                             maxMemoryInGBs,
                             maxDbNodeStorageInGBs,
                             timeCreated,
+                            dbServerPatchingDetails,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -224,6 +234,7 @@ public class DbServer {
                             .maxMemoryInGBs(o.getMaxMemoryInGBs())
                             .maxDbNodeStorageInGBs(o.getMaxDbNodeStorageInGBs())
                             .timeCreated(o.getTimeCreated())
+                            .dbServerPatchingDetails(o.getDbServerPatchingDetails())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -379,6 +390,9 @@ public class DbServer {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServerPatchingDetails")
+    DbServerPatchingDetails dbServerPatchingDetails;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServerPatchingDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServerPatchingDetails.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The scheduling details for the quarterly maintenance window. Patching and system updates take place during the maintenance window.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = DbServerPatchingDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class DbServerPatchingDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("estimatedPatchDuration")
+        private Integer estimatedPatchDuration;
+
+        public Builder estimatedPatchDuration(Integer estimatedPatchDuration) {
+            this.estimatedPatchDuration = estimatedPatchDuration;
+            this.__explicitlySet__.add("estimatedPatchDuration");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("patchingStatus")
+        private PatchingStatus patchingStatus;
+
+        public Builder patchingStatus(PatchingStatus patchingStatus) {
+            this.patchingStatus = patchingStatus;
+            this.__explicitlySet__.add("patchingStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timePatchingStarted")
+        private java.util.Date timePatchingStarted;
+
+        public Builder timePatchingStarted(java.util.Date timePatchingStarted) {
+            this.timePatchingStarted = timePatchingStarted;
+            this.__explicitlySet__.add("timePatchingStarted");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("timePatchingEnded")
+        private java.util.Date timePatchingEnded;
+
+        public Builder timePatchingEnded(java.util.Date timePatchingEnded) {
+            this.timePatchingEnded = timePatchingEnded;
+            this.__explicitlySet__.add("timePatchingEnded");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public DbServerPatchingDetails build() {
+            DbServerPatchingDetails __instance__ =
+                    new DbServerPatchingDetails(
+                            estimatedPatchDuration,
+                            patchingStatus,
+                            timePatchingStarted,
+                            timePatchingEnded);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(DbServerPatchingDetails o) {
+            Builder copiedBuilder =
+                    estimatedPatchDuration(o.getEstimatedPatchDuration())
+                            .patchingStatus(o.getPatchingStatus())
+                            .timePatchingStarted(o.getTimePatchingStarted())
+                            .timePatchingEnded(o.getTimePatchingEnded());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Estimated time, in minutes, to patch one database server.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("estimatedPatchDuration")
+    Integer estimatedPatchDuration;
+    /**
+     * The status of the patching operation.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PatchingStatus {
+        Scheduled("SCHEDULED"),
+        MaintenanceInProgress("MAINTENANCE_IN_PROGRESS"),
+        Failed("FAILED"),
+        Complete("COMPLETE"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PatchingStatus> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PatchingStatus v : PatchingStatus.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PatchingStatus(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PatchingStatus create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PatchingStatus', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The status of the patching operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patchingStatus")
+    PatchingStatus patchingStatus;
+
+    /**
+     * The time when the patching operation started.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timePatchingStarted")
+    java.util.Date timePatchingStarted;
+
+    /**
+     * The time when the patching operation ended.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("timePatchingEnded")
+    java.util.Date timePatchingEnded;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServerSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DbServerSummary.java
@@ -160,6 +160,15 @@ public class DbServerSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServerPatchingDetails")
+        private DbServerPatchingDetails dbServerPatchingDetails;
+
+        public Builder dbServerPatchingDetails(DbServerPatchingDetails dbServerPatchingDetails) {
+            this.dbServerPatchingDetails = dbServerPatchingDetails;
+            this.__explicitlySet__.add("dbServerPatchingDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -200,6 +209,7 @@ public class DbServerSummary {
                             maxMemoryInGBs,
                             maxDbNodeStorageInGBs,
                             timeCreated,
+                            dbServerPatchingDetails,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -224,6 +234,7 @@ public class DbServerSummary {
                             .maxMemoryInGBs(o.getMaxMemoryInGBs())
                             .maxDbNodeStorageInGBs(o.getMaxDbNodeStorageInGBs())
                             .timeCreated(o.getTimeCreated())
+                            .dbServerPatchingDetails(o.getDbServerPatchingDetails())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -379,6 +390,9 @@ public class DbServerSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeCreated")
     java.util.Date timeCreated;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServerPatchingDetails")
+    DbServerPatchingDetails dbServerPatchingDetails;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/EstimatedPatchingTime.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/EstimatedPatchingTime.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.model;
+
+/**
+ * The estimated total time required in minutes for all patching operations (database server, storage server, and network switch patching).
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = EstimatedPatchingTime.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class EstimatedPatchingTime {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("totalEstimatedPatchingTime")
+        private Integer totalEstimatedPatchingTime;
+
+        public Builder totalEstimatedPatchingTime(Integer totalEstimatedPatchingTime) {
+            this.totalEstimatedPatchingTime = totalEstimatedPatchingTime;
+            this.__explicitlySet__.add("totalEstimatedPatchingTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("estimatedDbServerPatchingTime")
+        private Integer estimatedDbServerPatchingTime;
+
+        public Builder estimatedDbServerPatchingTime(Integer estimatedDbServerPatchingTime) {
+            this.estimatedDbServerPatchingTime = estimatedDbServerPatchingTime;
+            this.__explicitlySet__.add("estimatedDbServerPatchingTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("estimatedStorageServerPatchingTime")
+        private Integer estimatedStorageServerPatchingTime;
+
+        public Builder estimatedStorageServerPatchingTime(
+                Integer estimatedStorageServerPatchingTime) {
+            this.estimatedStorageServerPatchingTime = estimatedStorageServerPatchingTime;
+            this.__explicitlySet__.add("estimatedStorageServerPatchingTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("estimatedNetworkSwitchesPatchingTime")
+        private Integer estimatedNetworkSwitchesPatchingTime;
+
+        public Builder estimatedNetworkSwitchesPatchingTime(
+                Integer estimatedNetworkSwitchesPatchingTime) {
+            this.estimatedNetworkSwitchesPatchingTime = estimatedNetworkSwitchesPatchingTime;
+            this.__explicitlySet__.add("estimatedNetworkSwitchesPatchingTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public EstimatedPatchingTime build() {
+            EstimatedPatchingTime __instance__ =
+                    new EstimatedPatchingTime(
+                            totalEstimatedPatchingTime,
+                            estimatedDbServerPatchingTime,
+                            estimatedStorageServerPatchingTime,
+                            estimatedNetworkSwitchesPatchingTime);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(EstimatedPatchingTime o) {
+            Builder copiedBuilder =
+                    totalEstimatedPatchingTime(o.getTotalEstimatedPatchingTime())
+                            .estimatedDbServerPatchingTime(o.getEstimatedDbServerPatchingTime())
+                            .estimatedStorageServerPatchingTime(
+                                    o.getEstimatedStorageServerPatchingTime())
+                            .estimatedNetworkSwitchesPatchingTime(
+                                    o.getEstimatedNetworkSwitchesPatchingTime());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The estimated total time required in minutes for all patching operations.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("totalEstimatedPatchingTime")
+    Integer totalEstimatedPatchingTime;
+
+    /**
+     * The estimated time required in minutes for database server patching.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("estimatedDbServerPatchingTime")
+    Integer estimatedDbServerPatchingTime;
+
+    /**
+     * The estimated time required in minutes for storage server patching.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("estimatedStorageServerPatchingTime")
+    Integer estimatedStorageServerPatchingTime;
+
+    /**
+     * The estimated time required in minutes for network switch patching.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("estimatedNetworkSwitchesPatchingTime")
+    Integer estimatedNetworkSwitchesPatchingTime;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructure.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructure.java
@@ -323,6 +323,24 @@ public class ExadataInfrastructure {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("storageServerVersion")
+        private String storageServerVersion;
+
+        public Builder storageServerVersion(String storageServerVersion) {
+            this.storageServerVersion = storageServerVersion;
+            this.__explicitlySet__.add("storageServerVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServerVersion")
+        private String dbServerVersion;
+
+        public Builder dbServerVersion(String dbServerVersion) {
+            this.dbServerVersion = dbServerVersion;
+            this.__explicitlySet__.add("dbServerVersion");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lastMaintenanceRunId")
         private String lastMaintenanceRunId;
 
@@ -338,6 +356,15 @@ public class ExadataInfrastructure {
         public Builder nextMaintenanceRunId(String nextMaintenanceRunId) {
             this.nextMaintenanceRunId = nextMaintenanceRunId;
             this.__explicitlySet__.add("nextMaintenanceRunId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCpsOfflineReportEnabled")
+        private Boolean isCpsOfflineReportEnabled;
+
+        public Builder isCpsOfflineReportEnabled(Boolean isCpsOfflineReportEnabled) {
+            this.isCpsOfflineReportEnabled = isCpsOfflineReportEnabled;
+            this.__explicitlySet__.add("isCpsOfflineReportEnabled");
             return this;
         }
 
@@ -399,8 +426,11 @@ public class ExadataInfrastructure {
                             contacts,
                             maintenanceSLOStatus,
                             maintenanceWindow,
+                            storageServerVersion,
+                            dbServerVersion,
                             lastMaintenanceRunId,
                             nextMaintenanceRunId,
+                            isCpsOfflineReportEnabled,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -443,8 +473,11 @@ public class ExadataInfrastructure {
                             .contacts(o.getContacts())
                             .maintenanceSLOStatus(o.getMaintenanceSLOStatus())
                             .maintenanceWindow(o.getMaintenanceWindow())
+                            .storageServerVersion(o.getStorageServerVersion())
+                            .dbServerVersion(o.getDbServerVersion())
                             .lastMaintenanceRunId(o.getLastMaintenanceRunId())
                             .nextMaintenanceRunId(o.getNextMaintenanceRunId())
+                            .isCpsOfflineReportEnabled(o.getIsCpsOfflineReportEnabled())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -757,6 +790,18 @@ public class ExadataInfrastructure {
     MaintenanceWindow maintenanceWindow;
 
     /**
+     * The software version of the storage servers (cells) in the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("storageServerVersion")
+    String storageServerVersion;
+
+    /**
+     * The software version of the database servers (dom0) in the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServerVersion")
+    String dbServerVersion;
+
+    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the last maintenance run.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lastMaintenanceRunId")
@@ -767,6 +812,15 @@ public class ExadataInfrastructure {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nextMaintenanceRunId")
     String nextMaintenanceRunId;
+
+    /**
+     * Indicates whether cps offline diagnostic report is enabled for this Exadata infrastructure. This will allow a customer to quickly check status themselves and fix problems on their end, saving time and frustration
+     * for both Oracle and the customer when they find the CPS in a disconnected state.You can enable offline diagnostic report during Exadata infrastructure provisioning. You can also disable or enable it at any time
+     * using the UpdateExadatainfrastructure API.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCpsOfflineReportEnabled")
+    Boolean isCpsOfflineReportEnabled;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructureSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/ExadataInfrastructureSummary.java
@@ -325,6 +325,24 @@ public class ExadataInfrastructureSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("storageServerVersion")
+        private String storageServerVersion;
+
+        public Builder storageServerVersion(String storageServerVersion) {
+            this.storageServerVersion = storageServerVersion;
+            this.__explicitlySet__.add("storageServerVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("dbServerVersion")
+        private String dbServerVersion;
+
+        public Builder dbServerVersion(String dbServerVersion) {
+            this.dbServerVersion = dbServerVersion;
+            this.__explicitlySet__.add("dbServerVersion");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lastMaintenanceRunId")
         private String lastMaintenanceRunId;
 
@@ -340,6 +358,15 @@ public class ExadataInfrastructureSummary {
         public Builder nextMaintenanceRunId(String nextMaintenanceRunId) {
             this.nextMaintenanceRunId = nextMaintenanceRunId;
             this.__explicitlySet__.add("nextMaintenanceRunId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCpsOfflineReportEnabled")
+        private Boolean isCpsOfflineReportEnabled;
+
+        public Builder isCpsOfflineReportEnabled(Boolean isCpsOfflineReportEnabled) {
+            this.isCpsOfflineReportEnabled = isCpsOfflineReportEnabled;
+            this.__explicitlySet__.add("isCpsOfflineReportEnabled");
             return this;
         }
 
@@ -401,8 +428,11 @@ public class ExadataInfrastructureSummary {
                             contacts,
                             maintenanceSLOStatus,
                             maintenanceWindow,
+                            storageServerVersion,
+                            dbServerVersion,
                             lastMaintenanceRunId,
                             nextMaintenanceRunId,
+                            isCpsOfflineReportEnabled,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -445,8 +475,11 @@ public class ExadataInfrastructureSummary {
                             .contacts(o.getContacts())
                             .maintenanceSLOStatus(o.getMaintenanceSLOStatus())
                             .maintenanceWindow(o.getMaintenanceWindow())
+                            .storageServerVersion(o.getStorageServerVersion())
+                            .dbServerVersion(o.getDbServerVersion())
                             .lastMaintenanceRunId(o.getLastMaintenanceRunId())
                             .nextMaintenanceRunId(o.getNextMaintenanceRunId())
+                            .isCpsOfflineReportEnabled(o.getIsCpsOfflineReportEnabled())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -759,6 +792,18 @@ public class ExadataInfrastructureSummary {
     MaintenanceWindow maintenanceWindow;
 
     /**
+     * The software version of the storage servers (cells) in the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("storageServerVersion")
+    String storageServerVersion;
+
+    /**
+     * The software version of the database servers (dom0) in the Exadata infrastructure.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("dbServerVersion")
+    String dbServerVersion;
+
+    /**
      * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the last maintenance run.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lastMaintenanceRunId")
@@ -769,6 +814,15 @@ public class ExadataInfrastructureSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nextMaintenanceRunId")
     String nextMaintenanceRunId;
+
+    /**
+     * Indicates whether cps offline diagnostic report is enabled for this Exadata infrastructure. This will allow a customer to quickly check status themselves and fix problems on their end, saving time and frustration
+     * for both Oracle and the customer when they find the CPS in a disconnected state.You can enable offline diagnostic report during Exadata infrastructure provisioning. You can also disable or enable it at any time
+     * using the UpdateExadatainfrastructure API.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCpsOfflineReportEnabled")
+    Boolean isCpsOfflineReportEnabled;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceRun.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceRun.java
@@ -178,6 +178,106 @@ public class MaintenanceRun {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("targetDbServerVersion")
+        private String targetDbServerVersion;
+
+        public Builder targetDbServerVersion(String targetDbServerVersion) {
+            this.targetDbServerVersion = targetDbServerVersion;
+            this.__explicitlySet__.add("targetDbServerVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetStorageServerVersion")
+        private String targetStorageServerVersion;
+
+        public Builder targetStorageServerVersion(String targetStorageServerVersion) {
+            this.targetStorageServerVersion = targetStorageServerVersion;
+            this.__explicitlySet__.add("targetStorageServerVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCustomActionTimeoutEnabled")
+        private Boolean isCustomActionTimeoutEnabled;
+
+        public Builder isCustomActionTimeoutEnabled(Boolean isCustomActionTimeoutEnabled) {
+            this.isCustomActionTimeoutEnabled = isCustomActionTimeoutEnabled;
+            this.__explicitlySet__.add("isCustomActionTimeoutEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customActionTimeoutInMins")
+        private Integer customActionTimeoutInMins;
+
+        public Builder customActionTimeoutInMins(Integer customActionTimeoutInMins) {
+            this.customActionTimeoutInMins = customActionTimeoutInMins;
+            this.__explicitlySet__.add("customActionTimeoutInMins");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("currentCustomActionTimeoutInMins")
+        private Integer currentCustomActionTimeoutInMins;
+
+        public Builder currentCustomActionTimeoutInMins(Integer currentCustomActionTimeoutInMins) {
+            this.currentCustomActionTimeoutInMins = currentCustomActionTimeoutInMins;
+            this.__explicitlySet__.add("currentCustomActionTimeoutInMins");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("patchingStatus")
+        private PatchingStatus patchingStatus;
+
+        public Builder patchingStatus(PatchingStatus patchingStatus) {
+            this.patchingStatus = patchingStatus;
+            this.__explicitlySet__.add("patchingStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("patchingStartTime")
+        private java.util.Date patchingStartTime;
+
+        public Builder patchingStartTime(java.util.Date patchingStartTime) {
+            this.patchingStartTime = patchingStartTime;
+            this.__explicitlySet__.add("patchingStartTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("patchingEndTime")
+        private java.util.Date patchingEndTime;
+
+        public Builder patchingEndTime(java.util.Date patchingEndTime) {
+            this.patchingEndTime = patchingEndTime;
+            this.__explicitlySet__.add("patchingEndTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("estimatedPatchingTime")
+        private EstimatedPatchingTime estimatedPatchingTime;
+
+        public Builder estimatedPatchingTime(EstimatedPatchingTime estimatedPatchingTime) {
+            this.estimatedPatchingTime = estimatedPatchingTime;
+            this.__explicitlySet__.add("estimatedPatchingTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("currentPatchingComponent")
+        private String currentPatchingComponent;
+
+        public Builder currentPatchingComponent(String currentPatchingComponent) {
+            this.currentPatchingComponent = currentPatchingComponent;
+            this.__explicitlySet__.add("currentPatchingComponent");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("estimatedComponentPatchingStartTime")
+        private java.util.Date estimatedComponentPatchingStartTime;
+
+        public Builder estimatedComponentPatchingStartTime(
+                java.util.Date estimatedComponentPatchingStartTime) {
+            this.estimatedComponentPatchingStartTime = estimatedComponentPatchingStartTime;
+            this.__explicitlySet__.add("estimatedComponentPatchingStartTime");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -200,7 +300,18 @@ public class MaintenanceRun {
                             maintenanceSubtype,
                             peerMaintenanceRunId,
                             patchingMode,
-                            patchFailureCount);
+                            patchFailureCount,
+                            targetDbServerVersion,
+                            targetStorageServerVersion,
+                            isCustomActionTimeoutEnabled,
+                            customActionTimeoutInMins,
+                            currentCustomActionTimeoutInMins,
+                            patchingStatus,
+                            patchingStartTime,
+                            patchingEndTime,
+                            estimatedPatchingTime,
+                            currentPatchingComponent,
+                            estimatedComponentPatchingStartTime);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -224,7 +335,20 @@ public class MaintenanceRun {
                             .maintenanceSubtype(o.getMaintenanceSubtype())
                             .peerMaintenanceRunId(o.getPeerMaintenanceRunId())
                             .patchingMode(o.getPatchingMode())
-                            .patchFailureCount(o.getPatchFailureCount());
+                            .patchFailureCount(o.getPatchFailureCount())
+                            .targetDbServerVersion(o.getTargetDbServerVersion())
+                            .targetStorageServerVersion(o.getTargetStorageServerVersion())
+                            .isCustomActionTimeoutEnabled(o.getIsCustomActionTimeoutEnabled())
+                            .customActionTimeoutInMins(o.getCustomActionTimeoutInMins())
+                            .currentCustomActionTimeoutInMins(
+                                    o.getCurrentCustomActionTimeoutInMins())
+                            .patchingStatus(o.getPatchingStatus())
+                            .patchingStartTime(o.getPatchingStartTime())
+                            .patchingEndTime(o.getPatchingEndTime())
+                            .estimatedPatchingTime(o.getEstimatedPatchingTime())
+                            .currentPatchingComponent(o.getCurrentPatchingComponent())
+                            .estimatedComponentPatchingStartTime(
+                                    o.getEstimatedComponentPatchingStartTime());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -587,6 +711,117 @@ public class MaintenanceRun {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("patchFailureCount")
     Integer patchFailureCount;
+
+    /**
+     * The target software version for the database server patching operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetDbServerVersion")
+    String targetDbServerVersion;
+
+    /**
+     * The target Cell version that is to be patched to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetStorageServerVersion")
+    String targetStorageServerVersion;
+
+    /**
+     * If true, enables the configuration of a custom action timeout (waiting period) between database servers patching operations.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCustomActionTimeoutEnabled")
+    Boolean isCustomActionTimeoutEnabled;
+
+    /**
+     * Determines the amount of time the system will wait before the start of each database server patching operation.
+     * Specify a number of minutes, from 15 to 120.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customActionTimeoutInMins")
+    Integer customActionTimeoutInMins;
+
+    /**
+     * Extend current custom action timeout between the current database servers during waiting state, from 0 (zero) to 30 minutes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currentCustomActionTimeoutInMins")
+    Integer currentCustomActionTimeoutInMins;
+    /**
+     * The status of the patching operation.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PatchingStatus {
+        Patching("PATCHING"),
+        Waiting("WAITING"),
+        Scheduled("SCHEDULED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PatchingStatus> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PatchingStatus v : PatchingStatus.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PatchingStatus(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PatchingStatus create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PatchingStatus', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The status of the patching operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patchingStatus")
+    PatchingStatus patchingStatus;
+
+    /**
+     * The time when the patching operation started.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patchingStartTime")
+    java.util.Date patchingStartTime;
+
+    /**
+     * The time when the patching operation ended.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patchingEndTime")
+    java.util.Date patchingEndTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("estimatedPatchingTime")
+    EstimatedPatchingTime estimatedPatchingTime;
+
+    /**
+     * The name of the current infrastruture component that is getting patched.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currentPatchingComponent")
+    String currentPatchingComponent;
+
+    /**
+     * The estimated start time of the next infrastruture component patching operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("estimatedComponentPatchingStartTime")
+    java.util.Date estimatedComponentPatchingStartTime;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceRunSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceRunSummary.java
@@ -180,6 +180,106 @@ public class MaintenanceRunSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("targetDbServerVersion")
+        private String targetDbServerVersion;
+
+        public Builder targetDbServerVersion(String targetDbServerVersion) {
+            this.targetDbServerVersion = targetDbServerVersion;
+            this.__explicitlySet__.add("targetDbServerVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("targetStorageServerVersion")
+        private String targetStorageServerVersion;
+
+        public Builder targetStorageServerVersion(String targetStorageServerVersion) {
+            this.targetStorageServerVersion = targetStorageServerVersion;
+            this.__explicitlySet__.add("targetStorageServerVersion");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCustomActionTimeoutEnabled")
+        private Boolean isCustomActionTimeoutEnabled;
+
+        public Builder isCustomActionTimeoutEnabled(Boolean isCustomActionTimeoutEnabled) {
+            this.isCustomActionTimeoutEnabled = isCustomActionTimeoutEnabled;
+            this.__explicitlySet__.add("isCustomActionTimeoutEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customActionTimeoutInMins")
+        private Integer customActionTimeoutInMins;
+
+        public Builder customActionTimeoutInMins(Integer customActionTimeoutInMins) {
+            this.customActionTimeoutInMins = customActionTimeoutInMins;
+            this.__explicitlySet__.add("customActionTimeoutInMins");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("currentCustomActionTimeoutInMins")
+        private Integer currentCustomActionTimeoutInMins;
+
+        public Builder currentCustomActionTimeoutInMins(Integer currentCustomActionTimeoutInMins) {
+            this.currentCustomActionTimeoutInMins = currentCustomActionTimeoutInMins;
+            this.__explicitlySet__.add("currentCustomActionTimeoutInMins");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("patchingStatus")
+        private PatchingStatus patchingStatus;
+
+        public Builder patchingStatus(PatchingStatus patchingStatus) {
+            this.patchingStatus = patchingStatus;
+            this.__explicitlySet__.add("patchingStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("patchingStartTime")
+        private java.util.Date patchingStartTime;
+
+        public Builder patchingStartTime(java.util.Date patchingStartTime) {
+            this.patchingStartTime = patchingStartTime;
+            this.__explicitlySet__.add("patchingStartTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("patchingEndTime")
+        private java.util.Date patchingEndTime;
+
+        public Builder patchingEndTime(java.util.Date patchingEndTime) {
+            this.patchingEndTime = patchingEndTime;
+            this.__explicitlySet__.add("patchingEndTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("estimatedPatchingTime")
+        private EstimatedPatchingTime estimatedPatchingTime;
+
+        public Builder estimatedPatchingTime(EstimatedPatchingTime estimatedPatchingTime) {
+            this.estimatedPatchingTime = estimatedPatchingTime;
+            this.__explicitlySet__.add("estimatedPatchingTime");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("currentPatchingComponent")
+        private String currentPatchingComponent;
+
+        public Builder currentPatchingComponent(String currentPatchingComponent) {
+            this.currentPatchingComponent = currentPatchingComponent;
+            this.__explicitlySet__.add("currentPatchingComponent");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("estimatedComponentPatchingStartTime")
+        private java.util.Date estimatedComponentPatchingStartTime;
+
+        public Builder estimatedComponentPatchingStartTime(
+                java.util.Date estimatedComponentPatchingStartTime) {
+            this.estimatedComponentPatchingStartTime = estimatedComponentPatchingStartTime;
+            this.__explicitlySet__.add("estimatedComponentPatchingStartTime");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -202,7 +302,18 @@ public class MaintenanceRunSummary {
                             maintenanceSubtype,
                             peerMaintenanceRunId,
                             patchingMode,
-                            patchFailureCount);
+                            patchFailureCount,
+                            targetDbServerVersion,
+                            targetStorageServerVersion,
+                            isCustomActionTimeoutEnabled,
+                            customActionTimeoutInMins,
+                            currentCustomActionTimeoutInMins,
+                            patchingStatus,
+                            patchingStartTime,
+                            patchingEndTime,
+                            estimatedPatchingTime,
+                            currentPatchingComponent,
+                            estimatedComponentPatchingStartTime);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -226,7 +337,20 @@ public class MaintenanceRunSummary {
                             .maintenanceSubtype(o.getMaintenanceSubtype())
                             .peerMaintenanceRunId(o.getPeerMaintenanceRunId())
                             .patchingMode(o.getPatchingMode())
-                            .patchFailureCount(o.getPatchFailureCount());
+                            .patchFailureCount(o.getPatchFailureCount())
+                            .targetDbServerVersion(o.getTargetDbServerVersion())
+                            .targetStorageServerVersion(o.getTargetStorageServerVersion())
+                            .isCustomActionTimeoutEnabled(o.getIsCustomActionTimeoutEnabled())
+                            .customActionTimeoutInMins(o.getCustomActionTimeoutInMins())
+                            .currentCustomActionTimeoutInMins(
+                                    o.getCurrentCustomActionTimeoutInMins())
+                            .patchingStatus(o.getPatchingStatus())
+                            .patchingStartTime(o.getPatchingStartTime())
+                            .patchingEndTime(o.getPatchingEndTime())
+                            .estimatedPatchingTime(o.getEstimatedPatchingTime())
+                            .currentPatchingComponent(o.getCurrentPatchingComponent())
+                            .estimatedComponentPatchingStartTime(
+                                    o.getEstimatedComponentPatchingStartTime());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -589,6 +713,117 @@ public class MaintenanceRunSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("patchFailureCount")
     Integer patchFailureCount;
+
+    /**
+     * The target software version for the database server patching operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetDbServerVersion")
+    String targetDbServerVersion;
+
+    /**
+     * The target Cell version that is to be patched to.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("targetStorageServerVersion")
+    String targetStorageServerVersion;
+
+    /**
+     * If true, enables the configuration of a custom action timeout (waiting period) between database servers patching operations.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCustomActionTimeoutEnabled")
+    Boolean isCustomActionTimeoutEnabled;
+
+    /**
+     * Determines the amount of time the system will wait before the start of each database server patching operation.
+     * Specify a number of minutes, from 15 to 120.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customActionTimeoutInMins")
+    Integer customActionTimeoutInMins;
+
+    /**
+     * Extend current custom action timeout between the current database servers during waiting state, from 0 (zero) to 30 minutes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currentCustomActionTimeoutInMins")
+    Integer currentCustomActionTimeoutInMins;
+    /**
+     * The status of the patching operation.
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PatchingStatus {
+        Patching("PATCHING"),
+        Waiting("WAITING"),
+        Scheduled("SCHEDULED"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PatchingStatus> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PatchingStatus v : PatchingStatus.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PatchingStatus(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PatchingStatus create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PatchingStatus', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * The status of the patching operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patchingStatus")
+    PatchingStatus patchingStatus;
+
+    /**
+     * The time when the patching operation started.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patchingStartTime")
+    java.util.Date patchingStartTime;
+
+    /**
+     * The time when the patching operation ended.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patchingEndTime")
+    java.util.Date patchingEndTime;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("estimatedPatchingTime")
+    EstimatedPatchingTime estimatedPatchingTime;
+
+    /**
+     * The name of the current infrastruture component that is getting patched.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currentPatchingComponent")
+    String currentPatchingComponent;
+
+    /**
+     * The estimated start time of the next infrastruture component patching operation.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("estimatedComponentPatchingStartTime")
+    java.util.Date estimatedComponentPatchingStartTime;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceWindow.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/MaintenanceWindow.java
@@ -36,6 +36,33 @@ public class MaintenanceWindow {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("patchingMode")
+        private PatchingMode patchingMode;
+
+        public Builder patchingMode(PatchingMode patchingMode) {
+            this.patchingMode = patchingMode;
+            this.__explicitlySet__.add("patchingMode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isCustomActionTimeoutEnabled")
+        private Boolean isCustomActionTimeoutEnabled;
+
+        public Builder isCustomActionTimeoutEnabled(Boolean isCustomActionTimeoutEnabled) {
+            this.isCustomActionTimeoutEnabled = isCustomActionTimeoutEnabled;
+            this.__explicitlySet__.add("isCustomActionTimeoutEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customActionTimeoutInMins")
+        private Integer customActionTimeoutInMins;
+
+        public Builder customActionTimeoutInMins(Integer customActionTimeoutInMins) {
+            this.customActionTimeoutInMins = customActionTimeoutInMins;
+            this.__explicitlySet__.add("customActionTimeoutInMins");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("months")
         private java.util.List<Month> months;
 
@@ -88,6 +115,9 @@ public class MaintenanceWindow {
             MaintenanceWindow __instance__ =
                     new MaintenanceWindow(
                             preference,
+                            patchingMode,
+                            isCustomActionTimeoutEnabled,
+                            customActionTimeoutInMins,
                             months,
                             weeksOfMonth,
                             daysOfWeek,
@@ -101,6 +131,9 @@ public class MaintenanceWindow {
         public Builder copy(MaintenanceWindow o) {
             Builder copiedBuilder =
                     preference(o.getPreference())
+                            .patchingMode(o.getPatchingMode())
+                            .isCustomActionTimeoutEnabled(o.getIsCustomActionTimeoutEnabled())
+                            .customActionTimeoutInMins(o.getCustomActionTimeoutInMins())
                             .months(o.getMonths())
                             .weeksOfMonth(o.getWeeksOfMonth())
                             .daysOfWeek(o.getDaysOfWeek())
@@ -170,6 +203,77 @@ public class MaintenanceWindow {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("preference")
     Preference preference;
+    /**
+     * Cloud Exadata infrastructure node patching method, either "ROLLING" or "NONROLLING". Default value is ROLLING.
+     * <p>
+     *IMPORTANT*: Non-rolling infrastructure patching involves system down time. See [Oracle-Managed Infrastructure Maintenance Updates](https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/examaintenance.htm#Oracle) for more information.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum PatchingMode {
+        Rolling("ROLLING"),
+        Nonrolling("NONROLLING"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, PatchingMode> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (PatchingMode v : PatchingMode.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        PatchingMode(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static PatchingMode create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'PatchingMode', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Cloud Exadata infrastructure node patching method, either "ROLLING" or "NONROLLING". Default value is ROLLING.
+     * <p>
+     *IMPORTANT*: Non-rolling infrastructure patching involves system down time. See [Oracle-Managed Infrastructure Maintenance Updates](https://docs.cloud.oracle.com/iaas/Content/Database/Concepts/examaintenance.htm#Oracle) for more information.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("patchingMode")
+    PatchingMode patchingMode;
+
+    /**
+     * If true, enables the configuration of a custom action timeout (waiting period) between database server patching operations.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCustomActionTimeoutEnabled")
+    Boolean isCustomActionTimeoutEnabled;
+
+    /**
+     * Determines the amount of time the system will wait before the start of each database server patching operation.
+     * Custom action timeout is in minutes and valid value is between 15 to 120 (inclusive).
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customActionTimeoutInMins")
+    Integer customActionTimeoutInMins;
 
     /**
      * Months during the year when maintenance should be performed.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateAutonomousDatabaseDetails.java
@@ -305,6 +305,15 @@ public class UpdateAutonomousDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+        private Boolean isAutoScalingForStorageEnabled;
+
+        public Builder isAutoScalingForStorageEnabled(Boolean isAutoScalingForStorageEnabled) {
+            this.isAutoScalingForStorageEnabled = isAutoScalingForStorageEnabled;
+            this.__explicitlySet__.add("isAutoScalingForStorageEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -340,7 +349,8 @@ public class UpdateAutonomousDatabaseDetails {
                             nsgIds,
                             customerContacts,
                             isMtlsConnectionRequired,
-                            scheduledOperations);
+                            scheduledOperations,
+                            isAutoScalingForStorageEnabled);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -377,7 +387,8 @@ public class UpdateAutonomousDatabaseDetails {
                             .nsgIds(o.getNsgIds())
                             .customerContacts(o.getCustomerContacts())
                             .isMtlsConnectionRequired(o.getIsMtlsConnectionRequired())
-                            .scheduledOperations(o.getScheduledOperations());
+                            .scheduledOperations(o.getScheduledOperations())
+                            .isAutoScalingForStorageEnabled(o.getIsAutoScalingForStorageEnabled());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -843,6 +854,13 @@ public class UpdateAutonomousDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("scheduledOperations")
     java.util.List<ScheduledOperationDetails> scheduledOperations;
+
+    /**
+     * Indicates if auto scaling is enabled for the Autonomous Database storage. The default value is {@code FALSE}.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoScalingForStorageEnabled")
+    Boolean isAutoScalingForStorageEnabled;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateExadataInfrastructureDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateExadataInfrastructureDetails.java
@@ -145,6 +145,15 @@ public class UpdateExadataInfrastructureDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCpsOfflineReportEnabled")
+        private Boolean isCpsOfflineReportEnabled;
+
+        public Builder isCpsOfflineReportEnabled(Boolean isCpsOfflineReportEnabled) {
+            this.isCpsOfflineReportEnabled = isCpsOfflineReportEnabled;
+            this.__explicitlySet__.add("isCpsOfflineReportEnabled");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -183,6 +192,7 @@ public class UpdateExadataInfrastructureDetails {
                             dnsServer,
                             ntpServer,
                             timeZone,
+                            isCpsOfflineReportEnabled,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -205,6 +215,7 @@ public class UpdateExadataInfrastructureDetails {
                             .dnsServer(o.getDnsServer())
                             .ntpServer(o.getNtpServer())
                             .timeZone(o.getTimeZone())
+                            .isCpsOfflineReportEnabled(o.getIsCpsOfflineReportEnabled())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -295,6 +306,15 @@ public class UpdateExadataInfrastructureDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeZone")
     String timeZone;
+
+    /**
+     * Indicates whether cps offline diagnostic report is enabled for this Exadata infrastructure. This will allow a customer to quickly check status themselves and fix problems on their end, saving time and frustration
+     * for both Oracle and the customer when they find the CPS in a disconnected state.You can enable offline diagnostic report during Exadata infrastructure provisioning. You can also disable or enable it at any time
+     * using the UpdateExadatainfrastructure API.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCpsOfflineReportEnabled")
+    Boolean isCpsOfflineReportEnabled;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateMaintenanceRunDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/UpdateMaintenanceRunDetails.java
@@ -72,13 +72,57 @@ public class UpdateMaintenanceRunDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("isCustomActionTimeoutEnabled")
+        private Boolean isCustomActionTimeoutEnabled;
+
+        public Builder isCustomActionTimeoutEnabled(Boolean isCustomActionTimeoutEnabled) {
+            this.isCustomActionTimeoutEnabled = isCustomActionTimeoutEnabled;
+            this.__explicitlySet__.add("isCustomActionTimeoutEnabled");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("customActionTimeoutInMins")
+        private Integer customActionTimeoutInMins;
+
+        public Builder customActionTimeoutInMins(Integer customActionTimeoutInMins) {
+            this.customActionTimeoutInMins = customActionTimeoutInMins;
+            this.__explicitlySet__.add("customActionTimeoutInMins");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("currentCustomActionTimeoutInMins")
+        private Integer currentCustomActionTimeoutInMins;
+
+        public Builder currentCustomActionTimeoutInMins(Integer currentCustomActionTimeoutInMins) {
+            this.currentCustomActionTimeoutInMins = currentCustomActionTimeoutInMins;
+            this.__explicitlySet__.add("currentCustomActionTimeoutInMins");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isResumePatching")
+        private Boolean isResumePatching;
+
+        public Builder isResumePatching(Boolean isResumePatching) {
+            this.isResumePatching = isResumePatching;
+            this.__explicitlySet__.add("isResumePatching");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateMaintenanceRunDetails build() {
             UpdateMaintenanceRunDetails __instance__ =
                     new UpdateMaintenanceRunDetails(
-                            isEnabled, timeScheduled, isPatchNowEnabled, patchId, patchingMode);
+                            isEnabled,
+                            timeScheduled,
+                            isPatchNowEnabled,
+                            patchId,
+                            patchingMode,
+                            isCustomActionTimeoutEnabled,
+                            customActionTimeoutInMins,
+                            currentCustomActionTimeoutInMins,
+                            isResumePatching);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -90,7 +134,12 @@ public class UpdateMaintenanceRunDetails {
                             .timeScheduled(o.getTimeScheduled())
                             .isPatchNowEnabled(o.getIsPatchNowEnabled())
                             .patchId(o.getPatchId())
-                            .patchingMode(o.getPatchingMode());
+                            .patchingMode(o.getPatchingMode())
+                            .isCustomActionTimeoutEnabled(o.getIsCustomActionTimeoutEnabled())
+                            .customActionTimeoutInMins(o.getCustomActionTimeoutInMins())
+                            .currentCustomActionTimeoutInMins(
+                                    o.getCurrentCustomActionTimeoutInMins())
+                            .isResumePatching(o.getIsResumePatching());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -173,6 +222,32 @@ public class UpdateMaintenanceRunDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("patchingMode")
     PatchingMode patchingMode;
+
+    /**
+     * If true, enables the configuration of a custom action timeout (waiting period) between database servers patching operations.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isCustomActionTimeoutEnabled")
+    Boolean isCustomActionTimeoutEnabled;
+
+    /**
+     * Determines the amount of time the system will wait before the start of each database server patching operation.
+     * Specify a number of minutes from 15 to 120.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("customActionTimeoutInMins")
+    Integer customActionTimeoutInMins;
+
+    /**
+     * The current custom action timeout between the current database servers during waiting state in addition to custom action timeout, from 0 (zero) to 30 minutes.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("currentCustomActionTimeoutInMins")
+    Integer currentCustomActionTimeoutInMins;
+
+    /**
+     * If true, then the patching is resumed and the next component will be patched immediately.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isResumePatching")
+    Boolean isResumePatching;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/requests/ShrinkAutonomousDatabaseRequest.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/requests/ShrinkAutonomousDatabaseRequest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.requests;
+
+import com.oracle.bmc.database.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/database/ShrinkAutonomousDatabaseExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ShrinkAutonomousDatabaseRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ShrinkAutonomousDatabaseRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The database [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm).
+     */
+    private String autonomousDatabaseId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call for a resource, set the {@code if-match}
+     * parameter to the value of the etag from a previous GET or POST response for that resource.  The resource
+     * will be updated or deleted only if the etag you provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ShrinkAutonomousDatabaseRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ShrinkAutonomousDatabaseRequest o) {
+            autonomousDatabaseId(o.getAutonomousDatabaseId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ShrinkAutonomousDatabaseRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ShrinkAutonomousDatabaseRequest
+         */
+        public ShrinkAutonomousDatabaseRequest build() {
+            ShrinkAutonomousDatabaseRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-database/src/main/java/com/oracle/bmc/database/responses/ShrinkAutonomousDatabaseResponse.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/responses/ShrinkAutonomousDatabaseResponse.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.database.responses;
+
+import com.oracle.bmc.database.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20160918")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ShrinkAutonomousDatabaseResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * For optimistic concurrency control. See {@code if-match}.
+     */
+    private String etag;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about
+     * a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the work request. Multiple OCID values are returned in a comma-separated list. Use {@link #getWorkRequest(GetWorkRequestRequest) getWorkRequest} with a work request OCID to track the status of the request.
+     *
+     */
+    private String opcWorkRequestId;
+
+    /**
+     * The returned AutonomousDatabase instance.
+     */
+    private com.oracle.bmc.database.model.AutonomousDatabase autonomousDatabase;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "etag",
+        "opcRequestId",
+        "opcWorkRequestId",
+        "autonomousDatabase"
+    })
+    private ShrinkAutonomousDatabaseResponse(
+            int __httpStatusCode__,
+            String etag,
+            String opcRequestId,
+            String opcWorkRequestId,
+            com.oracle.bmc.database.model.AutonomousDatabase autonomousDatabase) {
+        super(__httpStatusCode__);
+        this.etag = etag;
+        this.opcRequestId = opcRequestId;
+        this.opcWorkRequestId = opcWorkRequestId;
+        this.autonomousDatabase = autonomousDatabase;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ShrinkAutonomousDatabaseResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            etag(o.getEtag());
+            opcRequestId(o.getOpcRequestId());
+            opcWorkRequestId(o.getOpcWorkRequestId());
+            autonomousDatabase(o.getAutonomousDatabase());
+
+            return this;
+        }
+
+        public ShrinkAutonomousDatabaseResponse build() {
+            return new ShrinkAutonomousDatabaseResponse(
+                    __httpStatusCode__, etag, opcRequestId, opcWorkRequestId, autonomousDatabase);
+        }
+    }
+}

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasetools/pom.xml
+++ b/bmc-databasetools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasetools</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataconnectivity/pom.xml
+++ b/bmc-dataconnectivity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataconnectivity</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateNotebookSessionDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/CreateNotebookSessionDetails.java
@@ -64,6 +64,16 @@ public class CreateNotebookSessionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionConfigDetails")
+        private NotebookSessionConfigDetails notebookSessionConfigDetails;
+
+        public Builder notebookSessionConfigDetails(
+                NotebookSessionConfigDetails notebookSessionConfigDetails) {
+            this.notebookSessionConfigDetails = notebookSessionConfigDetails;
+            this.__explicitlySet__.add("notebookSessionConfigDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -93,6 +103,7 @@ public class CreateNotebookSessionDetails {
                             projectId,
                             compartmentId,
                             notebookSessionConfigurationDetails,
+                            notebookSessionConfigDetails,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -107,6 +118,7 @@ public class CreateNotebookSessionDetails {
                             .compartmentId(o.getCompartmentId())
                             .notebookSessionConfigurationDetails(
                                     o.getNotebookSessionConfigurationDetails())
+                            .notebookSessionConfigDetails(o.getNotebookSessionConfigDetails())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -144,6 +156,9 @@ public class CreateNotebookSessionDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionConfigurationDetails")
     NotebookSessionConfigurationDetails notebookSessionConfigurationDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionConfigDetails")
+    NotebookSessionConfigDetails notebookSessionConfigDetails;
 
     /**
      * Free-form tags for this resource. Each tag is a simple key-value pair with no predefined name, type, or namespace. See [Resource Tags](https://docs.cloud.oracle.com/Content/General/Concepts/resourcetags.htm).

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/JobInfrastructureConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/JobInfrastructureConfigurationDetails.java
@@ -30,6 +30,10 @@ package com.oracle.bmc.datascience.model;
 )
 @com.fasterxml.jackson.annotation.JsonSubTypes({
     @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ManagedEgressStandaloneJobInfrastructureConfigurationDetails.class,
+        name = "ME_STANDALONE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
         value = StandaloneJobInfrastructureConfigurationDetails.class,
         name = "STANDALONE"
     )
@@ -43,6 +47,7 @@ public class JobInfrastructureConfigurationDetails {
     @lombok.extern.slf4j.Slf4j
     public enum JobInfrastructureType {
         Standalone("STANDALONE"),
+        MeStandalone("ME_STANDALONE"),
 
         /**
          * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ManagedEgressStandaloneJobInfrastructureConfigurationDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/ManagedEgressStandaloneJobInfrastructureConfigurationDetails.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * The standalone job infrastructure configuration with network egress settings preconfigured.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ManagedEgressStandaloneJobInfrastructureConfigurationDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "jobInfrastructureType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ManagedEgressStandaloneJobInfrastructureConfigurationDetails
+        extends JobInfrastructureConfigurationDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+        private String shapeName;
+
+        public Builder shapeName(String shapeName) {
+            this.shapeName = shapeName;
+            this.__explicitlySet__.add("shapeName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("blockStorageSizeInGBs")
+        private Integer blockStorageSizeInGBs;
+
+        public Builder blockStorageSizeInGBs(Integer blockStorageSizeInGBs) {
+            this.blockStorageSizeInGBs = blockStorageSizeInGBs;
+            this.__explicitlySet__.add("blockStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ManagedEgressStandaloneJobInfrastructureConfigurationDetails build() {
+            ManagedEgressStandaloneJobInfrastructureConfigurationDetails __instance__ =
+                    new ManagedEgressStandaloneJobInfrastructureConfigurationDetails(
+                            shapeName, blockStorageSizeInGBs);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ManagedEgressStandaloneJobInfrastructureConfigurationDetails o) {
+            Builder copiedBuilder =
+                    shapeName(o.getShapeName()).blockStorageSizeInGBs(o.getBlockStorageSizeInGBs());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ManagedEgressStandaloneJobInfrastructureConfigurationDetails(
+            String shapeName, Integer blockStorageSizeInGBs) {
+        super();
+        this.shapeName = shapeName;
+        this.blockStorageSizeInGBs = blockStorageSizeInGBs;
+    }
+
+    /**
+     * The shape used to launch the job run instances.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shapeName")
+    String shapeName;
+
+    /**
+     * The size of the block storage volume to attach to the instance running the job
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("blockStorageSizeInGBs")
+    Integer blockStorageSizeInGBs;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSession.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSession.java
@@ -89,6 +89,16 @@ public class NotebookSession {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionConfigDetails")
+        private NotebookSessionConfigDetails notebookSessionConfigDetails;
+
+        public Builder notebookSessionConfigDetails(
+                NotebookSessionConfigDetails notebookSessionConfigDetails) {
+            this.notebookSessionConfigDetails = notebookSessionConfigDetails;
+            this.__explicitlySet__.add("notebookSessionConfigDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionUrl")
         private String notebookSessionUrl;
 
@@ -148,6 +158,7 @@ public class NotebookSession {
                             createdBy,
                             compartmentId,
                             notebookSessionConfigurationDetails,
+                            notebookSessionConfigDetails,
                             notebookSessionUrl,
                             lifecycleState,
                             lifecycleDetails,
@@ -168,6 +179,7 @@ public class NotebookSession {
                             .compartmentId(o.getCompartmentId())
                             .notebookSessionConfigurationDetails(
                                     o.getNotebookSessionConfigurationDetails())
+                            .notebookSessionConfigDetails(o.getNotebookSessionConfigDetails())
                             .notebookSessionUrl(o.getNotebookSessionUrl())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleDetails(o.getLifecycleDetails())
@@ -228,6 +240,9 @@ public class NotebookSession {
 
     @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionConfigurationDetails")
     NotebookSessionConfigurationDetails notebookSessionConfigurationDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionConfigDetails")
+    NotebookSessionConfigDetails notebookSessionConfigDetails;
 
     /**
      * The URL to interact with the notebook session.

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionConfigDetails.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionConfigDetails.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.datascience.model;
+
+/**
+ * Details for the notebook session configuration.
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190101")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = NotebookSessionConfigDetails.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NotebookSessionConfigDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("shape")
+        private String shape;
+
+        public Builder shape(String shape) {
+            this.shape = shape;
+            this.__explicitlySet__.add("shape");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("blockStorageSizeInGBs")
+        private Integer blockStorageSizeInGBs;
+
+        public Builder blockStorageSizeInGBs(Integer blockStorageSizeInGBs) {
+            this.blockStorageSizeInGBs = blockStorageSizeInGBs;
+            this.__explicitlySet__.add("blockStorageSizeInGBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+        private String subnetId;
+
+        public Builder subnetId(String subnetId) {
+            this.subnetId = subnetId;
+            this.__explicitlySet__.add("subnetId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionShapeConfigDetails")
+        private NotebookSessionShapeConfigDetails notebookSessionShapeConfigDetails;
+
+        public Builder notebookSessionShapeConfigDetails(
+                NotebookSessionShapeConfigDetails notebookSessionShapeConfigDetails) {
+            this.notebookSessionShapeConfigDetails = notebookSessionShapeConfigDetails;
+            this.__explicitlySet__.add("notebookSessionShapeConfigDetails");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NotebookSessionConfigDetails build() {
+            NotebookSessionConfigDetails __instance__ =
+                    new NotebookSessionConfigDetails(
+                            shape,
+                            blockStorageSizeInGBs,
+                            subnetId,
+                            notebookSessionShapeConfigDetails);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NotebookSessionConfigDetails o) {
+            Builder copiedBuilder =
+                    shape(o.getShape())
+                            .blockStorageSizeInGBs(o.getBlockStorageSizeInGBs())
+                            .subnetId(o.getSubnetId())
+                            .notebookSessionShapeConfigDetails(
+                                    o.getNotebookSessionShapeConfigDetails());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The shape used to launch the notebook session compute instance.  The list of available shapes in a given compartment can be retrieved using the {@code ListNotebookSessionShapes} endpoint.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("shape")
+    String shape;
+
+    /**
+     * A notebook session instance is provided with a block storage volume. This specifies the size of the volume in GBs.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("blockStorageSizeInGBs")
+    Integer blockStorageSizeInGBs;
+
+    /**
+     * A notebook session instance is provided with a VNIC for network access.  This specifies the [OCID](https://docs.cloud.oracle.com/iaas/Content/General/Concepts/identifiers.htm) of the subnet to create a VNIC in.  The subnet should be in a VCN with a NAT gateway for egress to the internet.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subnetId")
+    String subnetId;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionShapeConfigDetails")
+    NotebookSessionShapeConfigDetails notebookSessionShapeConfigDetails;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionSummary.java
+++ b/bmc-datascience/src/main/java/com/oracle/bmc/datascience/model/NotebookSessionSummary.java
@@ -90,6 +90,16 @@ public class NotebookSessionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionConfigDetails")
+        private NotebookSessionConfigDetails notebookSessionConfigDetails;
+
+        public Builder notebookSessionConfigDetails(
+                NotebookSessionConfigDetails notebookSessionConfigDetails) {
+            this.notebookSessionConfigDetails = notebookSessionConfigDetails;
+            this.__explicitlySet__.add("notebookSessionConfigDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionUrl")
         private String notebookSessionUrl;
 
@@ -140,6 +150,7 @@ public class NotebookSessionSummary {
                             createdBy,
                             compartmentId,
                             notebookSessionConfigurationDetails,
+                            notebookSessionConfigDetails,
                             notebookSessionUrl,
                             lifecycleState,
                             freeformTags,
@@ -159,6 +170,7 @@ public class NotebookSessionSummary {
                             .compartmentId(o.getCompartmentId())
                             .notebookSessionConfigurationDetails(
                                     o.getNotebookSessionConfigurationDetails())
+                            .notebookSessionConfigDetails(o.getNotebookSessionConfigDetails())
                             .notebookSessionUrl(o.getNotebookSessionUrl())
                             .lifecycleState(o.getLifecycleState())
                             .freeformTags(o.getFreeformTags())
@@ -218,6 +230,9 @@ public class NotebookSessionSummary {
 
     @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionConfigurationDetails")
     NotebookSessionConfigurationDetails notebookSessionConfigurationDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("notebookSessionConfigDetails")
+    NotebookSessionConfigDetails notebookSessionConfigDetails;
 
     /**
      * The URL to interact with the notebook session.

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.17.0</version>
+        <version>2.18.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identitydataplane/pom.xml
+++ b/bmc-identitydataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-identitydataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/DashxApis.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/DashxApis.java
@@ -77,9 +77,10 @@ public interface DashxApis extends AutoCloseable {
             ChangeManagementSavedSearchesCompartmentRequest request);
 
     /**
-     * Creates a new dashboard.  Limit for number of saved searches in a dashboard is 20. Here's an example of how you can use CLI to create a dashboard. For information on the details that must be passed to CREATE, you can use the GET API to obtain the Create.json file:
-     * oci management-dashboard dashboard get --management-dashboard-id  \"ocid1.managementdashboard.oc1..dashboardId1\" --query data > Create.json.
-     * You can then modify the Create.json file by removing the\"id\" attribute and making other required changes, and use the oci management-dashboard dashboard create command.
+     * Creates a new dashboard. Limit for number of saved searches in a dashboard is 20.
+     * Here's an example of how you can use CLI to create a dashboard. For information on the details that must be passed to CREATE, you can use the GET API to obtain the Create.json file:
+     * `oci management-dashboard dashboard get --management-dashboard-id  \"ocid1.managementdashboard.oc1..dashboardId1\" --query data > Create.json.`
+     * You can then modify the Create.json file by removing the `id` attribute and making other required changes, and use the `oci management-dashboard dashboard create` command.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -93,10 +94,10 @@ public interface DashxApis extends AutoCloseable {
             CreateManagementDashboardRequest request);
 
     /**
-     * Creates a new saved search. Here's an example of how you can use CLI to create a saved search. For information on the details that must be passed to CREATE, you can use the GET API to obtain the Create.json file:
-     * <p>
-     * oci management-dashboard saved-search get --management-saved-search-id ocid1.managementsavedsearch.oc1..savedsearchId1 --query data > Create.json.
-     * You can then modify the Create.json file by removing the \"id\" attribute and making other required changes, and use the oci management-dashboard saved-search create command.
+     * Creates a new saved search.
+     * Here's an example of how you can use CLI to create a saved search. For information on the details that must be passed to CREATE, you can use the GET API to obtain the Create.json file:
+     * `oci management-dashboard saved-search get --management-saved-search-id ocid1.managementsavedsearch.oc1..savedsearchId1 --query data > Create.json`.
+     * You can then modify the Create.json file by removing the `id` attribute and making other required changes, and use the `oci management-dashboard saved-search create` command.
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
@@ -136,7 +137,10 @@ public interface DashxApis extends AutoCloseable {
             DeleteManagementSavedSearchRequest request);
 
     /**
-     * Exports an array of dashboards and their saved searches. Export is designed to work with importDashboard. Here's an example of how you can use CLI to export a dashboard. $oci management-dashboard dashboard export --query data --export-dashboard-id \"{\\\"dashboardIds\\\":[\\\"ocid1.managementdashboard.oc1..dashboardId1\\\"]}\"  > dashboards.json
+     * Exports an array of dashboards and their saved searches. Export is designed to work with importDashboard.
+     * Here's an example of how you can use CLI to export a dashboard:
+     * `$oci management-dashboard dashboard export --query data --export-dashboard-id \"{\\\"dashboardIds\\\":[\\\"ocid1.managementdashboard.oc1..dashboardId1\\\"]}\"  > dashboards.json`
+     *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
@@ -173,12 +177,12 @@ public interface DashxApis extends AutoCloseable {
             GetManagementSavedSearchRequest request);
 
     /**
-     * Imports an array of dashboards and their saved searches. Here's an example of how you can use CLI to import a dashboard. For information on the details that must be passed to IMPORT, you can use the EXPORT API to obtain the Import.json file:
-     * oci management-dashboard dashboard export --query data --export-dashboard-id \"{\\\"dashboardIds\\\":[\\\"ocid1.managementdashboard.oc1..dashboardId1\\\"]}\"  > Import.json.
-     * Note that import API updates the resource if it already exist, and creates a new resource if it does not exist. To import to a different compartment, edit and change the compartmentId to the desired compartment OCID.
-     * Here is an example of how you can use CLI to do import:
-     * <p>
-     * oci management-dashboard dashboard import --from-json file://Import.json
+     * Imports an array of dashboards and their saved searches.
+     * Here's an example of how you can use CLI to import a dashboard. For information on the details that must be passed to IMPORT, you can use the EXPORT API to obtain the Import.json file:
+     * `oci management-dashboard dashboard export --query data --export-dashboard-id \"{\\\"dashboardIds\\\":[\\\"ocid1.managementdashboard.oc1..dashboardId1\\\"]}\"  > Import.json`.
+     * Note that import API updates the resource if it already exists, and creates a new resource if it does not exist. To import to a different compartment, edit and change the compartmentId to the desired compartment OCID.
+     * Here's an example of how you can use CLI to import:
+     * `oci management-dashboard dashboard import --from-json file://Import.json`
      *
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/DashxApisAsync.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/DashxApisAsync.java
@@ -86,9 +86,10 @@ public interface DashxApisAsync extends AutoCloseable {
                             handler);
 
     /**
-     * Creates a new dashboard.  Limit for number of saved searches in a dashboard is 20. Here's an example of how you can use CLI to create a dashboard. For information on the details that must be passed to CREATE, you can use the GET API to obtain the Create.json file:
-     * oci management-dashboard dashboard get --management-dashboard-id  \"ocid1.managementdashboard.oc1..dashboardId1\" --query data > Create.json.
-     * You can then modify the Create.json file by removing the\"id\" attribute and making other required changes, and use the oci management-dashboard dashboard create command.
+     * Creates a new dashboard. Limit for number of saved searches in a dashboard is 20.
+     * Here's an example of how you can use CLI to create a dashboard. For information on the details that must be passed to CREATE, you can use the GET API to obtain the Create.json file:
+     * `oci management-dashboard dashboard get --management-dashboard-id  \"ocid1.managementdashboard.oc1..dashboardId1\" --query data > Create.json.`
+     * You can then modify the Create.json file by removing the `id` attribute and making other required changes, and use the `oci management-dashboard dashboard create` command.
      *
      *
      * @param request The request object containing the details to send
@@ -105,10 +106,10 @@ public interface DashxApisAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Creates a new saved search. Here's an example of how you can use CLI to create a saved search. For information on the details that must be passed to CREATE, you can use the GET API to obtain the Create.json file:
-     * <p>
-     * oci management-dashboard saved-search get --management-saved-search-id ocid1.managementsavedsearch.oc1..savedsearchId1 --query data > Create.json.
-     * You can then modify the Create.json file by removing the \"id\" attribute and making other required changes, and use the oci management-dashboard saved-search create command.
+     * Creates a new saved search.
+     * Here's an example of how you can use CLI to create a saved search. For information on the details that must be passed to CREATE, you can use the GET API to obtain the Create.json file:
+     * `oci management-dashboard saved-search get --management-saved-search-id ocid1.managementsavedsearch.oc1..savedsearchId1 --query data > Create.json`.
+     * You can then modify the Create.json file by removing the `id` attribute and making other required changes, and use the `oci management-dashboard saved-search create` command.
      *
      *
      * @param request The request object containing the details to send
@@ -157,7 +158,10 @@ public interface DashxApisAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Exports an array of dashboards and their saved searches. Export is designed to work with importDashboard. Here's an example of how you can use CLI to export a dashboard. $oci management-dashboard dashboard export --query data --export-dashboard-id \"{\\\"dashboardIds\\\":[\\\"ocid1.managementdashboard.oc1..dashboardId1\\\"]}\"  > dashboards.json
+     * Exports an array of dashboards and their saved searches. Export is designed to work with importDashboard.
+     * Here's an example of how you can use CLI to export a dashboard:
+     * `$oci management-dashboard dashboard export --query data --export-dashboard-id \"{\\\"dashboardIds\\\":[\\\"ocid1.managementdashboard.oc1..dashboardId1\\\"]}\"  > dashboards.json`
+     *
      *
      * @param request The request object containing the details to send
      * @param handler The request handler to invoke upon completion, may be null.
@@ -204,12 +208,12 @@ public interface DashxApisAsync extends AutoCloseable {
                     handler);
 
     /**
-     * Imports an array of dashboards and their saved searches. Here's an example of how you can use CLI to import a dashboard. For information on the details that must be passed to IMPORT, you can use the EXPORT API to obtain the Import.json file:
-     * oci management-dashboard dashboard export --query data --export-dashboard-id \"{\\\"dashboardIds\\\":[\\\"ocid1.managementdashboard.oc1..dashboardId1\\\"]}\"  > Import.json.
-     * Note that import API updates the resource if it already exist, and creates a new resource if it does not exist. To import to a different compartment, edit and change the compartmentId to the desired compartment OCID.
-     * Here is an example of how you can use CLI to do import:
-     * <p>
-     * oci management-dashboard dashboard import --from-json file://Import.json
+     * Imports an array of dashboards and their saved searches.
+     * Here's an example of how you can use CLI to import a dashboard. For information on the details that must be passed to IMPORT, you can use the EXPORT API to obtain the Import.json file:
+     * `oci management-dashboard dashboard export --query data --export-dashboard-id \"{\\\"dashboardIds\\\":[\\\"ocid1.managementdashboard.oc1..dashboardId1\\\"]}\"  > Import.json`.
+     * Note that import API updates the resource if it already exists, and creates a new resource if it does not exist. To import to a different compartment, edit and change the compartmentId to the desired compartment OCID.
+     * Here's an example of how you can use CLI to import:
+     * `oci management-dashboard dashboard import --from-json file://Import.json`
      *
      *
      * @param request The request object containing the details to send

--- a/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/SavedSearchTypes.java
+++ b/bmc-managementdashboard/src/main/java/com/oracle/bmc/managementdashboard/model/SavedSearchTypes.java
@@ -14,6 +14,8 @@ public enum SavedSearchTypes {
     SearchDontShowInDashboard("SEARCH_DONT_SHOW_IN_DASHBOARD"),
     WidgetShowInDashboard("WIDGET_SHOW_IN_DASHBOARD"),
     WidgetDontShowInDashboard("WIDGET_DONT_SHOW_IN_DASHBOARD"),
+    FilterShowInDashboard("FILTER_SHOW_IN_DASHBOARD"),
+    FilterDontShowInDashboard("FILTER_DONT_SHOW_IN_DASHBOARD"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ospgateway/pom.xml
+++ b/bmc-ospgateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ospgateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubbillingschedule/pom.xml
+++ b/bmc-osubbillingschedule/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osuborganizationsubscription/pom.xml
+++ b/bmc-osuborganizationsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubsubscription/pom.xml
+++ b/bmc-osubsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubusage/pom.xml
+++ b/bmc-osubusage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubusage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemanagerproxy/pom.xml
+++ b/bmc-servicemanagerproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-threatintelligence/pom.xml
+++ b/bmc-threatintelligence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-threatintelligence</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usage/pom.xml
+++ b/bmc-usage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-visualbuilder/pom.xml
+++ b/bmc-visualbuilder/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-visualbuilder</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.17.0</version>
+    <version>2.18.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.17.0</version>
+  <version>2.18.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for DRG route distribution statements to be specified with a new match type `MATCH_ALL` for matching criteria in the Networking service

- Support for VCN route types on DRG attachments for deciding whether to import VCN CIDRs or subnet CIDRs into route rules in the Networking service

- Support for CPS offline reports in the Database service

- Support for infrastructure patching v2 features in the Database service

- Support for auto-scaling the storage of an autonomous database, as well as shrinking an autonomous database, in the Database service

- Support for managed egress via a default networking option on jobs and notebooks in the Data Science service

- Support for more types of saved search enums in the Management Dashboard service



### Breaking Changes

- Support for retries enabled by default on some operations in the AI Vision service