### PR TITLE
Releasing version 2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.19.0 - 2022-03-08
+### Added
+- Support for the Sales Accelerator license option in the Content Management service
+- Support for VCN hostname cluster endpoints in the Container Engine for Kubernetes service
+- Support for optionally specifying an admin username and password when creating a database system during a restore operation in the MySQL Database service
+- Support for automatic tablespace creation on non-autonomous and autonomous database dedicated targets in the Database Migration service
+- Support for reporting excluded objects based on static exclusion rules and dynamic exclusion settings in the Database Migration service
+- Support for removing, listing, and adding database objects reported by the Cloud Premigration Advisor Tool (CPAT) in the Database Migration service
+- Support for migrating Oracle databases from the AWS RDS service to OCI as autonomous databases, using the AWS S3 service and DBLINK for data transfer, in the Database Migration service
+- Support for querying additional fields of a resource using return clauses in the Search service
+- Support for clusters and station clusters in the Roving Edge Infrastructure service
+- Support for creating database systems and database homes using customer-managed keys in the Database service
+
+### Breaking Changes
+- Parameter 2 of `public com.oracle.bmc.waiter.Waiter forOceInstance(com.oracle.bmc.oce.requests.GetOceInstanceRequest, com.oracle.bmc.oce.model.OceInstance$LifecycleState[])` has changed its type to `com.oracle.bmc.oce.model.LifecycleState[]` in `com.oracle.bmc.oce.OceInstanceWaiters` in the Content Management service
+- Parameter 2 of `public com.oracle.bmc.waiter.Waiter forOceInstance(com.oracle.bmc.oce.requests.GetOceInstanceRequest, com.oracle.bmc.oce.model.OceInstance$LifecycleState, com.oracle.bmc.waiter.TerminationStrategy, com.oracle.bmc.waiter.DelayStrategy)` has changed its type to `com.oracle.bmc.oce.model.LifecycleState` in `com.oracle.bmc.oce.OceInstanceWaiters` in the Content Management service 
+- Parameter 4 of `public com.oracle.bmc.waiter.Waiter forOceInstance(com.oracle.bmc.oce.requests.GetOceInstanceRequest, com.oracle.bmc.waiter.TerminationStrategy, com.oracle.bmc.waiter.DelayStrategy, com.oracle.bmc.oce.model.OceInstance$LifecycleState[])` has changed its type to `com.oracle.bmc.oce.model.LifecycleState[]` in `com.oracle.bmc.oce.OceInstanceWaiters` in the Content Management service
+- Return type of method `public com.oracle.bmc.oce.model.OceInstance$LifecycleState getLifecycleState()` has been changed to `com.oracle.bmc.oce.model.LifecycleState` in the model `com.oracle.bmc.oce.model.OceInstance` in the Content Management service 
+- Class `com.oracle.bmc.oce.model.OceInstance$LifecycleState` has been removed in the Content Management service
+- Return type of method `public com.oracle.bmc.oce.model.OceInstanceSummary$LifecycleState getLifecycleState()` has been changed to `com.oracle.bmc.oce.model.LifecycleState` in the model `com.oracle.bmc.oce.model.OceInstanceSummary` in the Content Management service 
+- Class `com.oracle.bmc.oce.model.OceInstanceSummary$LifecycleState` has been removed in the Content Management service
+- Return type of method `public com.oracle.bmc.oce.requests.ListOceInstancesRequest$LifecycleState getLifecycleState()` has been changed to `com.oracle.bmc.oce.model.LifecycleState` in `com.oracle.bmc.oce.requests.ListOceInstancesRequest` in the Content Management service
+- Class `com.oracle.bmc.oce.requests.ListOceInstancesRequest$LifecycleState` has been removed in the Content Management service
+- Support for retries enabled by default on operations in the Container Engine for Kubernetes service
+- Support for retries enabled by default on operations in the Resource Manager service
+- Support for retries enabled by default on operations in the Search service
+
 ## 2.18.0 - 2022-03-01
 ### Added
 - Support for DRG route distribution statements to be specified with a new match type `MATCH_ALL` for matching criteria in the Networking service
@@ -122,6 +149,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Breaking Changes
 - Support for retries enabled by default on some operations in the Data Catalog service
+- Support for retries enabled by default on all operations in the Ocvp service
 
 ## 2.11.1 - 2021-12-07
 ### Added

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -108,7 +108,7 @@ jersey-media-json-jackson
 
 JSR305
 * Copyright © 2007-2009 JSR305 expert group
-* License: GNU Lesser General Public License 3.0
+* License: BSD 3-Clause
 * Source code: https://github.com/findbugsproject/findbugs
 * Project home: http://findbugs.sourceforge.net/
 

--- a/bmc-addons/bmc-apache-connector-provider/pom.xml
+++ b/bmc-addons/bmc-apache-connector-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-resteasy-client-configurator/pom.xml
+++ b/bmc-addons/bmc-resteasy-client-configurator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-addons</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-addons/bmc-sasl/pom.xml
+++ b/bmc-addons/bmc-sasl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>oci-java-sdk-addons</artifactId>
     <groupId>com.oracle.oci.sdk</groupId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-addons/pom.xml
+++ b/bmc-addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-aianomalydetection/pom.xml
+++ b/bmc-aianomalydetection/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aianomalydetection</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ailanguage/pom.xml
+++ b/bmc-ailanguage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ailanguage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aispeech/pom.xml
+++ b/bmc-aispeech/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aispeech</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-aivision/pom.xml
+++ b/bmc-aivision/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-aivision</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-analytics/pom.xml
+++ b/bmc-analytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-analytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-announcementsservice/pom.xml
+++ b/bmc-announcementsservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-announcementsservice</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apigateway/pom.xml
+++ b/bmc-apigateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apigateway</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmconfig/pom.xml
+++ b/bmc-apmconfig/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmconfig</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmcontrolplane/pom.xml
+++ b/bmc-apmcontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmsynthetics/pom.xml
+++ b/bmc-apmsynthetics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmsynthetics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-apmtraces/pom.xml
+++ b/bmc-apmtraces/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-apmtraces</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-applicationmigration/pom.xml
+++ b/bmc-applicationmigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-applicationmigration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-appmgmtcontrol/pom.xml
+++ b/bmc-appmgmtcontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-artifacts/pom.xml
+++ b/bmc-artifacts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-artifacts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-audit/pom.xml
+++ b/bmc-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-autoscaling/pom.xml
+++ b/bmc-autoscaling/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-autoscaling</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bastion/pom.xml
+++ b/bmc-bastion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bastion</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bds/pom.xml
+++ b/bmc-bds/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bds</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-blockchain/pom.xml
+++ b/bmc-blockchain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-blockchain</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-bom/pom.xml
+++ b/bmc-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-bom</artifactId>
@@ -19,636 +19,636 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-common</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <!-- Service modules, alpha sorted -->
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-audit</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-containerengine</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-core</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-database</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dns</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-email</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-filestorage</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identity</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loadbalancer</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-objectstorage</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-resteasy-client-configurator</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-sasl</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcesearch</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-addons-apache</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-keymanagement</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-announcementsservice</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-healthchecks</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waas</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-streaming</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-resourcemanager</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-monitoring</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ons</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-autoscaling</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-budget</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-workrequests</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-limits</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-functions</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-events</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dts</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oce</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-oda</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-analytics</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-integration</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osmanagement</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-marketplace</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apigateway</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-applicationmigration</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datacatalog</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataflow</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datascience</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-nosql</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-secrets</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vault</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bds</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-encryption</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cims</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datasafe</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-mysql</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataintegration</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ocvp</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usageapi</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-blockchain</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingingestion</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-logging</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loganalytics</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementdashboard</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-sch</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-loggingsearch</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-managementagent</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-cloudguard</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-opsi</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-optimizer</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-rover</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemanagement</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-artifacts</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmsynthetics</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-goldengate</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmcontrolplane</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmtraces</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasemigration</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicecatalog</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ailanguage</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bastion</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-jms</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-devops</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aianomalydetection</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservice</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-apmconfig</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-waf</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificates</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-usage</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-databasetools</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-appmgmtcontrol</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-ospgateway</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-identitydataplane</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-visualbuilder</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubusage</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubsubscription</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dashboardservice</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-threatintelligence</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aivision</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-aispeech</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-dataconnectivity</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <optional>false</optional>
       </dependency>
     </dependencies>

--- a/bmc-budget/pom.xml
+++ b/bmc-budget/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-budget</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificates/pom.xml
+++ b/bmc-certificates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificates</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-certificatesmanagement/pom.xml
+++ b/bmc-certificatesmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-certificatesmanagement</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-cims/pom.xml
+++ b/bmc-cims/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cims</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-circuitbreaker/pom.xml
+++ b/bmc-circuitbreaker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-circuitbreaker</artifactId>

--- a/bmc-cloudguard/pom.xml
+++ b/bmc-cloudguard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-cloudguard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-common/pom.xml
+++ b/bmc-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
     <!-- Begin ApacheConnector Http Dependencies  -->
     <dependency>

--- a/bmc-common/src/main/java/com/oracle/bmc/auth/internal/AuthUtils.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/auth/internal/AuthUtils.java
@@ -19,6 +19,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.RSAPublicKeySpec;
 
 import com.oracle.bmc.auth.exception.InstancePrincipalUnavailableException;
+import com.oracle.bmc.http.internal.RestClientFactory;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -42,7 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthUtils {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = RestClientFactory.getObjectMapper();
     private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
     /**

--- a/bmc-common/src/main/java/com/oracle/bmc/http/internal/ResponseHelper.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/http/internal/ResponseHelper.java
@@ -17,7 +17,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -42,7 +41,8 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @Slf4j
 public class ResponseHelper {
-    private static final ObjectReader STRING_READER = new ObjectMapper().readerFor(String.class);
+    private static final ObjectReader STRING_READER =
+            RestClientFactory.getObjectMapper().readerFor(String.class);
     private static final int MAX_RESPONSE_BUFFER_BYTES = 4096;
     private static final String OPC_REQUEST_ID_HEADER = "opc-request-id";
     private static final Map<Integer, String> DEFAULT_ERROR_MESSAGES = new HashMap<>();

--- a/bmc-common/src/main/java/com/oracle/bmc/model/internal/JsonConverter.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/model/internal/JsonConverter.java
@@ -6,6 +6,7 @@ package com.oracle.bmc.model.internal;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.oracle.bmc.http.internal.RestClientFactory;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,7 +20,8 @@ public class JsonConverter {
      * Object mapper to support jackson json operations
      */
     private static final ObjectMapper mapper =
-            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            RestClientFactory.getObjectMapper()
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     /**
      * Get desired object from the json provided

--- a/bmc-common/src/test/java/com/oracle/bmc/auth/internal/X509FederationClientTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/auth/internal/X509FederationClientTest.java
@@ -10,6 +10,7 @@ import com.oracle.bmc.auth.X509CertificateSupplier;
 import com.oracle.bmc.circuitbreaker.CircuitBreakerConfiguration;
 import com.oracle.bmc.http.ClientConfigurator;
 import com.oracle.bmc.http.internal.RestClient;
+import com.oracle.bmc.http.internal.RestClientFactory;
 import com.oracle.bmc.http.internal.WrappedInvocationBuilder;
 import com.oracle.bmc.model.BmcException;
 import com.oracle.bmc.requests.BmcRequest;
@@ -36,7 +37,6 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -140,14 +140,15 @@ public class X509FederationClientTest {
     public void jacksonCanDeserializeSecurityToken() throws IOException {
         final String strToken = "{\"token\" : \"abcdef\"}";
         // this line will fail on original code if Lombok and Jackson are not at exactly the right versions
-        new ObjectMapper().readValue(strToken, X509FederationClient.SecurityToken.class);
+        RestClientFactory.getObjectMapper()
+                .readValue(strToken, X509FederationClient.SecurityToken.class);
     }
 
     @Test
     public void jacksonCanRoundTripSecurityToken() throws IOException {
         final X509FederationClient.SecurityToken secToken =
                 new X509FederationClient.SecurityToken("abcdef");
-        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectMapper mapper = RestClientFactory.getObjectMapper();
         assertEquals(
                 secToken.getToken(),
                 mapper.readValue(mapper.writeValueAsString(secToken), secToken.getClass())

--- a/bmc-common/src/test/java/com/oracle/bmc/http/internal/ResponseHelperTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/http/internal/ResponseHelperTest.java
@@ -4,7 +4,6 @@
  */
 package com.oracle.bmc.http.internal;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.oracle.bmc.io.internal.AutoCloseableContentLengthVerifyingInputStream;
 import com.oracle.bmc.io.internal.ContentLengthVerifyingInputStream;
@@ -116,7 +115,8 @@ public class ResponseHelperTest {
         Response response = mock(Response.class);
         Response.StatusType statusInfo = mock(Response.StatusType.class);
         // with embedded quote
-        String jsonEncodedString = new ObjectMapper().writeValueAsString("foo \" bar");
+        String jsonEncodedString =
+                RestClientFactory.getObjectMapper().writeValueAsString("foo \" bar");
         assertEquals("\"foo \\\" bar\"", jsonEncodedString);
 
         Class<String> entityType = String.class;

--- a/bmc-computeinstanceagent/pom.xml
+++ b/bmc-computeinstanceagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-computeinstanceagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-containerengine/pom.xml
+++ b/bmc-containerengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngine.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngine.java
@@ -54,7 +54,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/ClusterMigrateToNativeVcnExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ClusterMigrateToNativeVcn API.
@@ -67,7 +67,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/CreateClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateCluster API.
@@ -79,7 +79,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/CreateKubeconfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateKubeconfig API.
@@ -91,7 +91,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/CreateNodePoolExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateNodePool API.
@@ -103,7 +103,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/DeleteClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteCluster API.
@@ -115,7 +115,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/DeleteNodePoolExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteNodePool API.
@@ -127,7 +127,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/DeleteWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteWorkRequest API.
@@ -139,7 +139,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/GetClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetCluster API.
@@ -151,7 +151,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/GetClusterMigrateToNativeVcnStatusExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetClusterMigrateToNativeVcnStatus API.
@@ -164,7 +164,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/GetClusterOptionsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetClusterOptions API.
@@ -176,7 +176,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/GetNodePoolExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetNodePool API.
@@ -188,7 +188,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/GetNodePoolOptionsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetNodePoolOptions API.
@@ -200,7 +200,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
@@ -212,7 +212,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/ListClustersExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListClusters API.
@@ -224,7 +224,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/ListNodePoolsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListNodePools API.
@@ -236,7 +236,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestErrors API.
@@ -248,7 +248,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestLogs API.
@@ -260,7 +260,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.
@@ -272,7 +272,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/UpdateClusterExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateCluster API.
@@ -284,7 +284,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/UpdateClusterEndpointConfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateClusterEndpointConfig API.
@@ -297,7 +297,7 @@ public interface ContainerEngine extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/containerengine/UpdateNodePoolExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateNodePool API.

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineClient.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/ContainerEngineClient.java
@@ -475,7 +475,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -509,7 +509,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -553,7 +553,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -587,7 +587,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -621,7 +621,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -651,7 +651,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -681,7 +681,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -710,7 +710,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -741,7 +741,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -770,7 +770,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -799,7 +799,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -828,7 +828,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -857,7 +857,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -886,7 +886,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -915,7 +915,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -945,7 +945,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -974,7 +974,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1003,7 +1003,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1032,7 +1032,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1067,7 +1067,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1101,7 +1101,7 @@ public class ContainerEngineClient implements ContainerEngine {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/ClusterEndpoints.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/ClusterEndpoints.java
@@ -51,12 +51,22 @@ public class ClusterEndpoints {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("vcnHostnameEndpoint")
+        private String vcnHostnameEndpoint;
+
+        public Builder vcnHostnameEndpoint(String vcnHostnameEndpoint) {
+            this.vcnHostnameEndpoint = vcnHostnameEndpoint;
+            this.__explicitlySet__.add("vcnHostnameEndpoint");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public ClusterEndpoints build() {
             ClusterEndpoints __instance__ =
-                    new ClusterEndpoints(kubernetes, publicEndpoint, privateEndpoint);
+                    new ClusterEndpoints(
+                            kubernetes, publicEndpoint, privateEndpoint, vcnHostnameEndpoint);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -66,7 +76,8 @@ public class ClusterEndpoints {
             Builder copiedBuilder =
                     kubernetes(o.getKubernetes())
                             .publicEndpoint(o.getPublicEndpoint())
-                            .privateEndpoint(o.getPrivateEndpoint());
+                            .privateEndpoint(o.getPrivateEndpoint())
+                            .vcnHostnameEndpoint(o.getVcnHostnameEndpoint());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -97,6 +108,14 @@ public class ClusterEndpoints {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("privateEndpoint")
     String privateEndpoint;
+
+    /**
+     * The FQDN assigned to the Kubernetes API private endpoint.
+     * Example: 'https://yourVcnHostnameEndpoint'
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vcnHostnameEndpoint")
+    String vcnHostnameEndpoint;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateClusterKubeconfigContentDetails.java
+++ b/bmc-containerengine/src/main/java/com/oracle/bmc/containerengine/model/CreateClusterKubeconfigContentDetails.java
@@ -102,6 +102,7 @@ public class CreateClusterKubeconfigContentDetails {
         LegacyKubernetes("LEGACY_KUBERNETES"),
         PublicEndpoint("PUBLIC_ENDPOINT"),
         PrivateEndpoint("PRIVATE_ENDPOINT"),
+        VcnHostname("VCN_HOSTNAME"),
         ;
 
         private final String value;

--- a/bmc-core/pom.xml
+++ b/bmc-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dashboardservice/pom.xml
+++ b/bmc-dashboardservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dashboardservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-database/pom.xml
+++ b/bmc-database/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,12 +20,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-workrequests</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/Backup.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/Backup.java
@@ -159,6 +159,24 @@ public class Backup {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+        private String kmsKeyVersionId;
+
+        public Builder kmsKeyVersionId(String kmsKeyVersionId) {
+            this.kmsKeyVersionId = kmsKeyVersionId;
+            this.__explicitlySet__.add("kmsKeyVersionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+        private String vaultId;
+
+        public Builder vaultId(String vaultId) {
+            this.vaultId = vaultId;
+            this.__explicitlySet__.add("vaultId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -179,7 +197,9 @@ public class Backup {
                             databaseSizeInGBs,
                             shape,
                             version,
-                            kmsKeyId);
+                            kmsKeyId,
+                            kmsKeyVersionId,
+                            vaultId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -201,7 +221,9 @@ public class Backup {
                             .databaseSizeInGBs(o.getDatabaseSizeInGBs())
                             .shape(o.getShape())
                             .version(o.getVersion())
-                            .kmsKeyId(o.getKmsKeyId());
+                            .kmsKeyId(o.getKmsKeyId())
+                            .kmsKeyVersionId(o.getKmsKeyVersionId())
+                            .vaultId(o.getVaultId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -448,6 +470,19 @@ public class Backup {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
     String kmsKeyId;
+
+    /**
+     * The OCID of the key container version that is used in database transparent data encryption (TDE) operations KMS Key can have multiple key versions. If none is specified, the current key version (latest) of the Key Id is used for the operation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+    String kmsKeyVersionId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure [vault](https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+    String vaultId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/BackupSummary.java
@@ -163,6 +163,24 @@ public class BackupSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+        private String kmsKeyVersionId;
+
+        public Builder kmsKeyVersionId(String kmsKeyVersionId) {
+            this.kmsKeyVersionId = kmsKeyVersionId;
+            this.__explicitlySet__.add("kmsKeyVersionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+        private String vaultId;
+
+        public Builder vaultId(String vaultId) {
+            this.vaultId = vaultId;
+            this.__explicitlySet__.add("vaultId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -183,7 +201,9 @@ public class BackupSummary {
                             databaseSizeInGBs,
                             shape,
                             version,
-                            kmsKeyId);
+                            kmsKeyId,
+                            kmsKeyVersionId,
+                            vaultId);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -205,7 +225,9 @@ public class BackupSummary {
                             .databaseSizeInGBs(o.getDatabaseSizeInGBs())
                             .shape(o.getShape())
                             .version(o.getVersion())
-                            .kmsKeyId(o.getKmsKeyId());
+                            .kmsKeyId(o.getKmsKeyId())
+                            .kmsKeyVersionId(o.getKmsKeyVersionId())
+                            .vaultId(o.getVaultId());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -452,6 +474,19 @@ public class BackupSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
     String kmsKeyId;
+
+    /**
+     * The OCID of the key container version that is used in database transparent data encryption (TDE) operations KMS Key can have multiple key versions. If none is specified, the current key version (latest) of the Key Id is used for the operation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+    String kmsKeyVersionId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure [vault](https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+    String vaultId;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/CreateDatabaseDetails.java
@@ -138,6 +138,33 @@ public class CreateDatabaseDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+        private String kmsKeyId;
+
+        public Builder kmsKeyId(String kmsKeyId) {
+            this.kmsKeyId = kmsKeyId;
+            this.__explicitlySet__.add("kmsKeyId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+        private String kmsKeyVersionId;
+
+        public Builder kmsKeyVersionId(String kmsKeyVersionId) {
+            this.kmsKeyVersionId = kmsKeyVersionId;
+            this.__explicitlySet__.add("kmsKeyVersionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+        private String vaultId;
+
+        public Builder vaultId(String vaultId) {
+            this.vaultId = vaultId;
+            this.__explicitlySet__.add("vaultId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sidPrefix")
         private String sidPrefix;
 
@@ -165,6 +192,9 @@ public class CreateDatabaseDetails {
                             dbBackupConfig,
                             freeformTags,
                             definedTags,
+                            kmsKeyId,
+                            kmsKeyVersionId,
+                            vaultId,
                             sidPrefix);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
@@ -185,6 +215,9 @@ public class CreateDatabaseDetails {
                             .dbBackupConfig(o.getDbBackupConfig())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
+                            .kmsKeyId(o.getKmsKeyId())
+                            .kmsKeyVersionId(o.getKmsKeyVersionId())
+                            .vaultId(o.getVaultId())
                             .sidPrefix(o.getSidPrefix());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
@@ -312,6 +345,25 @@ public class CreateDatabaseDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("definedTags")
     java.util.Map<String, java.util.Map<String, Object>> definedTags;
+
+    /**
+     * The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
+    String kmsKeyId;
+
+    /**
+     * The OCID of the key container version that is used in database transparent data encryption (TDE) operations KMS Key can have multiple key versions. If none is specified, the current key version (latest) of the Key Id is used for the operation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+    String kmsKeyVersionId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure [vault](https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+    String vaultId;
 
     /**
      * Specifies a prefix for the {@code Oracle SID} of the database to be created.

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/Database.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/Database.java
@@ -205,6 +205,24 @@ public class Database {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+        private String kmsKeyVersionId;
+
+        public Builder kmsKeyVersionId(String kmsKeyVersionId) {
+            this.kmsKeyVersionId = kmsKeyVersionId;
+            this.__explicitlySet__.add("kmsKeyVersionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+        private String vaultId;
+
+        public Builder vaultId(String vaultId) {
+            this.vaultId = vaultId;
+            this.__explicitlySet__.add("vaultId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceDatabasePointInTimeRecoveryTimestamp")
         private java.util.Date sourceDatabasePointInTimeRecoveryTimestamp;
 
@@ -279,6 +297,8 @@ public class Database {
                             definedTags,
                             connectionStrings,
                             kmsKeyId,
+                            kmsKeyVersionId,
+                            vaultId,
                             sourceDatabasePointInTimeRecoveryTimestamp,
                             databaseSoftwareImageId,
                             isCdb,
@@ -311,6 +331,8 @@ public class Database {
                             .definedTags(o.getDefinedTags())
                             .connectionStrings(o.getConnectionStrings())
                             .kmsKeyId(o.getKmsKeyId())
+                            .kmsKeyVersionId(o.getKmsKeyVersionId())
+                            .vaultId(o.getVaultId())
                             .sourceDatabasePointInTimeRecoveryTimestamp(
                                     o.getSourceDatabasePointInTimeRecoveryTimestamp())
                             .databaseSoftwareImageId(o.getDatabaseSoftwareImageId())
@@ -506,6 +528,19 @@ public class Database {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
     String kmsKeyId;
+
+    /**
+     * The OCID of the key container version that is used in database transparent data encryption (TDE) operations KMS Key can have multiple key versions. If none is specified, the current key version (latest) of the Key Id is used for the operation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+    String kmsKeyVersionId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure [vault](https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+    String vaultId;
 
     /**
      * Point in time recovery timeStamp of the source database at which cloned database system is cloned from the source database system, as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339)

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSummary.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/DatabaseSummary.java
@@ -210,6 +210,24 @@ public class DatabaseSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+        private String kmsKeyVersionId;
+
+        public Builder kmsKeyVersionId(String kmsKeyVersionId) {
+            this.kmsKeyVersionId = kmsKeyVersionId;
+            this.__explicitlySet__.add("kmsKeyVersionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+        private String vaultId;
+
+        public Builder vaultId(String vaultId) {
+            this.vaultId = vaultId;
+            this.__explicitlySet__.add("vaultId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("sourceDatabasePointInTimeRecoveryTimestamp")
         private java.util.Date sourceDatabasePointInTimeRecoveryTimestamp;
 
@@ -284,6 +302,8 @@ public class DatabaseSummary {
                             definedTags,
                             connectionStrings,
                             kmsKeyId,
+                            kmsKeyVersionId,
+                            vaultId,
                             sourceDatabasePointInTimeRecoveryTimestamp,
                             databaseSoftwareImageId,
                             isCdb,
@@ -316,6 +336,8 @@ public class DatabaseSummary {
                             .definedTags(o.getDefinedTags())
                             .connectionStrings(o.getConnectionStrings())
                             .kmsKeyId(o.getKmsKeyId())
+                            .kmsKeyVersionId(o.getKmsKeyVersionId())
+                            .vaultId(o.getVaultId())
                             .sourceDatabasePointInTimeRecoveryTimestamp(
                                     o.getSourceDatabasePointInTimeRecoveryTimestamp())
                             .databaseSoftwareImageId(o.getDatabaseSoftwareImageId())
@@ -511,6 +533,19 @@ public class DatabaseSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyId")
     String kmsKeyId;
+
+    /**
+     * The OCID of the key container version that is used in database transparent data encryption (TDE) operations KMS Key can have multiple key versions. If none is specified, the current key version (latest) of the Key Id is used for the operation.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
+    String kmsKeyVersionId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure [vault](https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+    String vaultId;
 
     /**
      * Point in time recovery timeStamp of the source database at which cloned database system is cloned from the source database system, as described in [RFC 3339](https://tools.ietf.org/rfc/rfc3339)

--- a/bmc-database/src/main/java/com/oracle/bmc/database/model/MigrateVaultKeyDetails.java
+++ b/bmc-database/src/main/java/com/oracle/bmc/database/model/MigrateVaultKeyDetails.java
@@ -45,12 +45,40 @@ public class MigrateVaultKeyDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+        private String vaultId;
+
+        public Builder vaultId(String vaultId) {
+            this.vaultId = vaultId;
+            this.__explicitlySet__.add("vaultId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("tdeWalletPassword")
+        private String tdeWalletPassword;
+
+        public Builder tdeWalletPassword(String tdeWalletPassword) {
+            this.tdeWalletPassword = tdeWalletPassword;
+            this.__explicitlySet__.add("tdeWalletPassword");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("adminPassword")
+        private String adminPassword;
+
+        public Builder adminPassword(String adminPassword) {
+            this.adminPassword = adminPassword;
+            this.__explicitlySet__.add("adminPassword");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public MigrateVaultKeyDetails build() {
             MigrateVaultKeyDetails __instance__ =
-                    new MigrateVaultKeyDetails(kmsKeyId, kmsKeyVersionId);
+                    new MigrateVaultKeyDetails(
+                            kmsKeyId, kmsKeyVersionId, vaultId, tdeWalletPassword, adminPassword);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -58,7 +86,11 @@ public class MigrateVaultKeyDetails {
         @com.fasterxml.jackson.annotation.JsonIgnore
         public Builder copy(MigrateVaultKeyDetails o) {
             Builder copiedBuilder =
-                    kmsKeyId(o.getKmsKeyId()).kmsKeyVersionId(o.getKmsKeyVersionId());
+                    kmsKeyId(o.getKmsKeyId())
+                            .kmsKeyVersionId(o.getKmsKeyVersionId())
+                            .vaultId(o.getVaultId())
+                            .tdeWalletPassword(o.getTdeWalletPassword())
+                            .adminPassword(o.getAdminPassword());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -84,6 +116,24 @@ public class MigrateVaultKeyDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("kmsKeyVersionId")
     String kmsKeyVersionId;
+
+    /**
+     * The [OCID](https://docs.cloud.oracle.com/Content/General/Concepts/identifiers.htm) of the Oracle Cloud Infrastructure [vault](https://docs.cloud.oracle.com/Content/KeyManagement/Concepts/keyoverview.htm#concepts).
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("vaultId")
+    String vaultId;
+
+    /**
+     * The existing TDE wallet password of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("tdeWalletPassword")
+    String tdeWalletPassword;
+
+    /**
+     * The existing admin password of the database.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("adminPassword")
+    String adminPassword;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemanagement/pom.xml
+++ b/bmc-databasemanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/pom.xml
+++ b/bmc-databasemigration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasemigration</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigration.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigration.java
@@ -60,6 +60,19 @@ public interface DatabaseMigration extends AutoCloseable {
     AbortJobResponse abortJob(AbortJobRequest request);
 
     /**
+     * Add excluded/included object to the list.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/AddMigrationObjectsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use AddMigrationObjects API.
+     */
+    AddMigrationObjectsResponse addMigrationObjects(AddMigrationObjectsRequest request);
+
+    /**
      * Used to configure an ODMS Agent Compartment ID.
      *
      * @param request The request object containing the details to send
@@ -338,6 +351,19 @@ public interface DatabaseMigration extends AutoCloseable {
     ListConnectionsResponse listConnections(ListConnectionsRequest request);
 
     /**
+     * List the excluded database objects.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListExcludedObjectsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListExcludedObjects API.
+     */
+    ListExcludedObjectsResponse listExcludedObjects(ListExcludedObjectsRequest request);
+
+    /**
      * List the Job Outputs
      *
      * @param request The request object containing the details to send
@@ -377,6 +403,19 @@ public interface DatabaseMigration extends AutoCloseable {
      */
     ListMigrationObjectTypesResponse listMigrationObjectTypes(
             ListMigrationObjectTypesRequest request);
+
+    /**
+     * Display excluded/included objects.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListMigrationObjectsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListMigrationObjects API.
+     */
+    ListMigrationObjectsResponse listMigrationObjects(ListMigrationObjectsRequest request);
 
     /**
      * List all Migrations.
@@ -429,6 +468,19 @@ public interface DatabaseMigration extends AutoCloseable {
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.
      */
     ListWorkRequestsResponse listWorkRequests(ListWorkRequestsRequest request);
+
+    /**
+     * Remove excluded/included objects.
+     *
+     * @param request The request object containing the details to send
+     * @return A response object containing details about the completed operation
+     * @throws BmcException when an error occurs.
+     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
+     *
+     * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/RemoveMigrationObjectsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use RemoveMigrationObjects API.
+     */
+    RemoveMigrationObjectsResponse removeMigrationObjects(RemoveMigrationObjectsRequest request);
 
     /**
      * Resume a migration Job.

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsync.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsync.java
@@ -61,6 +61,23 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             com.oracle.bmc.responses.AsyncHandler<AbortJobRequest, AbortJobResponse> handler);
 
     /**
+     * Add excluded/included object to the list.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<AddMigrationObjectsResponse> addMigrationObjects(
+            AddMigrationObjectsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            AddMigrationObjectsRequest, AddMigrationObjectsResponse>
+                    handler);
+
+    /**
      * Used to configure an ODMS Agent Compartment ID.
      *
      *
@@ -400,6 +417,23 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
                     handler);
 
     /**
+     * List the excluded database objects.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListExcludedObjectsResponse> listExcludedObjects(
+            ListExcludedObjectsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListExcludedObjectsRequest, ListExcludedObjectsResponse>
+                    handler);
+
+    /**
      * List the Job Outputs
      *
      *
@@ -446,6 +480,23 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
             ListMigrationObjectTypesRequest request,
             com.oracle.bmc.responses.AsyncHandler<
                             ListMigrationObjectTypesRequest, ListMigrationObjectTypesResponse>
+                    handler);
+
+    /**
+     * Display excluded/included objects.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<ListMigrationObjectsResponse> listMigrationObjects(
+            ListMigrationObjectsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            ListMigrationObjectsRequest, ListMigrationObjectsResponse>
                     handler);
 
     /**
@@ -512,6 +563,23 @@ public interface DatabaseMigrationAsync extends AutoCloseable {
     java.util.concurrent.Future<ListWorkRequestsResponse> listWorkRequests(
             ListWorkRequestsRequest request,
             com.oracle.bmc.responses.AsyncHandler<ListWorkRequestsRequest, ListWorkRequestsResponse>
+                    handler);
+
+    /**
+     * Remove excluded/included objects.
+     *
+     *
+     * @param request The request object containing the details to send
+     * @param handler The request handler to invoke upon completion, may be null.
+     * @return A Future that can be used to get the response if no AsyncHandler was
+     *         provided. Note, if you provide an AsyncHandler and use the Future, some
+     *         types of responses (like java.io.InputStream) may not be able to be read in
+     *         both places as the underlying stream may only be consumed once.
+     */
+    java.util.concurrent.Future<RemoveMigrationObjectsResponse> removeMigrationObjects(
+            RemoveMigrationObjectsRequest request,
+            com.oracle.bmc.responses.AsyncHandler<
+                            RemoveMigrationObjectsRequest, RemoveMigrationObjectsResponse>
                     handler);
 
     /**

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsyncClient.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationAsyncClient.java
@@ -415,6 +415,52 @@ public class DatabaseMigrationAsyncClient implements DatabaseMigrationAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<AddMigrationObjectsResponse> addMigrationObjects(
+            AddMigrationObjectsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            AddMigrationObjectsRequest, AddMigrationObjectsResponse>
+                    handler) {
+        LOG.trace("Called async addMigrationObjects");
+        final AddMigrationObjectsRequest interceptedRequest =
+                AddMigrationObjectsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddMigrationObjectsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, AddMigrationObjectsResponse>
+                transformer = AddMigrationObjectsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        AddMigrationObjectsRequest, AddMigrationObjectsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                AddMigrationObjectsRequest, AddMigrationObjectsResponse>,
+                        java.util.concurrent.Future<AddMigrationObjectsResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getAddMigrationObjectsDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    AddMigrationObjectsRequest, AddMigrationObjectsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ChangeAgentCompartmentResponse> changeAgentCompartment(
             ChangeAgentCompartmentRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -1279,6 +1325,47 @@ public class DatabaseMigrationAsyncClient implements DatabaseMigrationAsync {
     }
 
     @Override
+    public java.util.concurrent.Future<ListExcludedObjectsResponse> listExcludedObjects(
+            ListExcludedObjectsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListExcludedObjectsRequest, ListExcludedObjectsResponse>
+                    handler) {
+        LOG.trace("Called async listExcludedObjects");
+        final ListExcludedObjectsRequest interceptedRequest =
+                ListExcludedObjectsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListExcludedObjectsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListExcludedObjectsResponse>
+                transformer = ListExcludedObjectsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListExcludedObjectsRequest, ListExcludedObjectsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListExcludedObjectsRequest, ListExcludedObjectsResponse>,
+                        java.util.concurrent.Future<ListExcludedObjectsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListExcludedObjectsRequest, ListExcludedObjectsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
     public java.util.concurrent.Future<ListJobOutputsResponse> listJobOutputs(
             ListJobOutputsRequest request,
             final com.oracle.bmc.responses.AsyncHandler<
@@ -1382,6 +1469,47 @@ public class DatabaseMigrationAsyncClient implements DatabaseMigrationAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListMigrationObjectTypesRequest, ListMigrationObjectTypesResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<ListMigrationObjectsResponse> listMigrationObjects(
+            ListMigrationObjectsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            ListMigrationObjectsRequest, ListMigrationObjectsResponse>
+                    handler) {
+        LOG.trace("Called async listMigrationObjects");
+        final ListMigrationObjectsRequest interceptedRequest =
+                ListMigrationObjectsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListMigrationObjectsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, ListMigrationObjectsResponse>
+                transformer = ListMigrationObjectsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        ListMigrationObjectsRequest, ListMigrationObjectsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                ListMigrationObjectsRequest, ListMigrationObjectsResponse>,
+                        java.util.concurrent.Future<ListMigrationObjectsResponse>>
+                futureSupplier = client.getFutureSupplier(interceptedRequest, ib, transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    ListMigrationObjectsRequest, ListMigrationObjectsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,
@@ -1542,6 +1670,52 @@ public class DatabaseMigrationAsyncClient implements DatabaseMigrationAsync {
                 instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
             return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
                     ListWorkRequestsRequest, ListWorkRequestsResponse>(
+                    (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
+                            this.authenticationDetailsProvider,
+                    handlerToUse,
+                    futureSupplier) {
+                @Override
+                protected void beforeRetryAction() {}
+            };
+        } else {
+            return futureSupplier.apply(handlerToUse);
+        }
+    }
+
+    @Override
+    public java.util.concurrent.Future<RemoveMigrationObjectsResponse> removeMigrationObjects(
+            RemoveMigrationObjectsRequest request,
+            final com.oracle.bmc.responses.AsyncHandler<
+                            RemoveMigrationObjectsRequest, RemoveMigrationObjectsResponse>
+                    handler) {
+        LOG.trace("Called async removeMigrationObjects");
+        final RemoveMigrationObjectsRequest interceptedRequest =
+                RemoveMigrationObjectsConverter.interceptRequest(request);
+        final com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveMigrationObjectsConverter.fromRequest(client, interceptedRequest);
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response, RemoveMigrationObjectsResponse>
+                transformer = RemoveMigrationObjectsConverter.fromResponse();
+
+        com.oracle.bmc.responses.AsyncHandler<
+                        RemoveMigrationObjectsRequest, RemoveMigrationObjectsResponse>
+                handlerToUse = handler;
+
+        java.util.function.Function<
+                        com.oracle.bmc.responses.AsyncHandler<
+                                RemoveMigrationObjectsRequest, RemoveMigrationObjectsResponse>,
+                        java.util.concurrent.Future<RemoveMigrationObjectsResponse>>
+                futureSupplier =
+                        client.postFutureSupplier(
+                                interceptedRequest,
+                                interceptedRequest.getRemoveMigrationObjectsDetails(),
+                                ib,
+                                transformer);
+
+        if (this.authenticationDetailsProvider
+                instanceof com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider) {
+            return new com.oracle.bmc.util.internal.RefreshAuthTokenWrapper<
+                    RemoveMigrationObjectsRequest, RemoveMigrationObjectsResponse>(
                     (com.oracle.bmc.auth.RefreshableOnNotAuthenticatedProvider)
                             this.authenticationDetailsProvider,
                     handlerToUse,

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationClient.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationClient.java
@@ -491,6 +491,39 @@ public class DatabaseMigrationClient implements DatabaseMigration {
     }
 
     @Override
+    public AddMigrationObjectsResponse addMigrationObjects(AddMigrationObjectsRequest request) {
+        LOG.trace("Called addMigrationObjects");
+        final AddMigrationObjectsRequest interceptedRequest =
+                AddMigrationObjectsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                AddMigrationObjectsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, AddMigrationObjectsResponse>
+                transformer = AddMigrationObjectsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getAddMigrationObjectsDetails(),
+                                                retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ChangeAgentCompartmentResponse changeAgentCompartment(
             ChangeAgentCompartmentRequest request) {
         LOG.trace("Called changeAgentCompartment");
@@ -1149,6 +1182,35 @@ public class DatabaseMigrationClient implements DatabaseMigration {
     }
 
     @Override
+    public ListExcludedObjectsResponse listExcludedObjects(ListExcludedObjectsRequest request) {
+        LOG.trace("Called listExcludedObjects");
+        final ListExcludedObjectsRequest interceptedRequest =
+                ListExcludedObjectsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListExcludedObjectsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListExcludedObjectsResponse>
+                transformer = ListExcludedObjectsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
     public ListJobOutputsResponse listJobOutputs(ListJobOutputsRequest request) {
         LOG.trace("Called listJobOutputs");
         final ListJobOutputsRequest interceptedRequest =
@@ -1215,6 +1277,35 @@ public class DatabaseMigrationClient implements DatabaseMigration {
                 ListMigrationObjectTypesConverter.fromRequest(client, interceptedRequest);
         com.google.common.base.Function<javax.ws.rs.core.Response, ListMigrationObjectTypesResponse>
                 transformer = ListMigrationObjectTypesConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public ListMigrationObjectsResponse listMigrationObjects(ListMigrationObjectsRequest request) {
+        LOG.trace("Called listMigrationObjects");
+        final ListMigrationObjectsRequest interceptedRequest =
+                ListMigrationObjectsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                ListMigrationObjectsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, ListMigrationObjectsResponse>
+                transformer = ListMigrationObjectsConverter.fromResponse();
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
@@ -1347,6 +1438,40 @@ public class DatabaseMigrationClient implements DatabaseMigration {
                             retryRequest,
                             retriedRequest -> {
                                 javax.ws.rs.core.Response response = client.get(ib, retriedRequest);
+                                return transformer.apply(response);
+                            });
+                });
+    }
+
+    @Override
+    public RemoveMigrationObjectsResponse removeMigrationObjects(
+            RemoveMigrationObjectsRequest request) {
+        LOG.trace("Called removeMigrationObjects");
+        final RemoveMigrationObjectsRequest interceptedRequest =
+                RemoveMigrationObjectsConverter.interceptRequest(request);
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib =
+                RemoveMigrationObjectsConverter.fromRequest(client, interceptedRequest);
+        com.google.common.base.Function<javax.ws.rs.core.Response, RemoveMigrationObjectsResponse>
+                transformer = RemoveMigrationObjectsConverter.fromResponse();
+
+        final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
+                com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+        com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
+        return retrier.execute(
+                interceptedRequest,
+                retryRequest -> {
+                    final com.oracle.bmc.retrier.TokenRefreshRetrier tokenRefreshRetrier =
+                            new com.oracle.bmc.retrier.TokenRefreshRetrier(
+                                    authenticationDetailsProvider);
+                    return tokenRefreshRetrier.execute(
+                            retryRequest,
+                            retriedRequest -> {
+                                javax.ws.rs.core.Response response =
+                                        client.post(
+                                                ib,
+                                                retriedRequest.getRemoveMigrationObjectsDetails(),
+                                                retriedRequest);
                                 return transformer.apply(response);
                             });
                 });

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationPaginators.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/DatabaseMigrationPaginators.java
@@ -367,6 +367,122 @@ public class DatabaseMigrationPaginators {
     }
 
     /**
+     * Creates a new iterable which will iterate over the responses received from the listExcludedObjects operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListExcludedObjectsResponse> listExcludedObjectsResponseIterator(
+            final ListExcludedObjectsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListExcludedObjectsRequest.Builder, ListExcludedObjectsRequest,
+                ListExcludedObjectsResponse>(
+                new com.google.common.base.Supplier<ListExcludedObjectsRequest.Builder>() {
+                    @Override
+                    public ListExcludedObjectsRequest.Builder get() {
+                        return ListExcludedObjectsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListExcludedObjectsResponse, String>() {
+                    @Override
+                    public String apply(ListExcludedObjectsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListExcludedObjectsRequest.Builder>,
+                        ListExcludedObjectsRequest>() {
+                    @Override
+                    public ListExcludedObjectsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListExcludedObjectsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListExcludedObjectsRequest, ListExcludedObjectsResponse>() {
+                    @Override
+                    public ListExcludedObjectsResponse apply(ListExcludedObjectsRequest request) {
+                        return client.listExcludedObjects(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.databasemigration.model.ExcludedObjectSummary} objects
+     * contained in responses from the listExcludedObjects operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.databasemigration.model.ExcludedObjectSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.databasemigration.model.ExcludedObjectSummary>
+            listExcludedObjectsRecordIterator(final ListExcludedObjectsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListExcludedObjectsRequest.Builder, ListExcludedObjectsRequest,
+                ListExcludedObjectsResponse,
+                com.oracle.bmc.databasemigration.model.ExcludedObjectSummary>(
+                new com.google.common.base.Supplier<ListExcludedObjectsRequest.Builder>() {
+                    @Override
+                    public ListExcludedObjectsRequest.Builder get() {
+                        return ListExcludedObjectsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListExcludedObjectsResponse, String>() {
+                    @Override
+                    public String apply(ListExcludedObjectsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListExcludedObjectsRequest.Builder>,
+                        ListExcludedObjectsRequest>() {
+                    @Override
+                    public ListExcludedObjectsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListExcludedObjectsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListExcludedObjectsRequest, ListExcludedObjectsResponse>() {
+                    @Override
+                    public ListExcludedObjectsResponse apply(ListExcludedObjectsRequest request) {
+                        return client.listExcludedObjects(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListExcludedObjectsResponse,
+                        java.util.List<
+                                com.oracle.bmc.databasemigration.model.ExcludedObjectSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.databasemigration.model.ExcludedObjectSummary>
+                            apply(ListExcludedObjectsResponse response) {
+                        return response.getExcludedObjectSummaryCollection().getItems();
+                    }
+                });
+    }
+
+    /**
      * Creates a new iterable which will iterate over the responses received from the listJobOutputs operation. This iterable
      * will fetch more data from the server as needed.
      *
@@ -703,6 +819,122 @@ public class DatabaseMigrationPaginators {
                                             .MigrationObjectTypeSummary>
                             apply(ListMigrationObjectTypesResponse response) {
                         return response.getMigrationObjectTypeSummaryCollection().getItems();
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the responses received from the listMigrationObjects operation. This iterable
+     * will fetch more data from the server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the responses received from the service.
+     */
+    public Iterable<ListMigrationObjectsResponse> listMigrationObjectsResponseIterator(
+            final ListMigrationObjectsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseIterable<
+                ListMigrationObjectsRequest.Builder, ListMigrationObjectsRequest,
+                ListMigrationObjectsResponse>(
+                new com.google.common.base.Supplier<ListMigrationObjectsRequest.Builder>() {
+                    @Override
+                    public ListMigrationObjectsRequest.Builder get() {
+                        return ListMigrationObjectsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListMigrationObjectsResponse, String>() {
+                    @Override
+                    public String apply(ListMigrationObjectsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListMigrationObjectsRequest.Builder>,
+                        ListMigrationObjectsRequest>() {
+                    @Override
+                    public ListMigrationObjectsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListMigrationObjectsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListMigrationObjectsRequest, ListMigrationObjectsResponse>() {
+                    @Override
+                    public ListMigrationObjectsResponse apply(ListMigrationObjectsRequest request) {
+                        return client.listMigrationObjects(request);
+                    }
+                });
+    }
+
+    /**
+     * Creates a new iterable which will iterate over the {@link com.oracle.bmc.databasemigration.model.MigrationObjectSummary} objects
+     * contained in responses from the listMigrationObjects operation. This iterable will fetch more data from the
+     * server as needed.
+     *
+     * @param request a request which can be sent to the service operation
+     * @return an {@link java.lang.Iterable} which can be used to iterate over the {@link com.oracle.bmc.databasemigration.model.MigrationObjectSummary} objects
+     * contained in responses received from the service.
+     */
+    public Iterable<com.oracle.bmc.databasemigration.model.MigrationObjectSummary>
+            listMigrationObjectsRecordIterator(final ListMigrationObjectsRequest request) {
+        return new com.oracle.bmc.paginator.internal.ResponseRecordIterable<
+                ListMigrationObjectsRequest.Builder, ListMigrationObjectsRequest,
+                ListMigrationObjectsResponse,
+                com.oracle.bmc.databasemigration.model.MigrationObjectSummary>(
+                new com.google.common.base.Supplier<ListMigrationObjectsRequest.Builder>() {
+                    @Override
+                    public ListMigrationObjectsRequest.Builder get() {
+                        return ListMigrationObjectsRequest.builder().copy(request);
+                    }
+                },
+                new com.google.common.base.Function<ListMigrationObjectsResponse, String>() {
+                    @Override
+                    public String apply(ListMigrationObjectsResponse response) {
+                        return response.getOpcNextPage();
+                    }
+                },
+                new com.google.common.base.Function<
+                        com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                ListMigrationObjectsRequest.Builder>,
+                        ListMigrationObjectsRequest>() {
+                    @Override
+                    public ListMigrationObjectsRequest apply(
+                            com.oracle.bmc.paginator.internal.RequestBuilderAndToken<
+                                            ListMigrationObjectsRequest.Builder>
+                                    input) {
+                        if (input.getToken() == null) {
+                            return input.getRequestBuilder().build();
+                        } else {
+                            return input.getRequestBuilder()
+                                    .page(input.getToken().orNull())
+                                    .build();
+                        }
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListMigrationObjectsRequest, ListMigrationObjectsResponse>() {
+                    @Override
+                    public ListMigrationObjectsResponse apply(ListMigrationObjectsRequest request) {
+                        return client.listMigrationObjects(request);
+                    }
+                },
+                new com.google.common.base.Function<
+                        ListMigrationObjectsResponse,
+                        java.util.List<
+                                com.oracle.bmc.databasemigration.model.MigrationObjectSummary>>() {
+                    @Override
+                    public java.util.List<
+                                    com.oracle.bmc.databasemigration.model.MigrationObjectSummary>
+                            apply(ListMigrationObjectsResponse response) {
+                        return response.getMigrationObjectCollection().getItems();
                     }
                 });
     }

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/AddMigrationObjectsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/AddMigrationObjectsConverter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemigration.model.*;
+import com.oracle.bmc.databasemigration.requests.*;
+import com.oracle.bmc.databasemigration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public class AddMigrationObjectsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemigration.requests.AddMigrationObjectsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemigration.requests.AddMigrationObjectsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemigration.requests.AddMigrationObjectsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getMigrationId(), "migrationId must not be blank");
+        Validate.notNull(
+                request.getAddMigrationObjectsDetails(), "addMigrationObjectsDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210929")
+                        .path("migrations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getMigrationId()))
+                        .path("actions")
+                        .path("addMigrationObjects");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemigration.responses.AddMigrationObjectsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemigration.responses.AddMigrationObjectsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemigration.responses
+                                        .AddMigrationObjectsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemigration.responses
+                                            .AddMigrationObjectsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemigration.responses.AddMigrationObjectsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .AddMigrationObjectsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemigration.responses
+                                                        .AddMigrationObjectsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .AddMigrationObjectsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListExcludedObjectsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListExcludedObjectsConverter.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemigration.model.*;
+import com.oracle.bmc.databasemigration.requests.*;
+import com.oracle.bmc.databasemigration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public class ListExcludedObjectsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemigration.requests.ListExcludedObjectsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemigration.requests.ListExcludedObjectsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemigration.requests.ListExcludedObjectsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getJobId(), "jobId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210929")
+                        .path("jobs")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getJobId()))
+                        .path("excludedObjects");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        if (request.getSortOrder() != null) {
+            target =
+                    target.queryParam(
+                            "sortOrder",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortOrder().getValue()));
+        }
+
+        if (request.getSortBy() != null) {
+            target =
+                    target.queryParam(
+                            "sortBy",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSortBy().getValue()));
+        }
+
+        if (request.getType() != null) {
+            target =
+                    target.queryParam(
+                            "type",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getType()));
+        }
+
+        if (request.getOwner() != null) {
+            target =
+                    target.queryParam(
+                            "owner",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getOwner()));
+        }
+
+        if (request.getObject() != null) {
+            target =
+                    target.queryParam(
+                            "object",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getObject()));
+        }
+
+        if (request.getOwnerContains() != null) {
+            target =
+                    target.queryParam(
+                            "ownerContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getOwnerContains()));
+        }
+
+        if (request.getObjectContains() != null) {
+            target =
+                    target.queryParam(
+                            "objectContains",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getObjectContains()));
+        }
+
+        if (request.getReasonCategory() != null) {
+            target =
+                    target.queryParam(
+                            "reasonCategory",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getReasonCategory().getValue()));
+        }
+
+        if (request.getSourceRule() != null) {
+            target =
+                    target.queryParam(
+                            "sourceRule",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getSourceRule()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemigration.responses.ListExcludedObjectsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemigration.responses.ListExcludedObjectsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemigration.responses
+                                        .ListExcludedObjectsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemigration.responses
+                                            .ListExcludedObjectsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemigration.responses.ListExcludedObjectsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.databasemigration.model
+                                                                .ExcludedObjectSummaryCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.databasemigration.model
+                                                                        .ExcludedObjectSummaryCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.databasemigration.model
+                                                        .ExcludedObjectSummaryCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .ListExcludedObjectsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemigration.responses
+                                                        .ListExcludedObjectsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.excludedObjectSummaryCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .ListExcludedObjectsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListMigrationObjectsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/ListMigrationObjectsConverter.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemigration.model.*;
+import com.oracle.bmc.databasemigration.requests.*;
+import com.oracle.bmc.databasemigration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public class ListMigrationObjectsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemigration.requests.ListMigrationObjectsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemigration.requests.ListMigrationObjectsRequest request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemigration.requests.ListMigrationObjectsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getMigrationId(), "migrationId must not be blank");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210929")
+                        .path("migrations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getMigrationId()))
+                        .path("migrationObjects");
+
+        if (request.getLimit() != null) {
+            target =
+                    target.queryParam(
+                            "limit",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getLimit()));
+        }
+
+        if (request.getPage() != null) {
+            target =
+                    target.queryParam(
+                            "page",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getPage()));
+        }
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemigration.responses.ListMigrationObjectsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemigration.responses.ListMigrationObjectsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemigration.responses
+                                        .ListMigrationObjectsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemigration.responses
+                                            .ListMigrationObjectsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemigration.responses.ListMigrationObjectsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<
+                                                        com.oracle.bmc.databasemigration.model
+                                                                .MigrationObjectCollection>>
+                                        responseFn =
+                                                RESPONSE_CONVERSION_FACTORY.create(
+                                                        com.oracle.bmc.databasemigration.model
+                                                                        .MigrationObjectCollection
+                                                                .class);
+
+                                com.oracle.bmc.http.internal.WithHeaders<
+                                                com.oracle.bmc.databasemigration.model
+                                                        .MigrationObjectCollection>
+                                        response = responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .ListMigrationObjectsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemigration.responses
+                                                        .ListMigrationObjectsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                builder.migrationObjectCollection(response.getItem());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcNextPageHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-next-page");
+                                if (opcNextPageHeader.isPresent()) {
+                                    builder.opcNextPage(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-next-page",
+                                                    opcNextPageHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .ListMigrationObjectsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/RemoveMigrationObjectsConverter.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/internal/http/RemoveMigrationObjectsConverter.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.internal.http;
+
+import com.oracle.bmc.http.internal.ResponseHelper;
+import com.oracle.bmc.databasemigration.model.*;
+import com.oracle.bmc.databasemigration.requests.*;
+import com.oracle.bmc.databasemigration.responses.*;
+import org.apache.commons.lang3.Validate;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public class RemoveMigrationObjectsConverter {
+    private static final com.oracle.bmc.http.internal.ResponseConversionFunctionFactory
+            RESPONSE_CONVERSION_FACTORY =
+                    new com.oracle.bmc.http.internal.ResponseConversionFunctionFactory();
+
+    public static com.oracle.bmc.databasemigration.requests.RemoveMigrationObjectsRequest
+            interceptRequest(
+                    com.oracle.bmc.databasemigration.requests.RemoveMigrationObjectsRequest
+                            request) {
+
+        return request;
+    }
+
+    public static com.oracle.bmc.http.internal.WrappedInvocationBuilder fromRequest(
+            com.oracle.bmc.http.internal.RestClient client,
+            com.oracle.bmc.databasemigration.requests.RemoveMigrationObjectsRequest request) {
+        Validate.notNull(request, "request instance is required");
+        Validate.notBlank(request.getMigrationId(), "migrationId must not be blank");
+        Validate.notNull(
+                request.getRemoveMigrationObjectsDetails(),
+                "removeMigrationObjectsDetails is required");
+
+        com.oracle.bmc.http.internal.WrappedWebTarget target =
+                client.getBaseTarget()
+                        .path("/20210929")
+                        .path("migrations")
+                        .path(
+                                com.oracle.bmc.util.internal.HttpUtils.encodePathSegment(
+                                        request.getMigrationId()))
+                        .path("actions")
+                        .path("removeMigrationObjects");
+
+        com.oracle.bmc.http.internal.WrappedInvocationBuilder ib = target.request();
+
+        ib.accept(javax.ws.rs.core.MediaType.APPLICATION_JSON);
+
+        if (request.getOpcRequestId() != null) {
+            ib.header("opc-request-id", request.getOpcRequestId());
+        }
+
+        if (request.getIfMatch() != null) {
+            ib.header("if-match", request.getIfMatch());
+        }
+
+        if (client.getClientConfigurator() != null) {
+            client.getClientConfigurator().customizeRequest(request, ib);
+        }
+        return ib;
+    }
+
+    public static com.google.common.base.Function<
+                    javax.ws.rs.core.Response,
+                    com.oracle.bmc.databasemigration.responses.RemoveMigrationObjectsResponse>
+            fromResponse() {
+        final com.google.common.base.Function<
+                        javax.ws.rs.core.Response,
+                        com.oracle.bmc.databasemigration.responses.RemoveMigrationObjectsResponse>
+                transformer =
+                        new com.google.common.base.Function<
+                                javax.ws.rs.core.Response,
+                                com.oracle.bmc.databasemigration.responses
+                                        .RemoveMigrationObjectsResponse>() {
+                            @Override
+                            public com.oracle.bmc.databasemigration.responses
+                                            .RemoveMigrationObjectsResponse
+                                    apply(javax.ws.rs.core.Response rawResponse) {
+                                LOG.trace(
+                                        "Transform function invoked for com.oracle.bmc.databasemigration.responses.RemoveMigrationObjectsResponse");
+                                com.google.common.base.Function<
+                                                javax.ws.rs.core.Response,
+                                                com.oracle.bmc.http.internal.WithHeaders<Void>>
+                                        responseFn = RESPONSE_CONVERSION_FACTORY.create();
+
+                                com.oracle.bmc.http.internal.WithHeaders<Void> response =
+                                        responseFn.apply(rawResponse);
+                                javax.ws.rs.core.MultivaluedMap<String, String> headers =
+                                        response.getHeaders();
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .RemoveMigrationObjectsResponse.Builder
+                                        builder =
+                                                com.oracle.bmc.databasemigration.responses
+                                                        .RemoveMigrationObjectsResponse.builder()
+                                                        .__httpStatusCode__(
+                                                                rawResponse.getStatus());
+
+                                com.google.common.base.Optional<java.util.List<String>>
+                                        opcRequestIdHeader =
+                                                com.oracle.bmc.http.internal.HeaderUtils.get(
+                                                        headers, "opc-request-id");
+                                if (opcRequestIdHeader.isPresent()) {
+                                    builder.opcRequestId(
+                                            com.oracle.bmc.http.internal.HeaderUtils.toValue(
+                                                    "opc-request-id",
+                                                    opcRequestIdHeader.get().get(0),
+                                                    String.class));
+                                }
+
+                                com.oracle.bmc.databasemigration.responses
+                                                .RemoveMigrationObjectsResponse
+                                        responseWrapper = builder.build();
+
+                                ResponseHelper.closeResponseSilentlyIfNotBuffered(rawResponse);
+                                return responseWrapper;
+                            }
+                        };
+        return transformer;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ADBDedicatedAutoCreateTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ADBDedicatedAutoCreateTablespaceDetails.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for ADB-D target type using auto create feature
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ADBDedicatedAutoCreateTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ADBDedicatedAutoCreateTablespaceDetails extends TargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+        private Boolean isAutoCreate;
+
+        public Builder isAutoCreate(Boolean isAutoCreate) {
+            this.isAutoCreate = isAutoCreate;
+            this.__explicitlySet__.add("isAutoCreate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+        private Boolean isBigFile;
+
+        public Builder isBigFile(Boolean isBigFile) {
+            this.isBigFile = isBigFile;
+            this.__explicitlySet__.add("isBigFile");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+        private Integer extendSizeInMBs;
+
+        public Builder extendSizeInMBs(Integer extendSizeInMBs) {
+            this.extendSizeInMBs = extendSizeInMBs;
+            this.__explicitlySet__.add("extendSizeInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ADBDedicatedAutoCreateTablespaceDetails build() {
+            ADBDedicatedAutoCreateTablespaceDetails __instance__ =
+                    new ADBDedicatedAutoCreateTablespaceDetails(
+                            isAutoCreate, isBigFile, extendSizeInMBs);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ADBDedicatedAutoCreateTablespaceDetails o) {
+            Builder copiedBuilder =
+                    isAutoCreate(o.getIsAutoCreate())
+                            .isBigFile(o.getIsBigFile())
+                            .extendSizeInMBs(o.getExtendSizeInMBs());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ADBDedicatedAutoCreateTablespaceDetails(
+            Boolean isAutoCreate, Boolean isBigFile, Integer extendSizeInMBs) {
+        super();
+        this.isAutoCreate = isAutoCreate;
+        this.isBigFile = isBigFile;
+        this.extendSizeInMBs = extendSizeInMBs;
+    }
+
+    /**
+     * True to auto-create tablespace in the target Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+    Boolean isAutoCreate;
+
+    /**
+     * True set tablespace to big file.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+    Boolean isBigFile;
+
+    /**
+     * Size of extend in MB. Can only be specified if 'isBigFile' property is set to true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+    Integer extendSizeInMBs;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ADBDedicatedRemapTargetTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ADBDedicatedRemapTargetTablespaceDetails.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for ADB-D target type using remap feature
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ADBDedicatedRemapTargetTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ADBDedicatedRemapTargetTablespaceDetails extends TargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+        private String remapTarget;
+
+        public Builder remapTarget(String remapTarget) {
+            this.remapTarget = remapTarget;
+            this.__explicitlySet__.add("remapTarget");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ADBDedicatedRemapTargetTablespaceDetails build() {
+            ADBDedicatedRemapTargetTablespaceDetails __instance__ =
+                    new ADBDedicatedRemapTargetTablespaceDetails(remapTarget);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ADBDedicatedRemapTargetTablespaceDetails o) {
+            Builder copiedBuilder = remapTarget(o.getRemapTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ADBDedicatedRemapTargetTablespaceDetails(String remapTarget) {
+        super();
+        this.remapTarget = remapTarget;
+    }
+
+    /**
+     * Name of tablespace at target to which the source database tablespace need to be remapped.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+    String remapTarget;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ADBServerlesTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ADBServerlesTablespaceDetails.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for ADB-D target type using remap feature
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ADBServerlesTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ADBServerlesTablespaceDetails extends TargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+        private RemapTarget remapTarget;
+
+        public Builder remapTarget(RemapTarget remapTarget) {
+            this.remapTarget = remapTarget;
+            this.__explicitlySet__.add("remapTarget");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ADBServerlesTablespaceDetails build() {
+            ADBServerlesTablespaceDetails __instance__ =
+                    new ADBServerlesTablespaceDetails(remapTarget);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ADBServerlesTablespaceDetails o) {
+            Builder copiedBuilder = remapTarget(o.getRemapTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public ADBServerlesTablespaceDetails(RemapTarget remapTarget) {
+        super();
+        this.remapTarget = remapTarget;
+    }
+
+    /**
+     * Name of tablespace at target to which the source database tablespace need to be remapped.
+     *
+     **/
+    @lombok.extern.slf4j.Slf4j
+    public enum RemapTarget {
+        Data("DATA"),
+
+        /**
+         * This value is used if a service returns a value for this enum that is not recognized by this
+         * version of the SDK.
+         */
+        UnknownEnumValue(null);
+
+        private final String value;
+        private static java.util.Map<String, RemapTarget> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (RemapTarget v : RemapTarget.values()) {
+                if (v != UnknownEnumValue) {
+                    map.put(v.getValue(), v);
+                }
+            }
+        }
+
+        RemapTarget(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static RemapTarget create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            LOG.warn(
+                    "Received unknown value '{}' for enum 'RemapTarget', returning UnknownEnumValue",
+                    key);
+            return UnknownEnumValue;
+        }
+    };
+    /**
+     * Name of tablespace at target to which the source database tablespace need to be remapped.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+    RemapTarget remapTarget;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AwsS3Details.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/AwsS3Details.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * AWS S3 bucket details used for source Connection resources with RDS_ORACLE type.
+ * Only supported for source Connection resources with RDS_ORACLE type.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = AwsS3Details.Builder.class)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class AwsS3Details {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("region")
+        private String region;
+
+        public Builder region(String region) {
+            this.region = region;
+            this.__explicitlySet__.add("region");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public AwsS3Details build() {
+            AwsS3Details __instance__ = new AwsS3Details(name, region);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(AwsS3Details o) {
+            Builder copiedBuilder = name(o.getName()).region(o.getRegion());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * S3 bucket name.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * AWS region code where the S3 bucket is located.
+     * Region code should match the documented available regions:
+     * https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("region")
+    String region;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Connection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/Connection.java
@@ -52,6 +52,25 @@ public class Connection {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("manualDatabaseSubType")
+        private DatabaseManualConnectionSubTypes manualDatabaseSubType;
+
+        public Builder manualDatabaseSubType(
+                DatabaseManualConnectionSubTypes manualDatabaseSubType) {
+            this.manualDatabaseSubType = manualDatabaseSubType;
+            this.__explicitlySet__.add("manualDatabaseSubType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDedicated")
+        private Boolean isDedicated;
+
+        public Builder isDedicated(Boolean isDedicated) {
+            this.isDedicated = isDedicated;
+            this.__explicitlySet__.add("isDedicated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("displayName")
         private String displayName;
 
@@ -206,6 +225,8 @@ public class Connection {
                             id,
                             compartmentId,
                             databaseType,
+                            manualDatabaseSubType,
+                            isDedicated,
                             displayName,
                             databaseId,
                             connectDescriptor,
@@ -232,6 +253,8 @@ public class Connection {
                     id(o.getId())
                             .compartmentId(o.getCompartmentId())
                             .databaseType(o.getDatabaseType())
+                            .manualDatabaseSubType(o.getManualDatabaseSubType())
+                            .isDedicated(o.getIsDedicated())
                             .displayName(o.getDisplayName())
                             .databaseId(o.getDatabaseId())
                             .connectDescriptor(o.getConnectDescriptor())
@@ -281,6 +304,20 @@ public class Connection {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("databaseType")
     DatabaseConnectionTypes databaseType;
+
+    /**
+     * Database manual connection subtype. This value can only be specified for manual connections.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("manualDatabaseSubType")
+    DatabaseManualConnectionSubTypes manualDatabaseSubType;
+
+    /**
+     * True if the Autonomous Connection is dedicated. Not provided for Non-Autonomous Connections.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDedicated")
+    Boolean isDedicated;
 
     /**
      * Database Connection display name identifier.

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ConnectionSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ConnectionSummary.java
@@ -54,6 +54,25 @@ public class ConnectionSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("manualDatabaseSubType")
+        private DatabaseManualConnectionSubTypes manualDatabaseSubType;
+
+        public Builder manualDatabaseSubType(
+                DatabaseManualConnectionSubTypes manualDatabaseSubType) {
+            this.manualDatabaseSubType = manualDatabaseSubType;
+            this.__explicitlySet__.add("manualDatabaseSubType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isDedicated")
+        private Boolean isDedicated;
+
+        public Builder isDedicated(Boolean isDedicated) {
+            this.isDedicated = isDedicated;
+            this.__explicitlySet__.add("isDedicated");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("displayName")
         private String displayName;
 
@@ -145,6 +164,8 @@ public class ConnectionSummary {
                             id,
                             compartmentId,
                             databaseType,
+                            manualDatabaseSubType,
+                            isDedicated,
                             displayName,
                             databaseId,
                             timeCreated,
@@ -164,6 +185,8 @@ public class ConnectionSummary {
                     id(o.getId())
                             .compartmentId(o.getCompartmentId())
                             .databaseType(o.getDatabaseType())
+                            .manualDatabaseSubType(o.getManualDatabaseSubType())
+                            .isDedicated(o.getIsDedicated())
                             .displayName(o.getDisplayName())
                             .databaseId(o.getDatabaseId())
                             .timeCreated(o.getTimeCreated())
@@ -206,6 +229,20 @@ public class ConnectionSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("databaseType")
     DatabaseConnectionTypes databaseType;
+
+    /**
+     * Database manual connection subtype. This value can only be specified for manual connections.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("manualDatabaseSubType")
+    DatabaseManualConnectionSubTypes manualDatabaseSubType;
+
+    /**
+     * True if the Autonomous Connection is dedicated. Not provided for Non-Autonomous Connections.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isDedicated")
+    Boolean isDedicated;
 
     /**
      * Database Connection display name identifier.

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateADBDedicatedAutoCreateTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateADBDedicatedAutoCreateTablespaceDetails.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for ADB-D target type using auto create feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateADBDedicatedAutoCreateTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateADBDedicatedAutoCreateTablespaceDetails
+        extends CreateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+        private Boolean isAutoCreate;
+
+        public Builder isAutoCreate(Boolean isAutoCreate) {
+            this.isAutoCreate = isAutoCreate;
+            this.__explicitlySet__.add("isAutoCreate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+        private Boolean isBigFile;
+
+        public Builder isBigFile(Boolean isBigFile) {
+            this.isBigFile = isBigFile;
+            this.__explicitlySet__.add("isBigFile");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+        private Integer extendSizeInMBs;
+
+        public Builder extendSizeInMBs(Integer extendSizeInMBs) {
+            this.extendSizeInMBs = extendSizeInMBs;
+            this.__explicitlySet__.add("extendSizeInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateADBDedicatedAutoCreateTablespaceDetails build() {
+            CreateADBDedicatedAutoCreateTablespaceDetails __instance__ =
+                    new CreateADBDedicatedAutoCreateTablespaceDetails(
+                            isAutoCreate, isBigFile, extendSizeInMBs);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateADBDedicatedAutoCreateTablespaceDetails o) {
+            Builder copiedBuilder =
+                    isAutoCreate(o.getIsAutoCreate())
+                            .isBigFile(o.getIsBigFile())
+                            .extendSizeInMBs(o.getExtendSizeInMBs());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateADBDedicatedAutoCreateTablespaceDetails(
+            Boolean isAutoCreate, Boolean isBigFile, Integer extendSizeInMBs) {
+        super();
+        this.isAutoCreate = isAutoCreate;
+        this.isBigFile = isBigFile;
+        this.extendSizeInMBs = extendSizeInMBs;
+    }
+
+    /**
+     * True to auto-create tablespace in the target Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+    Boolean isAutoCreate;
+
+    /**
+     * True set tablespace to big file.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+    Boolean isBigFile;
+
+    /**
+     * Size of extend in MB. Can only be specified if 'isBigFile' property is set to true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+    Integer extendSizeInMBs;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateADBDedicatedRemapTargetTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateADBDedicatedRemapTargetTablespaceDetails.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for ADB-D target type using remap feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateADBDedicatedRemapTargetTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateADBDedicatedRemapTargetTablespaceDetails
+        extends CreateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+        private String remapTarget;
+
+        public Builder remapTarget(String remapTarget) {
+            this.remapTarget = remapTarget;
+            this.__explicitlySet__.add("remapTarget");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateADBDedicatedRemapTargetTablespaceDetails build() {
+            CreateADBDedicatedRemapTargetTablespaceDetails __instance__ =
+                    new CreateADBDedicatedRemapTargetTablespaceDetails(remapTarget);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateADBDedicatedRemapTargetTablespaceDetails o) {
+            Builder copiedBuilder = remapTarget(o.getRemapTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateADBDedicatedRemapTargetTablespaceDetails(String remapTarget) {
+        super();
+        this.remapTarget = remapTarget;
+    }
+
+    /**
+     * Name of tablespace at target to which the source database tablespace need to be remapped.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+    String remapTarget;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateADBServerlesTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateADBServerlesTablespaceDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for ADB-S target type using remap feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateADBServerlesTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateADBServerlesTablespaceDetails extends CreateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateADBServerlesTablespaceDetails build() {
+            CreateADBServerlesTablespaceDetails __instance__ =
+                    new CreateADBServerlesTablespaceDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateADBServerlesTablespaceDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateADBServerlesTablespaceDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAwsS3Details.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateAwsS3Details.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * AWS S3 bucket details used for source Connection resources with RDS_ORACLE type.
+ * Only supported for source Connection resources with RDS_ORACLE type.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateAwsS3Details.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateAwsS3Details {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("region")
+        private String region;
+
+        public Builder region(String region) {
+            this.region = region;
+            this.__explicitlySet__.add("region");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("accessKeyId")
+        private String accessKeyId;
+
+        public Builder accessKeyId(String accessKeyId) {
+            this.accessKeyId = accessKeyId;
+            this.__explicitlySet__.add("accessKeyId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("secretAccessKey")
+        private String secretAccessKey;
+
+        public Builder secretAccessKey(String secretAccessKey) {
+            this.secretAccessKey = secretAccessKey;
+            this.__explicitlySet__.add("secretAccessKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateAwsS3Details build() {
+            CreateAwsS3Details __instance__ =
+                    new CreateAwsS3Details(name, region, accessKeyId, secretAccessKey);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateAwsS3Details o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .region(o.getRegion())
+                            .accessKeyId(o.getAccessKeyId())
+                            .secretAccessKey(o.getSecretAccessKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * S3 bucket name.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * AWS region code where the S3 bucket is located.
+     * Region code should match the documented available regions:
+     * https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("region")
+    String region;
+
+    /**
+     * AWS access key credentials identifier
+     * Details: https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("accessKeyId")
+    String accessKeyId;
+
+    /**
+     * AWS secret access key credentials
+     * Details: https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("secretAccessKey")
+    String secretAccessKey;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateConnectionDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateConnectionDetails.java
@@ -54,6 +54,16 @@ public class CreateConnectionDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("manualDatabaseSubType")
+        private DatabaseManualConnectionSubTypes manualDatabaseSubType;
+
+        public Builder manualDatabaseSubType(
+                DatabaseManualConnectionSubTypes manualDatabaseSubType) {
+            this.manualDatabaseSubType = manualDatabaseSubType;
+            this.__explicitlySet__.add("manualDatabaseSubType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("databaseId")
         private String databaseId;
 
@@ -163,6 +173,7 @@ public class CreateConnectionDetails {
                             compartmentId,
                             displayName,
                             databaseType,
+                            manualDatabaseSubType,
                             databaseId,
                             connectDescriptor,
                             certificateTdn,
@@ -184,6 +195,7 @@ public class CreateConnectionDetails {
                     compartmentId(o.getCompartmentId())
                             .displayName(o.getDisplayName())
                             .databaseType(o.getDatabaseType())
+                            .manualDatabaseSubType(o.getManualDatabaseSubType())
                             .databaseId(o.getDatabaseId())
                             .connectDescriptor(o.getConnectDescriptor())
                             .certificateTdn(o.getCertificateTdn())
@@ -228,6 +240,13 @@ public class CreateConnectionDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("databaseType")
     DatabaseConnectionTypes databaseType;
+
+    /**
+     * Database manual connection subtype. This value can only be specified for manual connections.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("manualDatabaseSubType")
+    DatabaseManualConnectionSubTypes manualDatabaseSubType;
 
     /**
      * The OCID of the cloud database. Required if the database connection type is Autonomous.

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataPumpSettings.java
@@ -54,6 +54,15 @@ public class CreateDataPumpSettings {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("tablespaceDetails")
+        private CreateTargetTypeTablespaceDetails tablespaceDetails;
+
+        public Builder tablespaceDetails(CreateTargetTypeTablespaceDetails tablespaceDetails) {
+            this.tablespaceDetails = tablespaceDetails;
+            this.__explicitlySet__.add("tablespaceDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("exportDirectoryObject")
         private CreateDirectoryObject exportDirectoryObject;
 
@@ -81,6 +90,7 @@ public class CreateDataPumpSettings {
                             jobMode,
                             dataPumpParameters,
                             metadataRemaps,
+                            tablespaceDetails,
                             exportDirectoryObject,
                             importDirectoryObject);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -93,6 +103,7 @@ public class CreateDataPumpSettings {
                     jobMode(o.getJobMode())
                             .dataPumpParameters(o.getDataPumpParameters())
                             .metadataRemaps(o.getMetadataRemaps())
+                            .tablespaceDetails(o.getTablespaceDetails())
                             .exportDirectoryObject(o.getExportDirectoryObject())
                             .importDirectoryObject(o.getImportDirectoryObject());
 
@@ -126,6 +137,9 @@ public class CreateDataPumpSettings {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadataRemaps")
     java.util.List<MetadataRemap> metadataRemaps;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("tablespaceDetails")
+    CreateTargetTypeTablespaceDetails tablespaceDetails;
 
     @com.fasterxml.jackson.annotation.JsonProperty("exportDirectoryObject")
     CreateDirectoryObject exportDirectoryObject;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataTransferMediumDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateDataTransferMediumDetails.java
@@ -6,7 +6,8 @@ package com.oracle.bmc.databasemigration.model;
 
 /**
  * Data Transfer Medium details for the Migration. If not specified, it will default to Database Link. Only one type
- * of data transfer medium can be specified.
+ * of data transfer medium can be specified, except for the case of Amazon RDS Oracle as source, where Object Storage
+ * Details along with AwsS3Details are required.
  *
  * <br/>
  * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
@@ -46,12 +47,22 @@ public class CreateDataTransferMediumDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("awsS3Details")
+        private CreateAwsS3Details awsS3Details;
+
+        public Builder awsS3Details(CreateAwsS3Details awsS3Details) {
+            this.awsS3Details = awsS3Details;
+            this.__explicitlySet__.add("awsS3Details");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public CreateDataTransferMediumDetails build() {
             CreateDataTransferMediumDetails __instance__ =
-                    new CreateDataTransferMediumDetails(databaseLinkDetails, objectStorageDetails);
+                    new CreateDataTransferMediumDetails(
+                            databaseLinkDetails, objectStorageDetails, awsS3Details);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -60,7 +71,8 @@ public class CreateDataTransferMediumDetails {
         public Builder copy(CreateDataTransferMediumDetails o) {
             Builder copiedBuilder =
                     databaseLinkDetails(o.getDatabaseLinkDetails())
-                            .objectStorageDetails(o.getObjectStorageDetails());
+                            .objectStorageDetails(o.getObjectStorageDetails())
+                            .awsS3Details(o.getAwsS3Details());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -79,6 +91,9 @@ public class CreateDataTransferMediumDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("objectStorageDetails")
     CreateObjectStoreBucket objectStorageDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("awsS3Details")
+    CreateAwsS3Details awsS3Details;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateNonADBAutoCreateTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateNonADBAutoCreateTablespaceDetails.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for NON-ADB target type using auto create feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateNonADBAutoCreateTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateNonADBAutoCreateTablespaceDetails extends CreateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+        private Boolean isAutoCreate;
+
+        public Builder isAutoCreate(Boolean isAutoCreate) {
+            this.isAutoCreate = isAutoCreate;
+            this.__explicitlySet__.add("isAutoCreate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+        private Boolean isBigFile;
+
+        public Builder isBigFile(Boolean isBigFile) {
+            this.isBigFile = isBigFile;
+            this.__explicitlySet__.add("isBigFile");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+        private Integer extendSizeInMBs;
+
+        public Builder extendSizeInMBs(Integer extendSizeInMBs) {
+            this.extendSizeInMBs = extendSizeInMBs;
+            this.__explicitlySet__.add("extendSizeInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateNonADBAutoCreateTablespaceDetails build() {
+            CreateNonADBAutoCreateTablespaceDetails __instance__ =
+                    new CreateNonADBAutoCreateTablespaceDetails(
+                            isAutoCreate, isBigFile, extendSizeInMBs);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateNonADBAutoCreateTablespaceDetails o) {
+            Builder copiedBuilder =
+                    isAutoCreate(o.getIsAutoCreate())
+                            .isBigFile(o.getIsBigFile())
+                            .extendSizeInMBs(o.getExtendSizeInMBs());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateNonADBAutoCreateTablespaceDetails(
+            Boolean isAutoCreate, Boolean isBigFile, Integer extendSizeInMBs) {
+        super();
+        this.isAutoCreate = isAutoCreate;
+        this.isBigFile = isBigFile;
+        this.extendSizeInMBs = extendSizeInMBs;
+    }
+
+    /**
+     * True to auto-create tablespace in the target Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+    Boolean isAutoCreate;
+
+    /**
+     * True set tablespace to big file.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+    Boolean isBigFile;
+
+    /**
+     * Size of extend in MB. Can only be specified if 'isBigFile' property is set to true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+    Integer extendSizeInMBs;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateNonADBRemapTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateNonADBRemapTablespaceDetails.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for NON-ADB target type using remap feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = CreateNonADBRemapTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class CreateNonADBRemapTablespaceDetails extends CreateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+        private String remapTarget;
+
+        public Builder remapTarget(String remapTarget) {
+            this.remapTarget = remapTarget;
+            this.__explicitlySet__.add("remapTarget");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public CreateNonADBRemapTablespaceDetails build() {
+            CreateNonADBRemapTablespaceDetails __instance__ =
+                    new CreateNonADBRemapTablespaceDetails(remapTarget);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(CreateNonADBRemapTablespaceDetails o) {
+            Builder copiedBuilder = remapTarget(o.getRemapTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public CreateNonADBRemapTablespaceDetails(String remapTarget) {
+        super();
+        this.remapTarget = remapTarget;
+    }
+
+    /**
+     * Name of tablespace at target to which the source database tablespace need to be remapped.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+    String remapTarget;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateTargetTypeTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/CreateTargetTypeTablespaceDetails.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType",
+    defaultImpl = CreateTargetTypeTablespaceDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateNonADBAutoCreateTablespaceDetails.class,
+        name = "NON_ADB_AUTOCREATE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateNonADBRemapTablespaceDetails.class,
+        name = "NON_ADB_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateADBDedicatedRemapTargetTablespaceDetails.class,
+        name = "ADB_D_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateADBServerlesTablespaceDetails.class,
+        name = "ADB_S_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = CreateADBDedicatedAutoCreateTablespaceDetails.class,
+        name = "ADB_D_AUTOCREATE"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class CreateTargetTypeTablespaceDetails {}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataPumpSettings.java
@@ -52,6 +52,15 @@ public class DataPumpSettings {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("tablespaceDetails")
+        private TargetTypeTablespaceDetails tablespaceDetails;
+
+        public Builder tablespaceDetails(TargetTypeTablespaceDetails tablespaceDetails) {
+            this.tablespaceDetails = tablespaceDetails;
+            this.__explicitlySet__.add("tablespaceDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("exportDirectoryObject")
         private DirectoryObject exportDirectoryObject;
 
@@ -79,6 +88,7 @@ public class DataPumpSettings {
                             jobMode,
                             dataPumpParameters,
                             metadataRemaps,
+                            tablespaceDetails,
                             exportDirectoryObject,
                             importDirectoryObject);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -91,6 +101,7 @@ public class DataPumpSettings {
                     jobMode(o.getJobMode())
                             .dataPumpParameters(o.getDataPumpParameters())
                             .metadataRemaps(o.getMetadataRemaps())
+                            .tablespaceDetails(o.getTablespaceDetails())
                             .exportDirectoryObject(o.getExportDirectoryObject())
                             .importDirectoryObject(o.getImportDirectoryObject());
 
@@ -124,6 +135,9 @@ public class DataPumpSettings {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadataRemaps")
     java.util.List<MetadataRemap> metadataRemaps;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("tablespaceDetails")
+    TargetTypeTablespaceDetails tablespaceDetails;
 
     @com.fasterxml.jackson.annotation.JsonProperty("exportDirectoryObject")
     DirectoryObject exportDirectoryObject;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataTransferMediumDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DataTransferMediumDetails.java
@@ -45,12 +45,22 @@ public class DataTransferMediumDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("awsS3Details")
+        private AwsS3Details awsS3Details;
+
+        public Builder awsS3Details(AwsS3Details awsS3Details) {
+            this.awsS3Details = awsS3Details;
+            this.__explicitlySet__.add("awsS3Details");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public DataTransferMediumDetails build() {
             DataTransferMediumDetails __instance__ =
-                    new DataTransferMediumDetails(databaseLinkDetails, objectStorageDetails);
+                    new DataTransferMediumDetails(
+                            databaseLinkDetails, objectStorageDetails, awsS3Details);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -59,7 +69,8 @@ public class DataTransferMediumDetails {
         public Builder copy(DataTransferMediumDetails o) {
             Builder copiedBuilder =
                     databaseLinkDetails(o.getDatabaseLinkDetails())
-                            .objectStorageDetails(o.getObjectStorageDetails());
+                            .objectStorageDetails(o.getObjectStorageDetails())
+                            .awsS3Details(o.getAwsS3Details());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -78,6 +89,9 @@ public class DataTransferMediumDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("objectStorageDetails")
     ObjectStoreBucket objectStorageDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("awsS3Details")
+    AwsS3Details awsS3Details;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DatabaseManualConnectionSubTypes.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/DatabaseManualConnectionSubTypes.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Supported database manual connection subtypes
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public enum DatabaseManualConnectionSubTypes {
+    Oracle("ORACLE"),
+    RdsOracle("RDS_ORACLE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, DatabaseManualConnectionSubTypes> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (DatabaseManualConnectionSubTypes v : DatabaseManualConnectionSubTypes.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    DatabaseManualConnectionSubTypes(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static DatabaseManualConnectionSubTypes create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'DatabaseManualConnectionSubTypes', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExcludedObjectSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExcludedObjectSummary.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Excluded object summary line.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ExcludedObjectSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ExcludedObjectSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("owner")
+        private String owner;
+
+        public Builder owner(String owner) {
+            this.owner = owner;
+            this.__explicitlySet__.add("owner");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("object")
+        private String object;
+
+        public Builder object(String object) {
+            this.object = object;
+            this.__explicitlySet__.add("object");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private String type;
+
+        public Builder type(String type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("reasonCategory")
+        private ReasonKeywords reasonCategory;
+
+        public Builder reasonCategory(ReasonKeywords reasonCategory) {
+            this.reasonCategory = reasonCategory;
+            this.__explicitlySet__.add("reasonCategory");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("sourceRule")
+        private String sourceRule;
+
+        public Builder sourceRule(String sourceRule) {
+            this.sourceRule = sourceRule;
+            this.__explicitlySet__.add("sourceRule");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ExcludedObjectSummary build() {
+            ExcludedObjectSummary __instance__ =
+                    new ExcludedObjectSummary(owner, object, type, reasonCategory, sourceRule);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ExcludedObjectSummary o) {
+            Builder copiedBuilder =
+                    owner(o.getOwner())
+                            .object(o.getObject())
+                            .type(o.getType())
+                            .reasonCategory(o.getReasonCategory())
+                            .sourceRule(o.getSourceRule());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Database object owner.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("owner")
+    String owner;
+
+    /**
+     * Database object name.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("object")
+    String object;
+
+    /**
+     * Database object type.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    String type;
+
+    /**
+     * Reason category for object exclusion.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("reasonCategory")
+    ReasonKeywords reasonCategory;
+
+    /**
+     * Reason for exclusion.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("sourceRule")
+    String sourceRule;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExcludedObjectSummaryCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExcludedObjectSummaryCollection.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Results of a Job's Exclude objects output listing. Contains ExcludedObjectSummary items.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = ExcludedObjectSummaryCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class ExcludedObjectSummaryCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<ExcludedObjectSummary> items;
+
+        public Builder items(java.util.List<ExcludedObjectSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public ExcludedObjectSummaryCollection build() {
+            ExcludedObjectSummaryCollection __instance__ =
+                    new ExcludedObjectSummaryCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(ExcludedObjectSummaryCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Items in collection.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<ExcludedObjectSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExtractPerformanceProfile.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ExtractPerformanceProfile.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.databasemigration.model;
 
 /**
- * GoldenGate Extract perfoemance profile
+ * GoldenGate Extract performance profile
  *
  **/
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationDatabaseTargetTypes.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationDatabaseTargetTypes.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Possible Migration Database Target types to specify.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public enum MigrationDatabaseTargetTypes {
+    AdbSRemap("ADB_S_REMAP"),
+    AdbDRemap("ADB_D_REMAP"),
+    AdbDAutocreate("ADB_D_AUTOCREATE"),
+    NonAdbRemap("NON_ADB_REMAP"),
+    NonAdbAutocreate("NON_ADB_AUTOCREATE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, MigrationDatabaseTargetTypes> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (MigrationDatabaseTargetTypes v : MigrationDatabaseTargetTypes.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    MigrationDatabaseTargetTypes(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static MigrationDatabaseTargetTypes create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'MigrationDatabaseTargetTypes', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationDatabaseTargetTypesUpdate.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationDatabaseTargetTypesUpdate.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Possible Migration Database Target types to specify.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+public enum MigrationDatabaseTargetTypesUpdate {
+    AdbSRemap("ADB_S_REMAP"),
+    AdbDRemap("ADB_D_REMAP"),
+    AdbDAutocreate("ADB_D_AUTOCREATE"),
+    NonAdbRemap("NON_ADB_REMAP"),
+    NonAdbAutocreate("NON_ADB_AUTOCREATE"),
+    TargetDefaultsRemap("TARGET_DEFAULTS_REMAP"),
+    TargetDefaultsAutocreate("TARGET_DEFAULTS_AUTOCREATE"),
+    ;
+
+    private final String value;
+    private static java.util.Map<String, MigrationDatabaseTargetTypesUpdate> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (MigrationDatabaseTargetTypesUpdate v : MigrationDatabaseTargetTypesUpdate.values()) {
+            map.put(v.getValue(), v);
+        }
+    }
+
+    MigrationDatabaseTargetTypesUpdate(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static MigrationDatabaseTargetTypesUpdate create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        throw new IllegalArgumentException("Invalid MigrationDatabaseTargetTypesUpdate: " + key);
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationObjectCollection.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationObjectCollection.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Database objects to migrate.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = MigrationObjectCollection.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MigrationObjectCollection {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("items")
+        private java.util.List<MigrationObjectSummary> items;
+
+        public Builder items(java.util.List<MigrationObjectSummary> items) {
+            this.items = items;
+            this.__explicitlySet__.add("items");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MigrationObjectCollection build() {
+            MigrationObjectCollection __instance__ = new MigrationObjectCollection(items);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MigrationObjectCollection o) {
+            Builder copiedBuilder = items(o.getItems());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Database objects to exclude/include from migration
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    java.util.List<MigrationObjectSummary> items;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationObjectSummary.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/MigrationObjectSummary.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Database objects to include or exclude from migration
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = MigrationObjectSummary.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class MigrationObjectSummary {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("owner")
+        private String owner;
+
+        public Builder owner(String owner) {
+            this.owner = owner;
+            this.__explicitlySet__.add("owner");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectName")
+        private String objectName;
+
+        public Builder objectName(String objectName) {
+            this.objectName = objectName;
+            this.__explicitlySet__.add("objectName");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("type")
+        private String type;
+
+        public Builder type(String type) {
+            this.type = type;
+            this.__explicitlySet__.add("type");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+        private ObjectStatus objectStatus;
+
+        public Builder objectStatus(ObjectStatus objectStatus) {
+            this.objectStatus = objectStatus;
+            this.__explicitlySet__.add("objectStatus");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public MigrationObjectSummary build() {
+            MigrationObjectSummary __instance__ =
+                    new MigrationObjectSummary(owner, objectName, type, objectStatus);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(MigrationObjectSummary o) {
+            Builder copiedBuilder =
+                    owner(o.getOwner())
+                            .objectName(o.getObjectName())
+                            .type(o.getType())
+                            .objectStatus(o.getObjectStatus());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Owner of the object (regular expression is allowed)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("owner")
+    String owner;
+
+    /**
+     * Name of the object (regular expression is allowed)
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectName")
+    String objectName;
+
+    /**
+     * Type of object to exclude.
+     * If not specified, matching owners and object names of type TABLE would be excluded.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    String type;
+
+    /**
+     * Object status.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("objectStatus")
+    ObjectStatus objectStatus;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/NonADBAutoCreateTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/NonADBAutoCreateTablespaceDetails.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for NON-ADB target type using auto create feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = NonADBAutoCreateTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NonADBAutoCreateTablespaceDetails extends TargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+        private Boolean isAutoCreate;
+
+        public Builder isAutoCreate(Boolean isAutoCreate) {
+            this.isAutoCreate = isAutoCreate;
+            this.__explicitlySet__.add("isAutoCreate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+        private Boolean isBigFile;
+
+        public Builder isBigFile(Boolean isBigFile) {
+            this.isBigFile = isBigFile;
+            this.__explicitlySet__.add("isBigFile");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+        private Integer extendSizeInMBs;
+
+        public Builder extendSizeInMBs(Integer extendSizeInMBs) {
+            this.extendSizeInMBs = extendSizeInMBs;
+            this.__explicitlySet__.add("extendSizeInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NonADBAutoCreateTablespaceDetails build() {
+            NonADBAutoCreateTablespaceDetails __instance__ =
+                    new NonADBAutoCreateTablespaceDetails(isAutoCreate, isBigFile, extendSizeInMBs);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NonADBAutoCreateTablespaceDetails o) {
+            Builder copiedBuilder =
+                    isAutoCreate(o.getIsAutoCreate())
+                            .isBigFile(o.getIsBigFile())
+                            .extendSizeInMBs(o.getExtendSizeInMBs());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public NonADBAutoCreateTablespaceDetails(
+            Boolean isAutoCreate, Boolean isBigFile, Integer extendSizeInMBs) {
+        super();
+        this.isAutoCreate = isAutoCreate;
+        this.isBigFile = isBigFile;
+        this.extendSizeInMBs = extendSizeInMBs;
+    }
+
+    /**
+     * True to auto-create tablespace in the target Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+    Boolean isAutoCreate;
+
+    /**
+     * True set tablespace to big file.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+    Boolean isBigFile;
+
+    /**
+     * Size of extend in MB. Can only be specified if 'isBigFile' property is set to true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+    Integer extendSizeInMBs;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/NonADBRemapTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/NonADBRemapTablespaceDetails.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for NON-ADB target type using remap feature
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = NonADBRemapTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class NonADBRemapTablespaceDetails extends TargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+        private String remapTarget;
+
+        public Builder remapTarget(String remapTarget) {
+            this.remapTarget = remapTarget;
+            this.__explicitlySet__.add("remapTarget");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public NonADBRemapTablespaceDetails build() {
+            NonADBRemapTablespaceDetails __instance__ =
+                    new NonADBRemapTablespaceDetails(remapTarget);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(NonADBRemapTablespaceDetails o) {
+            Builder copiedBuilder = remapTarget(o.getRemapTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public NonADBRemapTablespaceDetails(String remapTarget) {
+        super();
+        this.remapTarget = remapTarget;
+    }
+
+    /**
+     * Name of tablespace at target to which the source database tablespace need to be remapped
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+    String remapTarget;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ObjectStatus.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ObjectStatus.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * exclude/include/ status.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public enum ObjectStatus {
+    Exclude("EXCLUDE"),
+    Include("INCLUDE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, ObjectStatus> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (ObjectStatus v : ObjectStatus.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    ObjectStatus(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static ObjectStatus create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'ObjectStatus', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ReasonKeywords.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/ReasonKeywords.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Object exclusion reason category.
+ *
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.extern.slf4j.Slf4j
+public enum ReasonKeywords {
+    OracleMaintained("ORACLE_MAINTAINED"),
+    GgUnsupported("GG_UNSUPPORTED"),
+    UserExcluded("USER_EXCLUDED"),
+    MandatoryExcluded("MANDATORY_EXCLUDED"),
+    UserExcludedType("USER_EXCLUDED_TYPE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, ReasonKeywords> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (ReasonKeywords v : ReasonKeywords.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    ReasonKeywords(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static ReasonKeywords create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'ReasonKeywords', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/TargetTypeTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/TargetTypeTablespaceDetails.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType",
+    defaultImpl = TargetTypeTablespaceDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ADBDedicatedAutoCreateTablespaceDetails.class,
+        name = "ADB_D_AUTOCREATE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ADBServerlesTablespaceDetails.class,
+        name = "ADB_S_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = ADBDedicatedRemapTargetTablespaceDetails.class,
+        name = "ADB_D_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = NonADBRemapTablespaceDetails.class,
+        name = "NON_ADB_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = NonADBAutoCreateTablespaceDetails.class,
+        name = "NON_ADB_AUTOCREATE"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class TargetTypeTablespaceDetails {}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateADBDedicatedAutoCreateTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateADBDedicatedAutoCreateTablespaceDetails.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for ADB-D target type using auto create feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateADBDedicatedAutoCreateTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateADBDedicatedAutoCreateTablespaceDetails
+        extends UpdateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+        private Boolean isAutoCreate;
+
+        public Builder isAutoCreate(Boolean isAutoCreate) {
+            this.isAutoCreate = isAutoCreate;
+            this.__explicitlySet__.add("isAutoCreate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+        private Boolean isBigFile;
+
+        public Builder isBigFile(Boolean isBigFile) {
+            this.isBigFile = isBigFile;
+            this.__explicitlySet__.add("isBigFile");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+        private Integer extendSizeInMBs;
+
+        public Builder extendSizeInMBs(Integer extendSizeInMBs) {
+            this.extendSizeInMBs = extendSizeInMBs;
+            this.__explicitlySet__.add("extendSizeInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateADBDedicatedAutoCreateTablespaceDetails build() {
+            UpdateADBDedicatedAutoCreateTablespaceDetails __instance__ =
+                    new UpdateADBDedicatedAutoCreateTablespaceDetails(
+                            isAutoCreate, isBigFile, extendSizeInMBs);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateADBDedicatedAutoCreateTablespaceDetails o) {
+            Builder copiedBuilder =
+                    isAutoCreate(o.getIsAutoCreate())
+                            .isBigFile(o.getIsBigFile())
+                            .extendSizeInMBs(o.getExtendSizeInMBs());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateADBDedicatedAutoCreateTablespaceDetails(
+            Boolean isAutoCreate, Boolean isBigFile, Integer extendSizeInMBs) {
+        super();
+        this.isAutoCreate = isAutoCreate;
+        this.isBigFile = isBigFile;
+        this.extendSizeInMBs = extendSizeInMBs;
+    }
+
+    /**
+     * True to auto-create tablespace in the target Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+    Boolean isAutoCreate;
+
+    /**
+     * True set tablespace to big file.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+    Boolean isBigFile;
+
+    /**
+     * Size of extend in MB. Can only be specified if 'isBigFile' property is set to true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+    Integer extendSizeInMBs;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateADBDedicatedRemapTargetTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateADBDedicatedRemapTargetTablespaceDetails.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for ADB-D target type using remap target.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateADBDedicatedRemapTargetTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateADBDedicatedRemapTargetTablespaceDetails
+        extends UpdateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+        private String remapTarget;
+
+        public Builder remapTarget(String remapTarget) {
+            this.remapTarget = remapTarget;
+            this.__explicitlySet__.add("remapTarget");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateADBDedicatedRemapTargetTablespaceDetails build() {
+            UpdateADBDedicatedRemapTargetTablespaceDetails __instance__ =
+                    new UpdateADBDedicatedRemapTargetTablespaceDetails(remapTarget);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateADBDedicatedRemapTargetTablespaceDetails o) {
+            Builder copiedBuilder = remapTarget(o.getRemapTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateADBDedicatedRemapTargetTablespaceDetails(String remapTarget) {
+        super();
+        this.remapTarget = remapTarget;
+    }
+
+    /**
+     * Name of tablespace at target to which the source database tablespace need to be remapped.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+    String remapTarget;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateADBServerlesTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateADBServerlesTablespaceDetails.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for ADB-S target type using remap feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateADBServerlesTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateADBServerlesTablespaceDetails extends UpdateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateADBServerlesTablespaceDetails build() {
+            UpdateADBServerlesTablespaceDetails __instance__ =
+                    new UpdateADBServerlesTablespaceDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateADBServerlesTablespaceDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateADBServerlesTablespaceDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAwsS3Details.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateAwsS3Details.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * AWS S3 bucket details used for source Connection resources with RDS_ORACLE type.
+ * Only supported for source Connection resources with RDS_ORACLE type.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(onConstructor = @__({@Deprecated}))
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateAwsS3Details.Builder.class
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateAwsS3Details {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("name")
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            this.__explicitlySet__.add("name");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("region")
+        private String region;
+
+        public Builder region(String region) {
+            this.region = region;
+            this.__explicitlySet__.add("region");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("accessKeyId")
+        private String accessKeyId;
+
+        public Builder accessKeyId(String accessKeyId) {
+            this.accessKeyId = accessKeyId;
+            this.__explicitlySet__.add("accessKeyId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("secretAccessKey")
+        private String secretAccessKey;
+
+        public Builder secretAccessKey(String secretAccessKey) {
+            this.secretAccessKey = secretAccessKey;
+            this.__explicitlySet__.add("secretAccessKey");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateAwsS3Details build() {
+            UpdateAwsS3Details __instance__ =
+                    new UpdateAwsS3Details(name, region, accessKeyId, secretAccessKey);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateAwsS3Details o) {
+            Builder copiedBuilder =
+                    name(o.getName())
+                            .region(o.getRegion())
+                            .accessKeyId(o.getAccessKeyId())
+                            .secretAccessKey(o.getSecretAccessKey());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * S3 bucket name.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    String name;
+
+    /**
+     * AWS region code where the S3 bucket is located.
+     * Region code should match the documented available regions:
+     * https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("region")
+    String region;
+
+    /**
+     * AWS access key credentials identifier
+     * Details: https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("accessKeyId")
+    String accessKeyId;
+
+    /**
+     * AWS secret access key credentials
+     * Details: https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("secretAccessKey")
+    String secretAccessKey;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpSettings.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataPumpSettings.java
@@ -54,6 +54,15 @@ public class UpdateDataPumpSettings {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("tablespaceDetails")
+        private UpdateTargetTypeTablespaceDetails tablespaceDetails;
+
+        public Builder tablespaceDetails(UpdateTargetTypeTablespaceDetails tablespaceDetails) {
+            this.tablespaceDetails = tablespaceDetails;
+            this.__explicitlySet__.add("tablespaceDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("exportDirectoryObject")
         private UpdateDirectoryObject exportDirectoryObject;
 
@@ -81,6 +90,7 @@ public class UpdateDataPumpSettings {
                             jobMode,
                             dataPumpParameters,
                             metadataRemaps,
+                            tablespaceDetails,
                             exportDirectoryObject,
                             importDirectoryObject);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -93,6 +103,7 @@ public class UpdateDataPumpSettings {
                     jobMode(o.getJobMode())
                             .dataPumpParameters(o.getDataPumpParameters())
                             .metadataRemaps(o.getMetadataRemaps())
+                            .tablespaceDetails(o.getTablespaceDetails())
                             .exportDirectoryObject(o.getExportDirectoryObject())
                             .importDirectoryObject(o.getImportDirectoryObject());
 
@@ -127,6 +138,9 @@ public class UpdateDataPumpSettings {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("metadataRemaps")
     java.util.List<MetadataRemap> metadataRemaps;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("tablespaceDetails")
+    UpdateTargetTypeTablespaceDetails tablespaceDetails;
 
     @com.fasterxml.jackson.annotation.JsonProperty("exportDirectoryObject")
     UpdateDirectoryObject exportDirectoryObject;

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataTransferMediumDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateDataTransferMediumDetails.java
@@ -6,7 +6,8 @@ package com.oracle.bmc.databasemigration.model;
 
 /**
  * Data Transfer Medium details for the Migration.
- * Only one type of data transfer medium can be specified and will replace the stored Data Transfer Medium details.
+ * Only one type of data transfer medium can be specified, except for the case of Amazon RDS Oracle as source,
+ * where Object Storage Details along with AwsS3Details are required.
  * If an empty object is specified, the stored Data Transfer Medium details will be removed.
  *
  * <br/>
@@ -47,12 +48,22 @@ public class UpdateDataTransferMediumDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("awsS3Details")
+        private UpdateAwsS3Details awsS3Details;
+
+        public Builder awsS3Details(UpdateAwsS3Details awsS3Details) {
+            this.awsS3Details = awsS3Details;
+            this.__explicitlySet__.add("awsS3Details");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
         public UpdateDataTransferMediumDetails build() {
             UpdateDataTransferMediumDetails __instance__ =
-                    new UpdateDataTransferMediumDetails(databaseLinkDetails, objectStorageDetails);
+                    new UpdateDataTransferMediumDetails(
+                            databaseLinkDetails, objectStorageDetails, awsS3Details);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -61,7 +72,8 @@ public class UpdateDataTransferMediumDetails {
         public Builder copy(UpdateDataTransferMediumDetails o) {
             Builder copiedBuilder =
                     databaseLinkDetails(o.getDatabaseLinkDetails())
-                            .objectStorageDetails(o.getObjectStorageDetails());
+                            .objectStorageDetails(o.getObjectStorageDetails())
+                            .awsS3Details(o.getAwsS3Details());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -80,6 +92,9 @@ public class UpdateDataTransferMediumDetails {
 
     @com.fasterxml.jackson.annotation.JsonProperty("objectStorageDetails")
     UpdateObjectStoreBucket objectStorageDetails;
+
+    @com.fasterxml.jackson.annotation.JsonProperty("awsS3Details")
+    UpdateAwsS3Details awsS3Details;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateNonADBAutoCreateTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateNonADBAutoCreateTablespaceDetails.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for NON-ADB target type using auto create feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateNonADBAutoCreateTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateNonADBAutoCreateTablespaceDetails extends UpdateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+        private Boolean isAutoCreate;
+
+        public Builder isAutoCreate(Boolean isAutoCreate) {
+            this.isAutoCreate = isAutoCreate;
+            this.__explicitlySet__.add("isAutoCreate");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+        private Boolean isBigFile;
+
+        public Builder isBigFile(Boolean isBigFile) {
+            this.isBigFile = isBigFile;
+            this.__explicitlySet__.add("isBigFile");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+        private Integer extendSizeInMBs;
+
+        public Builder extendSizeInMBs(Integer extendSizeInMBs) {
+            this.extendSizeInMBs = extendSizeInMBs;
+            this.__explicitlySet__.add("extendSizeInMBs");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateNonADBAutoCreateTablespaceDetails build() {
+            UpdateNonADBAutoCreateTablespaceDetails __instance__ =
+                    new UpdateNonADBAutoCreateTablespaceDetails(
+                            isAutoCreate, isBigFile, extendSizeInMBs);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateNonADBAutoCreateTablespaceDetails o) {
+            Builder copiedBuilder =
+                    isAutoCreate(o.getIsAutoCreate())
+                            .isBigFile(o.getIsBigFile())
+                            .extendSizeInMBs(o.getExtendSizeInMBs());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateNonADBAutoCreateTablespaceDetails(
+            Boolean isAutoCreate, Boolean isBigFile, Integer extendSizeInMBs) {
+        super();
+        this.isAutoCreate = isAutoCreate;
+        this.isBigFile = isBigFile;
+        this.extendSizeInMBs = extendSizeInMBs;
+    }
+
+    /**
+     * True to auto-create tablespace in the target Database.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isAutoCreate")
+    Boolean isAutoCreate;
+
+    /**
+     * True set tablespace to big file.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("isBigFile")
+    Boolean isBigFile;
+
+    /**
+     * Size of extend in MB. Can only be specified if 'isBigFile' property is set to true.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("extendSizeInMBs")
+    Integer extendSizeInMBs;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateNonADBRemapTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateNonADBRemapTablespaceDetails.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for NON-ADB target type using remap feature.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateNonADBRemapTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateNonADBRemapTablespaceDetails extends UpdateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+        @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+        private String remapTarget;
+
+        public Builder remapTarget(String remapTarget) {
+            this.remapTarget = remapTarget;
+            this.__explicitlySet__.add("remapTarget");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateNonADBRemapTablespaceDetails build() {
+            UpdateNonADBRemapTablespaceDetails __instance__ =
+                    new UpdateNonADBRemapTablespaceDetails(remapTarget);
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateNonADBRemapTablespaceDetails o) {
+            Builder copiedBuilder = remapTarget(o.getRemapTarget());
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateNonADBRemapTablespaceDetails(String remapTarget) {
+        super();
+        this.remapTarget = remapTarget;
+    }
+
+    /**
+     * Name of tablespace at target to which the source database tablespace need to be remapped.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("remapTarget")
+    String remapTarget;
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateTargetDefaultsAutoCreateTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateTargetDefaultsAutoCreateTablespaceDetails.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for TARGET_DEFAULTS_AUTOCREATE target type. The service will compute
+ * the targetType that corresponds to the targetDatabaseConnectionId type, and set the corresponding default values. When
+ * target type is ADB_D or NON_ADB the default will be set to auto-create feature ADB_D_AUTOCREATE or NON_ADB_AUTOCREATE.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateTargetDefaultsAutoCreateTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateTargetDefaultsAutoCreateTablespaceDetails
+        extends UpdateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateTargetDefaultsAutoCreateTablespaceDetails build() {
+            UpdateTargetDefaultsAutoCreateTablespaceDetails __instance__ =
+                    new UpdateTargetDefaultsAutoCreateTablespaceDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateTargetDefaultsAutoCreateTablespaceDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateTargetDefaultsAutoCreateTablespaceDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateTargetDefaultsRemapTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateTargetDefaultsRemapTablespaceDetails.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings valid for TARGET_DEFAULTS_REMAP target type. The service will compute the targetType
+ * that corresponds to the targetDatabaseConnectionId type, and set the corresponding default values. When target type is ADB_S,
+ * ADB_D or NON_ADB the default will be set to remap feature ADB_S_REMAP, ADB_D_REMAP or NON_ADB_REMAP.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Value
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(
+    builder = UpdateTargetDefaultsRemapTablespaceDetails.Builder.class
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType"
+)
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
+public class UpdateTargetDefaultsRemapTablespaceDetails extends UpdateTargetTypeTablespaceDetails {
+    @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "")
+    @lombok.experimental.Accessors(fluent = true)
+    public static class Builder {
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+
+        public UpdateTargetDefaultsRemapTablespaceDetails build() {
+            UpdateTargetDefaultsRemapTablespaceDetails __instance__ =
+                    new UpdateTargetDefaultsRemapTablespaceDetails();
+            __instance__.__explicitlySet__.addAll(__explicitlySet__);
+            return __instance__;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        public Builder copy(UpdateTargetDefaultsRemapTablespaceDetails o) {
+            Builder copiedBuilder = this;
+
+            copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
+            return copiedBuilder;
+        }
+    }
+
+    /**
+     * Create a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public UpdateTargetDefaultsRemapTablespaceDetails() {
+        super();
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateTargetTypeTablespaceDetails.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/model/UpdateTargetTypeTablespaceDetails.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.model;
+
+/**
+ * Migration tablespace settings.
+ *
+ * <br/>
+ * Note: Objects should always be created or deserialized using the {@link Builder}. This model distinguishes fields
+ * that are {@code null} because they are unset from fields that are explicitly set to {@code null}. This is done in
+ * the setter methods of the {@link Builder}, which maintain a set of all explicitly set fields called
+ * {@link #__explicitlySet__}. The {@link #hashCode()} and {@link #equals(Object)} methods are implemented to take
+ * {@link #__explicitlySet__} into account. The constructor, on the other hand, does not set {@link #__explicitlySet__}
+ * (since the constructor cannot distinguish explicit {@code null} from unset {@code null}).
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.AllArgsConstructor(
+    onConstructor = @__({@Deprecated}),
+    access = lombok.AccessLevel.PROTECTED
+)
+@lombok.Value
+@lombok.experimental.NonFinal
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+    use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+    include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+    property = "targetType",
+    defaultImpl = UpdateTargetTypeTablespaceDetails.class
+)
+@com.fasterxml.jackson.annotation.JsonSubTypes({
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateTargetDefaultsRemapTablespaceDetails.class,
+        name = "TARGET_DEFAULTS_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateADBDedicatedRemapTargetTablespaceDetails.class,
+        name = "ADB_D_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateNonADBRemapTablespaceDetails.class,
+        name = "NON_ADB_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateNonADBAutoCreateTablespaceDetails.class,
+        name = "NON_ADB_AUTOCREATE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateADBDedicatedAutoCreateTablespaceDetails.class,
+        name = "ADB_D_AUTOCREATE"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateADBServerlesTablespaceDetails.class,
+        name = "ADB_S_REMAP"
+    ),
+    @com.fasterxml.jackson.annotation.JsonSubTypes.Type(
+        value = UpdateTargetDefaultsAutoCreateTablespaceDetails.class,
+        name = "TARGET_DEFAULTS_AUTOCREATE"
+    )
+})
+@com.fasterxml.jackson.annotation.JsonFilter(com.oracle.bmc.http.internal.ExplicitlySetFilter.NAME)
+public class UpdateTargetTypeTablespaceDetails {}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/AddMigrationObjectsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/AddMigrationObjectsRequest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.requests;
+
+import com.oracle.bmc.databasemigration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/AddMigrationObjectsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use AddMigrationObjectsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class AddMigrationObjectsRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.databasemigration.model.MigrationObjectCollection> {
+
+    /**
+     * The OCID of the migration
+     *
+     */
+    private String migrationId;
+
+    /**
+     * Arrays of object.
+     *
+     */
+    private com.oracle.bmc.databasemigration.model.MigrationObjectCollection
+            addMigrationObjectsDetails;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.databasemigration.model.MigrationObjectCollection getBody$() {
+        return addMigrationObjectsDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    AddMigrationObjectsRequest,
+                    com.oracle.bmc.databasemigration.model.MigrationObjectCollection> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddMigrationObjectsRequest o) {
+            migrationId(o.getMigrationId());
+            addMigrationObjectsDetails(o.getAddMigrationObjectsDetails());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of AddMigrationObjectsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of AddMigrationObjectsRequest
+         */
+        public AddMigrationObjectsRequest build() {
+            AddMigrationObjectsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.databasemigration.model.MigrationObjectCollection body) {
+            addMigrationObjectsDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListExcludedObjectsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListExcludedObjectsRequest.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.requests;
+
+import com.oracle.bmc.databasemigration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListExcludedObjectsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListExcludedObjectsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListExcludedObjectsRequest extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the job
+     *
+     */
+    private String jobId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * The maximum number of items to return.
+     *
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    /**
+     * The sort order to use, either 'asc' or 'desc'.
+     *
+     */
+    private com.oracle.bmc.databasemigration.model.SortOrders sortOrder;
+
+    /**
+     * The field to sort by. Only one sort order may be provided.
+     * Default order for reasonCategory is ascending.
+     * If no value is specified reasonCategory is default.
+     *
+     */
+    private SortBy sortBy;
+
+    /**
+     * The field to sort by. Only one sort order may be provided.
+     * Default order for reasonCategory is ascending.
+     * If no value is specified reasonCategory is default.
+     *
+     **/
+    public enum SortBy {
+        Type("type"),
+        ReasonCategory("reasonCategory"),
+        ;
+
+        private final String value;
+        private static java.util.Map<String, SortBy> map;
+
+        static {
+            map = new java.util.HashMap<>();
+            for (SortBy v : SortBy.values()) {
+                map.put(v.getValue(), v);
+            }
+        }
+
+        SortBy(String value) {
+            this.value = value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonCreator
+        public static SortBy create(String key) {
+            if (map.containsKey(key)) {
+                return map.get(key);
+            }
+            throw new IllegalArgumentException("Invalid SortBy: " + key);
+        }
+    };
+    /**
+     * Excluded object type.
+     *
+     */
+    private String type;
+
+    /**
+     * Excluded object owner
+     *
+     */
+    private String owner;
+
+    /**
+     * Excluded object name
+     *
+     */
+    private String object;
+
+    /**
+     * Excluded object owner which contains provided value.
+     *
+     */
+    private String ownerContains;
+
+    /**
+     * Excluded object name which contains provided value.
+     *
+     */
+    private String objectContains;
+
+    /**
+     * Reason category for the excluded object
+     *
+     */
+    private com.oracle.bmc.databasemigration.model.ReasonKeywords reasonCategory;
+
+    /**
+     * Exclude object rule that matches the excluded object, if applicable.
+     *
+     */
+    private String sourceRule;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListExcludedObjectsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListExcludedObjectsRequest o) {
+            jobId(o.getJobId());
+            opcRequestId(o.getOpcRequestId());
+            limit(o.getLimit());
+            page(o.getPage());
+            sortOrder(o.getSortOrder());
+            sortBy(o.getSortBy());
+            type(o.getType());
+            owner(o.getOwner());
+            object(o.getObject());
+            ownerContains(o.getOwnerContains());
+            objectContains(o.getObjectContains());
+            reasonCategory(o.getReasonCategory());
+            sourceRule(o.getSourceRule());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListExcludedObjectsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListExcludedObjectsRequest
+         */
+        public ListExcludedObjectsRequest build() {
+            ListExcludedObjectsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListMigrationObjectsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/ListMigrationObjectsRequest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.requests;
+
+import com.oracle.bmc.databasemigration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/ListMigrationObjectsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use ListMigrationObjectsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListMigrationObjectsRequest
+        extends com.oracle.bmc.requests.BmcRequest<java.lang.Void> {
+
+    /**
+     * The OCID of the migration
+     *
+     */
+    private String migrationId;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * The maximum number of items to return.
+     *
+     */
+    private Integer limit;
+
+    /**
+     * The page token representing the page at which to start retrieving results. This is usually retrieved from a previous list call.
+     *
+     */
+    private String page;
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    ListMigrationObjectsRequest, java.lang.Void> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListMigrationObjectsRequest o) {
+            migrationId(o.getMigrationId());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            limit(o.getLimit());
+            page(o.getPage());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of ListMigrationObjectsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of ListMigrationObjectsRequest
+         */
+        public ListMigrationObjectsRequest build() {
+            ListMigrationObjectsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/RemoveMigrationObjectsRequest.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/requests/RemoveMigrationObjectsRequest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.requests;
+
+import com.oracle.bmc.databasemigration.model.*;
+/**
+ * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/databasemigration/RemoveMigrationObjectsExample.java.html" target="_blank" rel="noopener noreferrer">here</a> to see how to use RemoveMigrationObjectsRequest.
+ */
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(
+    builderClassName = "Builder",
+    buildMethodName = "buildWithoutInvocationCallback",
+    toBuilder = true
+)
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RemoveMigrationObjectsRequest
+        extends com.oracle.bmc.requests.BmcRequest<
+                com.oracle.bmc.databasemigration.model.MigrationObjectCollection> {
+
+    /**
+     * The OCID of the migration
+     *
+     */
+    private String migrationId;
+
+    /**
+     * Arrays of object.
+     *
+     */
+    private com.oracle.bmc.databasemigration.model.MigrationObjectCollection
+            removeMigrationObjectsDetails;
+
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact Oracle about a
+     * particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For optimistic concurrency control. In the PUT or DELETE call
+     * for a resource, set the {@code if-match} parameter to the value of the
+     * etag from a previous GET or POST response for that resource.
+     * The resource will be updated or deleted only if the etag you
+     * provide matches the resource's current etag value.
+     *
+     */
+    private String ifMatch;
+
+    /**
+     * Alternative accessor for the body parameter.
+     * @return body parameter
+     */
+    @Override
+    @com.oracle.bmc.InternalSdk
+    public com.oracle.bmc.databasemigration.model.MigrationObjectCollection getBody$() {
+        return removeMigrationObjectsDetails;
+    }
+
+    public static class Builder
+            implements com.oracle.bmc.requests.BmcRequest.Builder<
+                    RemoveMigrationObjectsRequest,
+                    com.oracle.bmc.databasemigration.model.MigrationObjectCollection> {
+        private com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                invocationCallback = null;
+        private com.oracle.bmc.retrier.RetryConfiguration retryConfiguration = null;
+
+        /**
+         * Set the invocation callback for the request to be built.
+         * @param invocationCallback the invocation callback to be set for the request
+         * @return this builder instance
+         */
+        public Builder invocationCallback(
+                com.oracle.bmc.util.internal.Consumer<javax.ws.rs.client.Invocation.Builder>
+                        invocationCallback) {
+            this.invocationCallback = invocationCallback;
+            return this;
+        }
+
+        /**
+         * Set the retry configuration for the request to be built.
+         * @param retryConfiguration the retry configuration to be used for the request
+         * @return this builder instance
+         */
+        public Builder retryConfiguration(
+                com.oracle.bmc.retrier.RetryConfiguration retryConfiguration) {
+            this.retryConfiguration = retryConfiguration;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveMigrationObjectsRequest o) {
+            migrationId(o.getMigrationId());
+            removeMigrationObjectsDetails(o.getRemoveMigrationObjectsDetails());
+            opcRequestId(o.getOpcRequestId());
+            ifMatch(o.getIfMatch());
+            invocationCallback(o.getInvocationCallback());
+            retryConfiguration(o.getRetryConfiguration());
+            return this;
+        }
+
+        /**
+         * Build the instance of RemoveMigrationObjectsRequest as configured by this builder
+         *
+         * Note that this method takes calls to {@link Builder#invocationCallback(com.oracle.bmc.util.internal.Consumer)} into account,
+         * while the method {@link Builder#buildWithoutInvocationCallback} does not.
+         *
+         * This is the preferred method to build an instance.
+         *
+         * @return instance of RemoveMigrationObjectsRequest
+         */
+        public RemoveMigrationObjectsRequest build() {
+            RemoveMigrationObjectsRequest request = buildWithoutInvocationCallback();
+            request.setInvocationCallback(invocationCallback);
+            request.setRetryConfiguration(retryConfiguration);
+            return request;
+        }
+
+        /**
+         * Alternative setter for the body parameter.
+         * @param body the body parameter
+         * @return this builder instance
+         */
+        @com.oracle.bmc.InternalSdk
+        public Builder body$(
+                com.oracle.bmc.databasemigration.model.MigrationObjectCollection body) {
+            removeMigrationObjectsDetails(body);
+            return this;
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/AddMigrationObjectsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/AddMigrationObjectsResponse.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.responses;
+
+import com.oracle.bmc.databasemigration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class AddMigrationObjectsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcRequestId"})
+    private AddMigrationObjectsResponse(int __httpStatusCode__, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(AddMigrationObjectsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public AddMigrationObjectsResponse build() {
+            return new AddMigrationObjectsResponse(__httpStatusCode__, opcRequestId);
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListExcludedObjectsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListExcludedObjectsResponse.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.responses;
+
+import com.oracle.bmc.databasemigration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListExcludedObjectsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the {@code page} parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned ExcludedObjectSummaryCollection instance.
+     */
+    private com.oracle.bmc.databasemigration.model.ExcludedObjectSummaryCollection
+            excludedObjectSummaryCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "excludedObjectSummaryCollection"
+    })
+    private ListExcludedObjectsResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            com.oracle.bmc.databasemigration.model.ExcludedObjectSummaryCollection
+                    excludedObjectSummaryCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.excludedObjectSummaryCollection = excludedObjectSummaryCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListExcludedObjectsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            excludedObjectSummaryCollection(o.getExcludedObjectSummaryCollection());
+
+            return this;
+        }
+
+        public ListExcludedObjectsResponse build() {
+            return new ListExcludedObjectsResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, excludedObjectSummaryCollection);
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListMigrationObjectsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/ListMigrationObjectsResponse.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.responses;
+
+import com.oracle.bmc.databasemigration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class ListMigrationObjectsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    /**
+     * For pagination of a list of items. When paging through a list, if this header appears in the response,
+     * then a partial list might have been returned. Include this value as the {@code page} parameter for the
+     * subsequent GET request to get the next batch of items.
+     *
+     */
+    private String opcNextPage;
+
+    /**
+     * The returned MigrationObjectCollection instance.
+     */
+    private com.oracle.bmc.databasemigration.model.MigrationObjectCollection
+            migrationObjectCollection;
+
+    @java.beans.ConstructorProperties({
+        "__httpStatusCode__",
+        "opcRequestId",
+        "opcNextPage",
+        "migrationObjectCollection"
+    })
+    private ListMigrationObjectsResponse(
+            int __httpStatusCode__,
+            String opcRequestId,
+            String opcNextPage,
+            com.oracle.bmc.databasemigration.model.MigrationObjectCollection
+                    migrationObjectCollection) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+        this.opcNextPage = opcNextPage;
+        this.migrationObjectCollection = migrationObjectCollection;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(ListMigrationObjectsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+            opcNextPage(o.getOpcNextPage());
+            migrationObjectCollection(o.getMigrationObjectCollection());
+
+            return this;
+        }
+
+        public ListMigrationObjectsResponse build() {
+            return new ListMigrationObjectsResponse(
+                    __httpStatusCode__, opcRequestId, opcNextPage, migrationObjectCollection);
+        }
+    }
+}

--- a/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/RemoveMigrationObjectsResponse.java
+++ b/bmc-databasemigration/src/main/java/com/oracle/bmc/databasemigration/responses/RemoveMigrationObjectsResponse.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.databasemigration.responses;
+
+import com.oracle.bmc.databasemigration.model.*;
+
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20210929")
+@lombok.Builder(builderClassName = "Builder")
+@lombok.ToString(callSuper = true)
+@lombok.EqualsAndHashCode(callSuper = true)
+@lombok.Getter
+public class RemoveMigrationObjectsResponse extends com.oracle.bmc.responses.BmcResponse {
+    /**
+     * Unique Oracle-assigned identifier for the request. If you need to contact
+     * Oracle about a particular request, please provide the request ID.
+     *
+     */
+    private String opcRequestId;
+
+    @java.beans.ConstructorProperties({"__httpStatusCode__", "opcRequestId"})
+    private RemoveMigrationObjectsResponse(int __httpStatusCode__, String opcRequestId) {
+        super(__httpStatusCode__);
+        this.opcRequestId = opcRequestId;
+    }
+
+    public static class Builder {
+        private int __httpStatusCode__;
+
+        public Builder __httpStatusCode__(int __httpStatusCode__) {
+            this.__httpStatusCode__ = __httpStatusCode__;
+            return this;
+        }
+
+        /**
+         * Copy method to populate the builder with values from the given instance.
+         * @return this builder instance
+         */
+        public Builder copy(RemoveMigrationObjectsResponse o) {
+            __httpStatusCode__(o.get__httpStatusCode__());
+            opcRequestId(o.getOpcRequestId());
+
+            return this;
+        }
+
+        public RemoveMigrationObjectsResponse build() {
+            return new RemoveMigrationObjectsResponse(__httpStatusCode__, opcRequestId);
+        }
+    }
+}

--- a/bmc-databasetools/pom.xml
+++ b/bmc-databasetools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-databasetools</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datacatalog/pom.xml
+++ b/bmc-datacatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datacatalog</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataconnectivity/pom.xml
+++ b/bmc-dataconnectivity/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataconnectivity</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataflow/pom.xml
+++ b/bmc-dataflow/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataflow</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dataintegration/pom.xml
+++ b/bmc-dataintegration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dataintegration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservice/pom.xml
+++ b/bmc-datalabelingservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservice</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datalabelingservicedataplane/pom.xml
+++ b/bmc-datalabelingservicedataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datalabelingservicedataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datasafe/pom.xml
+++ b/bmc-datasafe/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datasafe</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-datascience/pom.xml
+++ b/bmc-datascience/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-datascience</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-devops/pom.xml
+++ b/bmc-devops/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-devops</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-dns/pom.xml
+++ b/bmc-dns/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-dts/pom.xml
+++ b/bmc-dts/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-dts</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-email/pom.xml
+++ b/bmc-email/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-encryption/pom.xml
+++ b/bmc-encryption/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,17 +26,17 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
   </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-circuitbreaker</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-keymanagement</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/bmc-encryption/src/main/java/com/oracle/bmc/encryption/internal/EncryptionHeader.java
+++ b/bmc-encryption/src/main/java/com/oracle/bmc/encryption/internal/EncryptionHeader.java
@@ -6,14 +6,11 @@ package com.oracle.bmc.encryption.internal;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.oracle.bmc.encryption.internal.EncryptionKey;
+import com.oracle.bmc.http.internal.RestClientFactory;
 
 import java.util.*;
 
 public class EncryptionHeader {
-    public final int encryptedContentFormat = 0;
-    public final int algorithmId = 0;
     private String additionalAuthenticatedData;
     private List<EncryptionKey> encryptedDataKeys = new ArrayList<>();
     private String iv;
@@ -49,7 +46,8 @@ public class EncryptionHeader {
         if (additionalAuthenticatedData.isEmpty()) return new HashMap<String, String>();
 
         Map<String, String> result =
-                new ObjectMapper().readValue(additionalAuthenticatedData, HashMap.class);
+                RestClientFactory.getObjectMapper()
+                        .readValue(additionalAuthenticatedData, HashMap.class);
         return result;
     }
 

--- a/bmc-encryption/src/main/java/com/oracle/bmc/encryption/internal/SerializeHeader.java
+++ b/bmc-encryption/src/main/java/com/oracle/bmc/encryption/internal/SerializeHeader.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.oracle.bmc.encryption.KmsMasterKey;
 import com.oracle.bmc.encryption.MasterKeyProvider;
+import com.oracle.bmc.http.internal.RestClientFactory;
 import net.minidev.json.JSONObject;
 
 public class SerializeHeader {
@@ -63,7 +64,7 @@ public class SerializeHeader {
 
     private String serializeJsonHeader(EncryptionHeader encryptionHeader) {
         String jsonOutput = null;
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = RestClientFactory.getObjectMapper();
         try {
             jsonOutput = objectMapper.writeValueAsString(encryptionHeader);
         } catch (JsonProcessingException e) {
@@ -78,7 +79,7 @@ public class SerializeHeader {
 
     public EncryptionHeader deserializeJsonHeader(byte[] header) {
         EncryptionHeader encryptionHeader;
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = RestClientFactory.getObjectMapper();
         try {
             encryptionHeader = objectMapper.readValue(header, EncryptionHeader.class);
         } catch (IOException e) {

--- a/bmc-events/pom.xml
+++ b/bmc-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-events</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-examples/pom.xml
+++ b/bmc-examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
@@ -31,7 +31,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-examples/src/main/java/ContainerImageSigningExample.java
+++ b/bmc-examples/src/main/java/ContainerImageSigningExample.java
@@ -19,6 +19,7 @@ import com.oracle.bmc.artifacts.responses.GetContainerImageResponse;
 import com.oracle.bmc.artifacts.responses.ListContainerImageSignaturesResponse;
 import com.oracle.bmc.auth.AuthenticationDetailsProvider;
 import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
+import com.oracle.bmc.http.internal.RestClientFactory;
 import com.oracle.bmc.keymanagement.KmsCryptoClient;
 import com.oracle.bmc.keymanagement.model.SignDataDetails;
 import com.oracle.bmc.keymanagement.model.SignedData;
@@ -171,7 +172,7 @@ public class ContainerImageSigningExample {
         ContainerImage containerImage = getContainerImageMetadata(artifactsClient, imageId);
 
         // Generate message
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = RestClientFactory.getObjectMapper();
         Map<String, Object> message = new LinkedHashMap<>();
         message.put("description", description);
         message.put("imageDigest", containerImage.getDigest());

--- a/bmc-filestorage/pom.xml
+++ b/bmc-filestorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-full/pom.xml
+++ b/bmc-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-full</artifactId>
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-java-sdk-bom</artifactId>
-        <version>2.18.0</version>
+        <version>2.19.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bmc-functions/pom.xml
+++ b/bmc-functions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-functions</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-genericartifactscontent/pom.xml
+++ b/bmc-genericartifactscontent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-genericartifactscontent</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-goldengate/pom.xml
+++ b/bmc-goldengate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-goldengate</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-healthchecks/pom.xml
+++ b/bmc-healthchecks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-healthchecks</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-identity/pom.xml
+++ b/bmc-identity/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-identitydataplane/pom.xml
+++ b/bmc-identitydataplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-identitydataplane</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-integration/pom.xml
+++ b/bmc-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-integration</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-jms/pom.xml
+++ b/bmc-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-jms</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-keymanagement/pom.xml
+++ b/bmc-keymanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-keymanagement</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-limits/pom.xml
+++ b/bmc-limits/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-limits</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loadbalancer/pom.xml
+++ b/bmc-loadbalancer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-loganalytics/pom.xml
+++ b/bmc-loganalytics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loganalytics</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-logging/pom.xml
+++ b/bmc-logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-logging</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingingestion/pom.xml
+++ b/bmc-loggingingestion/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingingestion</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-loggingsearch/pom.xml
+++ b/bmc-loggingsearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-loggingsearch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementagent/pom.xml
+++ b/bmc-managementagent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementagent</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-managementdashboard/pom.xml
+++ b/bmc-managementdashboard/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-managementdashboard</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-marketplace/pom.xml
+++ b/bmc-marketplace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-marketplace</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-monitoring/pom.xml
+++ b/bmc-monitoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-monitoring</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-mysql/pom.xml
+++ b/bmc-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-mysql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-networkloadbalancer/pom.xml
+++ b/bmc-networkloadbalancer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-networkloadbalancer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-nosql/pom.xml
+++ b/bmc-nosql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-nosql</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-combined/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-extensions</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-objectstorage-generated</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
+++ b/bmc-objectstorage/bmc-objectstorage-generated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-objectstorage-parent</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 

--- a/bmc-objectstorage/pom.xml
+++ b/bmc-objectstorage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-oce/pom.xml
+++ b/bmc-oce/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oce</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/OceInstance.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/OceInstance.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.oce.requests.*;
 import com.oracle.bmc.oce.responses.*;
 
 /**
- * Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+ * Oracle Content Management is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
  * This service client uses CircuitBreakerUtils.DEFAULT_CIRCUIT_BREAKER for all the operations by default if no circuit breaker configuration is defined by the user.
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190912")

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/OceInstanceAsync.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/OceInstanceAsync.java
@@ -8,7 +8,7 @@ import com.oracle.bmc.oce.requests.*;
 import com.oracle.bmc.oce.responses.*;
 
 /**
- * Oracle Content and Experience is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
+ * Oracle Content Management is a cloud-based content hub to drive omni-channel content management and accelerate experience delivery
  */
 @javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190912")
 public interface OceInstanceAsync extends AutoCloseable {

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/OceInstanceWaiters.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/OceInstanceWaiters.java
@@ -23,13 +23,13 @@ public class OceInstanceWaiters {
      * Creates a new {@link com.oracle.bmc.waiter.Waiter} using the default configuration.
      *
      * @param request the request to send
-     * @param targetStates the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
-     * @return a new {@code Waiter} instance
+     * @param targetState the desired states to wait for. If multiple states are provided then the waiter will return once the resource reaches any of the provided states
+     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<GetOceInstanceRequest, GetOceInstanceResponse>
             forOceInstance(
                     GetOceInstanceRequest request,
-                    com.oracle.bmc.oce.model.OceInstance.LifecycleState... targetStates) {
+                    com.oracle.bmc.oce.model.LifecycleState... targetStates) {
         org.apache.commons.lang3.Validate.notEmpty(
                 targetStates, "At least one targetState must be provided");
         org.apache.commons.lang3.Validate.noNullElements(
@@ -51,7 +51,7 @@ public class OceInstanceWaiters {
     public com.oracle.bmc.waiter.Waiter<GetOceInstanceRequest, GetOceInstanceResponse>
             forOceInstance(
                     GetOceInstanceRequest request,
-                    com.oracle.bmc.oce.model.OceInstance.LifecycleState targetState,
+                    com.oracle.bmc.oce.model.LifecycleState targetState,
                     com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
                     com.oracle.bmc.waiter.DelayStrategy delayStrategy) {
         org.apache.commons.lang3.Validate.notNull(targetState, "The targetState cannot be null");
@@ -69,18 +69,18 @@ public class OceInstanceWaiters {
      * @param terminationStrategy the {@link com.oracle.bmc.waiter.TerminationStrategy} to use
      * @param delayStrategy the {@link com.oracle.bmc.waiter.DelayStrategy} to use
      * @param targetStates the desired states to wait for. The waiter will return once the resource reaches any of the provided states
-     * @return a new {@code com.oracle.bmc.waiter.Waiter} instance
+     * @return a new {@code Waiter} instance
      */
     public com.oracle.bmc.waiter.Waiter<GetOceInstanceRequest, GetOceInstanceResponse>
             forOceInstance(
                     GetOceInstanceRequest request,
                     com.oracle.bmc.waiter.TerminationStrategy terminationStrategy,
                     com.oracle.bmc.waiter.DelayStrategy delayStrategy,
-                    com.oracle.bmc.oce.model.OceInstance.LifecycleState... targetStates) {
+                    com.oracle.bmc.oce.model.LifecycleState... targetStates) {
         org.apache.commons.lang3.Validate.notEmpty(
-                targetStates, "At least one target state must be provided");
+                targetStates, "At least one targetState must be provided");
         org.apache.commons.lang3.Validate.noNullElements(
-                targetStates, "Null target states are not permitted");
+                targetStates, "Null targetState values are not permitted");
 
         return forOceInstance(
                 com.oracle.bmc.waiter.Waiters.newWaiter(terminationStrategy, delayStrategy),
@@ -93,8 +93,8 @@ public class OceInstanceWaiters {
             forOceInstance(
                     com.oracle.bmc.waiter.BmcGenericWaiter waiter,
                     final GetOceInstanceRequest request,
-                    final com.oracle.bmc.oce.model.OceInstance.LifecycleState... targetStates) {
-        final java.util.Set<com.oracle.bmc.oce.model.OceInstance.LifecycleState> targetStatesSet =
+                    final com.oracle.bmc.oce.model.LifecycleState... targetStates) {
+        final java.util.Set<com.oracle.bmc.oce.model.LifecycleState> targetStatesSet =
                 new java.util.HashSet<>(java.util.Arrays.asList(targetStates));
 
         return new com.oracle.bmc.waiter.internal.SimpleWaiterImpl<>(
@@ -115,8 +115,7 @@ public class OceInstanceWaiters {
                                         response.getOceInstance().getLifecycleState());
                             }
                         },
-                        targetStatesSet.contains(
-                                com.oracle.bmc.oce.model.OceInstance.LifecycleState.Deleted)),
+                        targetStatesSet.contains(com.oracle.bmc.oce.model.LifecycleState.Deleted)),
                 request);
     }
 

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/model/CreateOceInstanceDetails.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/model/CreateOceInstanceDetails.java
@@ -98,6 +98,15 @@ public class CreateOceInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("addOnFeatures")
+        private java.util.List<String> addOnFeatures;
+
+        public Builder addOnFeatures(java.util.List<String> addOnFeatures) {
+            this.addOnFeatures = addOnFeatures;
+            this.__explicitlySet__.add("addOnFeatures");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("objectStorageNamespace")
         private String objectStorageNamespace;
 
@@ -185,6 +194,7 @@ public class CreateOceInstanceDetails {
                             identityStripe,
                             tenancyName,
                             instanceUsageType,
+                            addOnFeatures,
                             objectStorageNamespace,
                             adminEmail,
                             upgradeSchedule,
@@ -208,6 +218,7 @@ public class CreateOceInstanceDetails {
                             .identityStripe(o.getIdentityStripe())
                             .tenancyName(o.getTenancyName())
                             .instanceUsageType(o.getInstanceUsageType())
+                            .addOnFeatures(o.getAddOnFeatures())
                             .objectStorageNamespace(o.getObjectStorageNamespace())
                             .adminEmail(o.getAdminEmail())
                             .upgradeSchedule(o.getUpgradeSchedule())
@@ -307,6 +318,12 @@ public class CreateOceInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("instanceUsageType")
     InstanceUsageType instanceUsageType;
+
+    /**
+     * a list of add-on features for the ocm instance
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("addOnFeatures")
+    java.util.List<String> addOnFeatures;
 
     /**
      * Object Storage Namespace of Tenancy

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/model/LicenseType.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/model/LicenseType.java
@@ -5,7 +5,7 @@
 package com.oracle.bmc.oce.model;
 
 /**
- * license types can be NEW for new oracle content and experience cloud license,
+ * license types can be NEW for new oracle content management cloud license,
  * or BYOL for bring your own license
  *
  **/

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/model/LifecycleDetails.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/model/LifecycleDetails.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.oce.model;
+
+/**
+ * Instance lifecycle details
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190912")
+@lombok.extern.slf4j.Slf4j
+public enum LifecycleDetails {
+    Standby("STANDBY"),
+    Failover("FAILOVER"),
+    Down("DOWN"),
+    Active("ACTIVE"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, LifecycleDetails> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (LifecycleDetails v : LifecycleDetails.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    LifecycleDetails(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static LifecycleDetails create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'LifecycleDetails', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/model/LifecycleState.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/model/LifecycleState.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.oce.model;
+
+/**
+ * Instance lifecycle state
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20190912")
+@lombok.extern.slf4j.Slf4j
+public enum LifecycleState {
+    Creating("CREATING"),
+    Updating("UPDATING"),
+    Active("ACTIVE"),
+    Deleting("DELETING"),
+    Deleted("DELETED"),
+    Failed("FAILED"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, LifecycleState> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (LifecycleState v : LifecycleState.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    LifecycleState(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static LifecycleState create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/model/OceInstance.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/model/OceInstance.java
@@ -123,6 +123,15 @@ public class OceInstance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("addOnFeatures")
+        private java.util.List<String> addOnFeatures;
+
+        public Builder addOnFeatures(java.util.List<String> addOnFeatures) {
+            this.addOnFeatures = addOnFeatures;
+            this.__explicitlySet__.add("addOnFeatures");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("objectStorageNamespace")
         private String objectStorageNamespace;
 
@@ -195,6 +204,15 @@ public class OceInstance {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private LifecycleDetails lifecycleDetails;
+
+        public Builder lifecycleDetails(LifecycleDetails lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("stateMessage")
         private String stateMessage;
 
@@ -258,6 +276,7 @@ public class OceInstance {
                             upgradeSchedule,
                             identityStripe,
                             instanceUsageType,
+                            addOnFeatures,
                             objectStorageNamespace,
                             adminEmail,
                             wafPrimaryDomain,
@@ -266,6 +285,7 @@ public class OceInstance {
                             timeCreated,
                             timeUpdated,
                             lifecycleState,
+                            lifecycleDetails,
                             stateMessage,
                             freeformTags,
                             definedTags,
@@ -289,6 +309,7 @@ public class OceInstance {
                             .upgradeSchedule(o.getUpgradeSchedule())
                             .identityStripe(o.getIdentityStripe())
                             .instanceUsageType(o.getInstanceUsageType())
+                            .addOnFeatures(o.getAddOnFeatures())
                             .objectStorageNamespace(o.getObjectStorageNamespace())
                             .adminEmail(o.getAdminEmail())
                             .wafPrimaryDomain(o.getWafPrimaryDomain())
@@ -297,6 +318,7 @@ public class OceInstance {
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
                             .stateMessage(o.getStateMessage())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags())
@@ -473,6 +495,12 @@ public class OceInstance {
     InstanceUsageType instanceUsageType;
 
     /**
+     * a list of add-on features for the ocm instance
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("addOnFeatures")
+    java.util.List<String> addOnFeatures;
+
+    /**
      * Object Storage Namespace of tenancy
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("objectStorageNamespace")
@@ -558,61 +586,18 @@ public class OceInstance {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     java.util.Date timeUpdated;
+
     /**
-     * The current state of the file system.
-     **/
-    @lombok.extern.slf4j.Slf4j
-    public enum LifecycleState {
-        Creating("CREATING"),
-        Updating("UPDATING"),
-        Active("ACTIVE"),
-        Deleting("DELETING"),
-        Deleted("DELETED"),
-        Failed("FAILED"),
-
-        /**
-         * This value is used if a service returns a value for this enum that is not recognized by this
-         * version of the SDK.
-         */
-        UnknownEnumValue(null);
-
-        private final String value;
-        private static java.util.Map<String, LifecycleState> map;
-
-        static {
-            map = new java.util.HashMap<>();
-            for (LifecycleState v : LifecycleState.values()) {
-                if (v != UnknownEnumValue) {
-                    map.put(v.getValue(), v);
-                }
-            }
-        }
-
-        LifecycleState(String value) {
-            this.value = value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonValue
-        public String getValue() {
-            return value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonCreator
-        public static LifecycleState create(String key) {
-            if (map.containsKey(key)) {
-                return map.get(key);
-            }
-            LOG.warn(
-                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
-                    key);
-            return UnknownEnumValue;
-        }
-    };
-    /**
-     * The current state of the file system.
+     * The current state of the instance lifecycle.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
+
+    /**
+     * Details of the current state of the instance lifecycle
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    LifecycleDetails lifecycleDetails;
 
     /**
      * An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/model/OceInstanceSummary.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/model/OceInstanceSummary.java
@@ -107,6 +107,15 @@ public class OceInstanceSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("addOnFeatures")
+        private java.util.List<String> addOnFeatures;
+
+        public Builder addOnFeatures(java.util.List<String> addOnFeatures) {
+            this.addOnFeatures = addOnFeatures;
+            this.__explicitlySet__.add("addOnFeatures");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("objectStorageNamespace")
         private String objectStorageNamespace;
 
@@ -188,6 +197,15 @@ public class OceInstanceSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+        private LifecycleDetails lifecycleDetails;
+
+        public Builder lifecycleDetails(LifecycleDetails lifecycleDetails) {
+            this.lifecycleDetails = lifecycleDetails;
+            this.__explicitlySet__.add("lifecycleDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("stateMessage")
         private String stateMessage;
 
@@ -249,6 +267,7 @@ public class OceInstanceSummary {
                             idcsTenancy,
                             tenancyName,
                             instanceUsageType,
+                            addOnFeatures,
                             objectStorageNamespace,
                             adminEmail,
                             upgradeSchedule,
@@ -258,6 +277,7 @@ public class OceInstanceSummary {
                             timeCreated,
                             timeUpdated,
                             lifecycleState,
+                            lifecycleDetails,
                             stateMessage,
                             service,
                             freeformTags,
@@ -279,6 +299,7 @@ public class OceInstanceSummary {
                             .idcsTenancy(o.getIdcsTenancy())
                             .tenancyName(o.getTenancyName())
                             .instanceUsageType(o.getInstanceUsageType())
+                            .addOnFeatures(o.getAddOnFeatures())
                             .objectStorageNamespace(o.getObjectStorageNamespace())
                             .adminEmail(o.getAdminEmail())
                             .upgradeSchedule(o.getUpgradeSchedule())
@@ -288,6 +309,7 @@ public class OceInstanceSummary {
                             .timeCreated(o.getTimeCreated())
                             .timeUpdated(o.getTimeUpdated())
                             .lifecycleState(o.getLifecycleState())
+                            .lifecycleDetails(o.getLifecycleDetails())
                             .stateMessage(o.getStateMessage())
                             .service(o.getService())
                             .freeformTags(o.getFreeformTags())
@@ -406,6 +428,12 @@ public class OceInstanceSummary {
     InstanceUsageType instanceUsageType;
 
     /**
+     * a list of add-on features for the ocm instance
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("addOnFeatures")
+    java.util.List<String> addOnFeatures;
+
+    /**
      * Object Storage Namespace of tenancy
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("objectStorageNamespace")
@@ -499,61 +527,18 @@ public class OceInstanceSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("timeUpdated")
     java.util.Date timeUpdated;
+
     /**
-     * The current state of the file system.
-     **/
-    @lombok.extern.slf4j.Slf4j
-    public enum LifecycleState {
-        Creating("CREATING"),
-        Updating("UPDATING"),
-        Active("ACTIVE"),
-        Deleting("DELETING"),
-        Deleted("DELETED"),
-        Failed("FAILED"),
-
-        /**
-         * This value is used if a service returns a value for this enum that is not recognized by this
-         * version of the SDK.
-         */
-        UnknownEnumValue(null);
-
-        private final String value;
-        private static java.util.Map<String, LifecycleState> map;
-
-        static {
-            map = new java.util.HashMap<>();
-            for (LifecycleState v : LifecycleState.values()) {
-                if (v != UnknownEnumValue) {
-                    map.put(v.getValue(), v);
-                }
-            }
-        }
-
-        LifecycleState(String value) {
-            this.value = value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonValue
-        public String getValue() {
-            return value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonCreator
-        public static LifecycleState create(String key) {
-            if (map.containsKey(key)) {
-                return map.get(key);
-            }
-            LOG.warn(
-                    "Received unknown value '{}' for enum 'LifecycleState', returning UnknownEnumValue",
-                    key);
-            return UnknownEnumValue;
-        }
-    };
-    /**
-     * The current state of the file system.
+     * The current state of the instance lifecycle.
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
     LifecycleState lifecycleState;
+
+    /**
+     * Details of the current state of the instance lifecycle
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("lifecycleDetails")
+    LifecycleDetails lifecycleDetails;
 
     /**
      * An message describing the current state in more detail. For example, can be used to provide actionable information for a resource in Failed state.

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/model/UpdateOceInstanceDetails.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/model/UpdateOceInstanceDetails.java
@@ -62,6 +62,15 @@ public class UpdateOceInstanceDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("addOnFeatures")
+        private java.util.List<String> addOnFeatures;
+
+        public Builder addOnFeatures(java.util.List<String> addOnFeatures) {
+            this.addOnFeatures = addOnFeatures;
+            this.__explicitlySet__.add("addOnFeatures");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("freeformTags")
         private java.util.Map<String, String> freeformTags;
 
@@ -91,6 +100,7 @@ public class UpdateOceInstanceDetails {
                             wafPrimaryDomain,
                             instanceLicenseType,
                             instanceUsageType,
+                            addOnFeatures,
                             freeformTags,
                             definedTags);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
@@ -104,6 +114,7 @@ public class UpdateOceInstanceDetails {
                             .wafPrimaryDomain(o.getWafPrimaryDomain())
                             .instanceLicenseType(o.getInstanceLicenseType())
                             .instanceUsageType(o.getInstanceUsageType())
+                            .addOnFeatures(o.getAddOnFeatures())
                             .freeformTags(o.getFreeformTags())
                             .definedTags(o.getDefinedTags());
 
@@ -176,6 +187,12 @@ public class UpdateOceInstanceDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("instanceUsageType")
     InstanceUsageType instanceUsageType;
+
+    /**
+     * a list of add-on features for the ocm instance
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("addOnFeatures")
+    java.util.List<String> addOnFeatures;
 
     /**
      * Simple key-value pair that is applied without any predefined name, type or scope. Exists for cross-compatibility only.

--- a/bmc-oce/src/main/java/com/oracle/bmc/oce/requests/ListOceInstancesRequest.java
+++ b/bmc-oce/src/main/java/com/oracle/bmc/oce/requests/ListOceInstancesRequest.java
@@ -132,47 +132,8 @@ public class ListOceInstancesRequest extends com.oracle.bmc.requests.BmcRequest<
     /**
      * Filter results on lifecycleState.
      */
-    private LifecycleState lifecycleState;
+    private com.oracle.bmc.oce.model.LifecycleState lifecycleState;
 
-    /**
-     * Filter results on lifecycleState.
-     **/
-    public enum LifecycleState {
-        Creating("CREATING"),
-        Updating("UPDATING"),
-        Active("ACTIVE"),
-        Deleting("DELETING"),
-        Deleted("DELETED"),
-        Failed("FAILED"),
-        ;
-
-        private final String value;
-        private static java.util.Map<String, LifecycleState> map;
-
-        static {
-            map = new java.util.HashMap<>();
-            for (LifecycleState v : LifecycleState.values()) {
-                map.put(v.getValue(), v);
-            }
-        }
-
-        LifecycleState(String value) {
-            this.value = value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonValue
-        public String getValue() {
-            return value;
-        }
-
-        @com.fasterxml.jackson.annotation.JsonCreator
-        public static LifecycleState create(String key) {
-            if (map.containsKey(key)) {
-                return map.get(key);
-            }
-            throw new IllegalArgumentException("Invalid LifecycleState: " + key);
-        }
-    };
     /**
      * The client request ID for tracing.
      */

--- a/bmc-ocvp/pom.xml
+++ b/bmc-ocvp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ocvp</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-oda/pom.xml
+++ b/bmc-oda/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-oda</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ons/pom.xml
+++ b/bmc-ons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ons</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-operatoraccesscontrol/pom.xml
+++ b/bmc-operatoraccesscontrol/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-operatoraccesscontrol</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-opsi/pom.xml
+++ b/bmc-opsi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-opsi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-optimizer/pom.xml
+++ b/bmc-optimizer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-optimizer</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osmanagement/pom.xml
+++ b/bmc-osmanagement/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osmanagement</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-ospgateway/pom.xml
+++ b/bmc-ospgateway/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-ospgateway</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubbillingschedule/pom.xml
+++ b/bmc-osubbillingschedule/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubbillingschedule</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osuborganizationsubscription/pom.xml
+++ b/bmc-osuborganizationsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osuborganizationsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubsubscription/pom.xml
+++ b/bmc-osubsubscription/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubsubscription</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-osubusage/pom.xml
+++ b/bmc-osubusage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-osubusage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/pom.xml
+++ b/bmc-resourcemanager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcemanager</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/ResourceManager.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/ResourceManager.java
@@ -61,7 +61,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/CancelJobExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CancelJob API.
@@ -76,7 +76,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ChangeConfigurationSourceProviderCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeConfigurationSourceProviderCompartment API.
@@ -90,7 +90,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ChangeStackCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeStackCompartment API.
@@ -105,7 +105,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ChangeTemplateCompartmentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ChangeTemplateCompartment API.
@@ -121,7 +121,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/CreateConfigurationSourceProviderExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateConfigurationSourceProvider API.
@@ -134,7 +134,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/CreateJobExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateJob API.
@@ -153,7 +153,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/CreateStackExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateStack API.
@@ -166,7 +166,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/CreateTemplateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use CreateTemplate API.
@@ -178,7 +178,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/DeleteConfigurationSourceProviderExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteConfigurationSourceProvider API.
@@ -191,7 +191,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/DeleteStackExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteStack API.
@@ -203,7 +203,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/DeleteTemplateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DeleteTemplate API.
@@ -215,7 +215,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/DetectStackDriftExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use DetectStackDrift API.
@@ -227,7 +227,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetConfigurationSourceProviderExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetConfigurationSourceProvider API.
@@ -240,7 +240,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetJobExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetJob API.
@@ -253,7 +253,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetJobDetailedLogContentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetJobDetailedLogContent API.
@@ -267,7 +267,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetJobLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetJobLogs API.
@@ -280,7 +280,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetJobLogsContentExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetJobLogsContent API.
@@ -294,7 +294,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetJobTfConfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetJobTfConfig API.
@@ -306,7 +306,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetJobTfStateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetJobTfState API.
@@ -318,7 +318,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetStackExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetStack API.
@@ -332,7 +332,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetStackTfConfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetStackTfConfig API.
@@ -344,7 +344,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetStackTfStateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetStackTfState API.
@@ -356,7 +356,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetTemplateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetTemplate API.
@@ -370,7 +370,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetTemplateLogoExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetTemplateLogo API.
@@ -384,7 +384,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetTemplateTfConfigExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetTemplateTfConfig API.
@@ -396,7 +396,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/GetWorkRequestExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetWorkRequest API.
@@ -411,7 +411,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListConfigurationSourceProvidersExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListConfigurationSourceProviders API.
@@ -429,7 +429,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListJobsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListJobs API.
@@ -442,7 +442,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListResourceDiscoveryServicesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListResourceDiscoveryServices API.
@@ -460,7 +460,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListStackResourceDriftDetailsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListStackResourceDriftDetails API.
@@ -476,7 +476,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListStacksExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListStacks API.
@@ -489,7 +489,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListTemplateCategoriesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListTemplateCategories API.
@@ -503,7 +503,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListTemplatesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListTemplates API.
@@ -516,7 +516,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListTerraformVersionsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListTerraformVersions API.
@@ -529,7 +529,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListWorkRequestErrorsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestErrors API.
@@ -542,7 +542,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListWorkRequestLogsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequestLogs API.
@@ -555,7 +555,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/ListWorkRequestsExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListWorkRequests API.
@@ -570,7 +570,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/UpdateConfigurationSourceProviderExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateConfigurationSourceProvider API.
@@ -583,7 +583,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/UpdateJobExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateJob API.
@@ -601,7 +601,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/UpdateStackExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateStack API.
@@ -614,7 +614,7 @@ public interface ResourceManager extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcemanager/UpdateTemplateExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use UpdateTemplate API.

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/ResourceManagerClient.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/ResourceManagerClient.java
@@ -471,7 +471,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -506,7 +506,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -542,7 +542,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -578,7 +578,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -615,7 +615,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -649,7 +649,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -683,7 +683,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -717,7 +717,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -753,7 +753,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -783,7 +783,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -813,7 +813,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -843,7 +843,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryTokenUtils.addRetryToken(ib);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
@@ -879,7 +879,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -907,7 +907,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -937,7 +937,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -965,7 +965,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -994,7 +994,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1033,7 +1033,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1072,7 +1072,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1100,7 +1100,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1139,7 +1139,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1178,7 +1178,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1207,7 +1207,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1246,7 +1246,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1285,7 +1285,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1314,7 +1314,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1345,7 +1345,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1373,7 +1373,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1404,7 +1404,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1435,7 +1435,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1464,7 +1464,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1494,7 +1494,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1523,7 +1523,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1553,7 +1553,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1583,7 +1583,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1612,7 +1612,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1641,7 +1641,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1672,7 +1672,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1705,7 +1705,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1738,7 +1738,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -1771,7 +1771,7 @@ public class ResourceManagerClient implements ResourceManager {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ConfigSource.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ConfigSource.java
@@ -52,7 +52,10 @@ public class ConfigSource {
     /**
      * File path to the directory to use for running Terraform.
      * If not specified, the root directory is used.
-     * This parameter is ignored for the {@code configSourceType} value of {@code COMPARTMENT_CONFIG_SOURCE}.
+     * Required when using a zip Terraform configuration ({@code configSourceType} value of {@code ZIP_UPLOAD}) that contains folders.
+     * Ignored for the {@code configSourceType} value of {@code COMPARTMENT_CONFIG_SOURCE}.
+     * For more information about required and recommended file structure, see
+     * [File Structure (Terraform Configurations for Resource Manager)](https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/terraformconfigresourcemanager.htm#filestructure).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("workingDirectory")

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateConfigSourceDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateConfigSourceDetails.java
@@ -54,9 +54,12 @@ package com.oracle.bmc.resourcemanager.model;
 public class CreateConfigSourceDetails {
 
     /**
-     * File path to the directory from which Terraform runs.
+     * File path to the directory to use for running Terraform.
      * If not specified, the root directory is used.
-     * This parameter is ignored for the {@code configSourceType} value of {@code COMPARTMENT_CONFIG_SOURCE}.
+     * Required when using a zip Terraform configuration ({@code configSourceType} value of {@code ZIP_UPLOAD}) that contains folders.
+     * Ignored for the {@code configSourceType} value of {@code COMPARTMENT_CONFIG_SOURCE}.
+     * For more information about required and recommended file structure, see
+     * [File Structure (Terraform Configurations for Resource Manager)](https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/terraformconfigresourcemanager.htm#filestructure).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("workingDirectory")

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateObjectStorageConfigSourceDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/CreateObjectStorageConfigSourceDetails.java
@@ -111,7 +111,7 @@ public class CreateObjectStorageConfigSourceDetails extends CreateConfigSourceDe
 
     /**
      * The name of the bucket's region.
-     * Example: {@code PHX}
+     * Example: {@code us-phoenix-1}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("region")

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/Job.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/Job.java
@@ -435,9 +435,12 @@ public class Job {
     CancellationDetails cancellationDetails;
 
     /**
-     * File path to the directory from which Terraform runs.
+     * File path to the directory to use for running Terraform.
      * If not specified, the root directory is used.
-     * This parameter is ignored for the {@code configSourceType} value of {@code COMPARTMENT_CONFIG_SOURCE}.
+     * Required when using a zip Terraform configuration ({@code configSourceType} value of {@code ZIP_UPLOAD}) that contains folders.
+     * Ignored for the {@code configSourceType} value of {@code COMPARTMENT_CONFIG_SOURCE}.
+     * For more information about required and recommended file structure, see
+     * [File Structure (Terraform Configurations for Resource Manager)](https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/terraformconfigresourcemanager.htm#filestructure).
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("workingDirectory")

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ObjectStorageConfigSource.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ObjectStorageConfigSource.java
@@ -110,7 +110,7 @@ public class ObjectStorageConfigSource extends ConfigSource {
 
     /**
      * The name of the bucket's region.
-     * Example: {@code PHX}
+     * Example: {@code us-phoenix-1}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("region")

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ObjectStorageConfigSourceRecord.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/ObjectStorageConfigSourceRecord.java
@@ -97,7 +97,7 @@ public class ObjectStorageConfigSourceRecord extends ConfigSourceRecord {
 
     /**
      * The name of the bucket's region.
-     * Example: {@code PHX}
+     * Example: {@code us-phoenix-1}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("region")

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/UpdateConfigSourceDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/UpdateConfigSourceDetails.java
@@ -46,7 +46,13 @@ package com.oracle.bmc.resourcemanager.model;
 public class UpdateConfigSourceDetails {
 
     /**
-     * The path of the directory from which to run terraform. If not specified, the the root will be used. This parameter is ignored for the {@code configSourceType} value of {@code COMPARTMENT_CONFIG_SOURCE}.
+     * File path to the directory to use for running Terraform.
+     * If not specified, the root directory is used.
+     * Required when using a zip Terraform configuration ({@code configSourceType} value of {@code ZIP_UPLOAD}) that contains folders.
+     * Ignored for the {@code configSourceType} value of {@code COMPARTMENT_CONFIG_SOURCE}.
+     * For more information about required and recommended file structure, see
+     * [File Structure (Terraform Configurations for Resource Manager)](https://docs.cloud.oracle.com/iaas/Content/ResourceManager/Concepts/terraformconfigresourcemanager.htm#filestructure).
+     *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("workingDirectory")
     String workingDirectory;

--- a/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/UpdateObjectStorageConfigSourceDetails.java
+++ b/bmc-resourcemanager/src/main/java/com/oracle/bmc/resourcemanager/model/UpdateObjectStorageConfigSourceDetails.java
@@ -110,7 +110,7 @@ public class UpdateObjectStorageConfigSourceDetails extends UpdateConfigSourceDe
 
     /**
      * The name of the bucket's region.
-     * Example: {@code PHX}
+     * Example: {@code us-phoenix-1}
      *
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("region")

--- a/bmc-resourcesearch/pom.xml
+++ b/bmc-resourcesearch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-resourcesearch</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/ResourceSearch.java
+++ b/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/ResourceSearch.java
@@ -52,7 +52,7 @@ public interface ResourceSearch extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcesearch/GetResourceTypeExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use GetResourceType API.
@@ -65,7 +65,7 @@ public interface ResourceSearch extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcesearch/ListResourceTypesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use ListResourceTypes API.
@@ -80,7 +80,7 @@ public interface ResourceSearch extends AutoCloseable {
      * @param request The request object containing the details to send
      * @return A response object containing details about the completed operation
      * @throws BmcException when an error occurs.
-     * This operation will not retry by default, users can also use RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION provided by the SDK to enable retries for it.
+     * This operation uses RetryConfiguration.SDK_DEFAULT_RETRY_CONFIGURATION as default if no retry strategy is provided.
      * The specifics of the default retry strategy are described here https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/javasdkconcepts.htm#javasdkconcepts_topic_Retries
      *
      * <b>Example: </b>Click <a href="https://docs.cloud.oracle.com/en-us/iaas/tools/java-sdk-examples/latest/resourcesearch/SearchResourcesExample.java.html" target="_blank" rel="noopener noreferrer" >here</a> to see how to use SearchResources API.

--- a/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/ResourceSearchClient.java
+++ b/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/ResourceSearchClient.java
@@ -398,7 +398,7 @@ public class ResourceSearchClient implements ResourceSearch {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -427,7 +427,7 @@ public class ResourceSearchClient implements ResourceSearch {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,
@@ -456,7 +456,7 @@ public class ResourceSearchClient implements ResourceSearch {
 
         final com.oracle.bmc.retrier.BmcGenericRetrier retrier =
                 com.oracle.bmc.retrier.Retriers.createPreferredRetrier(
-                        interceptedRequest.getRetryConfiguration(), retryConfiguration, false);
+                        interceptedRequest.getRetryConfiguration(), retryConfiguration, true);
         com.oracle.bmc.http.internal.RetryUtils.setClientRetriesHeader(ib, retrier);
         return retrier.execute(
                 interceptedRequest,

--- a/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/model/ResourceSummary.java
+++ b/bmc-resourcesearch/src/main/java/com/oracle/bmc/resourcesearch/model/ResourceSummary.java
@@ -133,6 +133,15 @@ public class ResourceSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
+        private java.util.Map<String, Object> additionalDetails;
+
+        public Builder additionalDetails(java.util.Map<String, Object> additionalDetails) {
+            this.additionalDetails = additionalDetails;
+            this.__explicitlySet__.add("additionalDetails");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonIgnore
         private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();
 
@@ -150,7 +159,8 @@ public class ResourceSummary {
                             definedTags,
                             systemTags,
                             searchContext,
-                            identityContext);
+                            identityContext,
+                            additionalDetails);
             __instance__.__explicitlySet__.addAll(__explicitlySet__);
             return __instance__;
         }
@@ -169,7 +179,8 @@ public class ResourceSummary {
                             .definedTags(o.getDefinedTags())
                             .systemTags(o.getSystemTags())
                             .searchContext(o.getSearchContext())
-                            .identityContext(o.getIdentityContext());
+                            .identityContext(o.getIdentityContext())
+                            .additionalDetails(o.getAdditionalDetails());
 
             copiedBuilder.__explicitlySet__.retainAll(o.__explicitlySet__);
             return copiedBuilder;
@@ -262,6 +273,18 @@ public class ResourceSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("identityContext")
     java.util.Map<String, Object> identityContext;
+
+    /**
+     * Additional resource attribute fields of this resource that match queries with a return clause, if any.
+     * For example, if you ran a query to find the private IP addresses, public IP addresses, and isPrimary field of
+     * the VNIC attachment on instance resources, that field would be included in the ResourceSummary object as:
+     * {"additionalDetails": {"attachedVnic": [{"publicIP" : "172.110.110.110","privateIP" : "10.10.10.10","isPrimary" : true},
+     * {"publicIP" : "172.110.110.111","privateIP" : "10.10.10.11","isPrimary" : false}]}.
+     * The structure of the additional details attribute fields depends on the matching resource.
+     *
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("additionalDetails")
+    java.util.Map<String, Object> additionalDetails;
 
     @com.fasterxml.jackson.annotation.JsonIgnore
     private final java.util.Set<String> __explicitlySet__ = new java.util.HashSet<String>();

--- a/bmc-rover/pom.xml
+++ b/bmc-rover/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-rover</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/internal/http/ListRoverClustersConverter.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/internal/http/ListRoverClustersConverter.java
@@ -46,6 +46,14 @@ public class ListRoverClustersConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getClusterType() != null) {
+            target =
+                    target.queryParam(
+                            "clusterType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getClusterType().getValue()));
+        }
+
         if (request.getLimit() != null) {
             target =
                     target.queryParam(

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/internal/http/ListRoverNodesConverter.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/internal/http/ListRoverNodesConverter.java
@@ -46,6 +46,14 @@ public class ListRoverNodesConverter {
                                     request.getDisplayName()));
         }
 
+        if (request.getNodeType() != null) {
+            target =
+                    target.queryParam(
+                            "nodeType",
+                            com.oracle.bmc.util.internal.HttpUtils.attemptEncodeQueryParam(
+                                    request.getNodeType().getValue()));
+        }
+
         if (request.getLimit() != null) {
             target =
                     target.queryParam(

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/model/ClusterType.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/model/ClusterType.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+package com.oracle.bmc.rover.model;
+
+/**
+ * Possible rover node types.
+ **/
+@javax.annotation.Generated(value = "OracleSDKGenerator", comments = "API Version: 20201210")
+@lombok.extern.slf4j.Slf4j
+public enum ClusterType {
+    Standalone("STANDALONE"),
+    Station("STATION"),
+
+    /**
+     * This value is used if a service returns a value for this enum that is not recognized by this
+     * version of the SDK.
+     */
+    UnknownEnumValue(null);
+
+    private final String value;
+    private static java.util.Map<String, ClusterType> map;
+
+    static {
+        map = new java.util.HashMap<>();
+        for (ClusterType v : ClusterType.values()) {
+            if (v != UnknownEnumValue) {
+                map.put(v.getValue(), v);
+            }
+        }
+    }
+
+    ClusterType(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonCreator
+    public static ClusterType create(String key) {
+        if (map.containsKey(key)) {
+            return map.get(key);
+        }
+        LOG.warn(
+                "Received unknown value '{}' for enum 'ClusterType', returning UnknownEnumValue",
+                key);
+        return UnknownEnumValue;
+    }
+}

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/model/CreateRoverClusterDetails.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/model/CreateRoverClusterDetails.java
@@ -71,6 +71,15 @@ public class CreateRoverClusterDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterType")
+        private ClusterType clusterType;
+
+        public Builder clusterType(ClusterType clusterType) {
+            this.clusterType = clusterType;
+            this.__explicitlySet__.add("clusterType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("superUserPassword")
         private String superUserPassword;
 
@@ -149,6 +158,15 @@ public class CreateRoverClusterDetails {
         public Builder oracleShippingTrackingUrl(String oracleShippingTrackingUrl) {
             this.oracleShippingTrackingUrl = oracleShippingTrackingUrl;
             this.__explicitlySet__.add("oracleShippingTrackingUrl");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subscriptionId")
+        private String subscriptionId;
+
+        public Builder subscriptionId(String subscriptionId) {
+            this.subscriptionId = subscriptionId;
+            this.__explicitlySet__.add("subscriptionId");
             return this;
         }
 
@@ -245,6 +263,7 @@ public class CreateRoverClusterDetails {
                             clusterSize,
                             customerShippingAddress,
                             clusterWorkloads,
+                            clusterType,
                             superUserPassword,
                             enclosureType,
                             unlockPassphrase,
@@ -254,6 +273,7 @@ public class CreateRoverClusterDetails {
                             shippingVendor,
                             timePickupExpected,
                             oracleShippingTrackingUrl,
+                            subscriptionId,
                             lifecycleState,
                             lifecycleStateDetails,
                             isImportRequested,
@@ -275,6 +295,7 @@ public class CreateRoverClusterDetails {
                             .clusterSize(o.getClusterSize())
                             .customerShippingAddress(o.getCustomerShippingAddress())
                             .clusterWorkloads(o.getClusterWorkloads())
+                            .clusterType(o.getClusterType())
                             .superUserPassword(o.getSuperUserPassword())
                             .enclosureType(o.getEnclosureType())
                             .unlockPassphrase(o.getUnlockPassphrase())
@@ -284,6 +305,7 @@ public class CreateRoverClusterDetails {
                             .shippingVendor(o.getShippingVendor())
                             .timePickupExpected(o.getTimePickupExpected())
                             .oracleShippingTrackingUrl(o.getOracleShippingTrackingUrl())
+                            .subscriptionId(o.getSubscriptionId())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleStateDetails(o.getLifecycleStateDetails())
                             .isImportRequested(o.getIsImportRequested())
@@ -332,6 +354,12 @@ public class CreateRoverClusterDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("clusterWorkloads")
     java.util.List<RoverWorkload> clusterWorkloads;
+
+    /**
+     * Type of cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clusterType")
+    ClusterType clusterType;
 
     /**
      * Root password for the rover cluster.
@@ -420,6 +448,12 @@ public class CreateRoverClusterDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("oracleShippingTrackingUrl")
     String oracleShippingTrackingUrl;
+
+    /**
+     * ID provided to customer after successful subscription to Rover Stations.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subscriptionId")
+    String subscriptionId;
 
     /**
      * The current state of the RoverCluster.

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/model/NodeType.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/model/NodeType.java
@@ -12,6 +12,7 @@ package com.oracle.bmc.rover.model;
 public enum NodeType {
     Standalone("STANDALONE"),
     Clustered("CLUSTERED"),
+    Station("STATION"),
 
     /**
      * This value is used if a service returns a value for this enum that is not recognized by this

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/model/RoverCluster.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/model/RoverCluster.java
@@ -150,6 +150,42 @@ public class RoverCluster {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterType")
+        private ClusterType clusterType;
+
+        public Builder clusterType(ClusterType clusterType) {
+            this.clusterType = clusterType;
+            this.__explicitlySet__.add("clusterType");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("subscriptionId")
+        private String subscriptionId;
+
+        public Builder subscriptionId(String subscriptionId) {
+            this.subscriptionId = subscriptionId;
+            this.__explicitlySet__.add("subscriptionId");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("exteriorDoorCode")
+        private String exteriorDoorCode;
+
+        public Builder exteriorDoorCode(String exteriorDoorCode) {
+            this.exteriorDoorCode = exteriorDoorCode;
+            this.__explicitlySet__.add("exteriorDoorCode");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("interiorAlarmDisarmCode")
+        private String interiorAlarmDisarmCode;
+
+        public Builder interiorAlarmDisarmCode(String interiorAlarmDisarmCode) {
+            this.interiorAlarmDisarmCode = interiorAlarmDisarmCode;
+            this.__explicitlySet__.add("interiorAlarmDisarmCode");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("superUserPassword")
         private String superUserPassword;
 
@@ -351,6 +387,10 @@ public class RoverCluster {
                             timeCustomerReturned,
                             deliveryTrackingInfo,
                             clusterWorkloads,
+                            clusterType,
+                            subscriptionId,
+                            exteriorDoorCode,
+                            interiorAlarmDisarmCode,
                             superUserPassword,
                             unlockPassphrase,
                             pointOfContact,
@@ -392,6 +432,10 @@ public class RoverCluster {
                             .timeCustomerReturned(o.getTimeCustomerReturned())
                             .deliveryTrackingInfo(o.getDeliveryTrackingInfo())
                             .clusterWorkloads(o.getClusterWorkloads())
+                            .clusterType(o.getClusterType())
+                            .subscriptionId(o.getSubscriptionId())
+                            .exteriorDoorCode(o.getExteriorDoorCode())
+                            .interiorAlarmDisarmCode(o.getInteriorAlarmDisarmCode())
                             .superUserPassword(o.getSuperUserPassword())
                             .unlockPassphrase(o.getUnlockPassphrase())
                             .pointOfContact(o.getPointOfContact())
@@ -505,6 +549,30 @@ public class RoverCluster {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("clusterWorkloads")
     java.util.List<RoverWorkload> clusterWorkloads;
+
+    /**
+     * Type of cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clusterType")
+    ClusterType clusterType;
+
+    /**
+     * ID provided to customer after successful subscription to Rover Stations.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subscriptionId")
+    String subscriptionId;
+
+    /**
+     * Service generated code for the exterior trailer door of the trailer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("exteriorDoorCode")
+    String exteriorDoorCode;
+
+    /**
+     * Service generated code to disarm the interior alarm of the trailer.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("interiorAlarmDisarmCode")
+    String interiorAlarmDisarmCode;
 
     /**
      * Root password for the rover cluster.

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/model/RoverClusterSummary.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/model/RoverClusterSummary.java
@@ -71,6 +71,24 @@ public class RoverClusterSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+        private Integer clusterSize;
+
+        public Builder clusterSize(Integer clusterSize) {
+            this.clusterSize = clusterSize;
+            this.__explicitlySet__.add("clusterSize");
+            return this;
+        }
+
+        @com.fasterxml.jackson.annotation.JsonProperty("clusterType")
+        private ClusterType clusterType;
+
+        public Builder clusterType(ClusterType clusterType) {
+            this.clusterType = clusterType;
+            this.__explicitlySet__.add("clusterType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("lifecycleState")
         private LifecycleState lifecycleState;
 
@@ -128,6 +146,8 @@ public class RoverClusterSummary {
                             displayName,
                             timeCreated,
                             nodes,
+                            clusterSize,
+                            clusterType,
                             lifecycleState,
                             lifecycleStateDetails,
                             freeformTags,
@@ -145,6 +165,8 @@ public class RoverClusterSummary {
                             .displayName(o.getDisplayName())
                             .timeCreated(o.getTimeCreated())
                             .nodes(o.getNodes())
+                            .clusterSize(o.getClusterSize())
+                            .clusterType(o.getClusterType())
                             .lifecycleState(o.getLifecycleState())
                             .lifecycleStateDetails(o.getLifecycleStateDetails())
                             .freeformTags(o.getFreeformTags())
@@ -192,6 +214,18 @@ public class RoverClusterSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("nodes")
     java.util.List<String> nodes;
+
+    /**
+     * Size of the cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clusterSize")
+    Integer clusterSize;
+
+    /**
+     * Type of cluster.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("clusterType")
+    ClusterType clusterType;
 
     /**
      * The current state of the RoverCluster.

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/model/RoverNodeSummary.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/model/RoverNodeSummary.java
@@ -60,6 +60,15 @@ public class RoverNodeSummary {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("nodeType")
+        private NodeType nodeType;
+
+        public Builder nodeType(NodeType nodeType) {
+            this.nodeType = nodeType;
+            this.__explicitlySet__.add("nodeType");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("displayName")
         private String displayName;
 
@@ -134,6 +143,7 @@ public class RoverNodeSummary {
                             compartmentId,
                             clusterId,
                             serialNumber,
+                            nodeType,
                             displayName,
                             timeCreated,
                             lifecycleState,
@@ -152,6 +162,7 @@ public class RoverNodeSummary {
                             .compartmentId(o.getCompartmentId())
                             .clusterId(o.getClusterId())
                             .serialNumber(o.getSerialNumber())
+                            .nodeType(o.getNodeType())
                             .displayName(o.getDisplayName())
                             .timeCreated(o.getTimeCreated())
                             .lifecycleState(o.getLifecycleState())
@@ -195,6 +206,12 @@ public class RoverNodeSummary {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("serialNumber")
     String serialNumber;
+
+    /**
+     * The type of node indicating if it belongs to a cluster
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeType")
+    NodeType nodeType;
 
     /**
      * A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/model/UpdateRoverClusterDetails.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/model/UpdateRoverClusterDetails.java
@@ -143,6 +143,15 @@ public class UpdateRoverClusterDetails {
             return this;
         }
 
+        @com.fasterxml.jackson.annotation.JsonProperty("subscriptionId")
+        private String subscriptionId;
+
+        public Builder subscriptionId(String subscriptionId) {
+            this.subscriptionId = subscriptionId;
+            this.__explicitlySet__.add("subscriptionId");
+            return this;
+        }
+
         @com.fasterxml.jackson.annotation.JsonProperty("shippingVendor")
         private String shippingVendor;
 
@@ -244,6 +253,7 @@ public class UpdateRoverClusterDetails {
                             pointOfContactPhoneNumber,
                             shippingPreference,
                             oracleShippingTrackingUrl,
+                            subscriptionId,
                             shippingVendor,
                             timePickupExpected,
                             isImportRequested,
@@ -273,6 +283,7 @@ public class UpdateRoverClusterDetails {
                             .pointOfContactPhoneNumber(o.getPointOfContactPhoneNumber())
                             .shippingPreference(o.getShippingPreference())
                             .oracleShippingTrackingUrl(o.getOracleShippingTrackingUrl())
+                            .subscriptionId(o.getSubscriptionId())
                             .shippingVendor(o.getShippingVendor())
                             .timePickupExpected(o.getTimePickupExpected())
                             .isImportRequested(o.getIsImportRequested())
@@ -403,6 +414,12 @@ public class UpdateRoverClusterDetails {
      **/
     @com.fasterxml.jackson.annotation.JsonProperty("oracleShippingTrackingUrl")
     String oracleShippingTrackingUrl;
+
+    /**
+     * ID provided to customer after successful subscription to Rover Stations.
+     **/
+    @com.fasterxml.jackson.annotation.JsonProperty("subscriptionId")
+    String subscriptionId;
 
     /**
      * Shipping vendor of choice for orace to customer shipping.

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/requests/ListRoverClustersRequest.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/requests/ListRoverClustersRequest.java
@@ -30,6 +30,11 @@ public class ListRoverClustersRequest extends com.oracle.bmc.requests.BmcRequest
     private String displayName;
 
     /**
+     * A filter to return only Clusters of type matched with the given cluster type.
+     */
+    private com.oracle.bmc.rover.model.ClusterType clusterType;
+
+    /**
      * The maximum number of items to return.
      */
     private Integer limit;
@@ -133,6 +138,7 @@ public class ListRoverClustersRequest extends com.oracle.bmc.requests.BmcRequest
         public Builder copy(ListRoverClustersRequest o) {
             compartmentId(o.getCompartmentId());
             displayName(o.getDisplayName());
+            clusterType(o.getClusterType());
             limit(o.getLimit());
             page(o.getPage());
             lifecycleState(o.getLifecycleState());

--- a/bmc-rover/src/main/java/com/oracle/bmc/rover/requests/ListRoverNodesRequest.java
+++ b/bmc-rover/src/main/java/com/oracle/bmc/rover/requests/ListRoverNodesRequest.java
@@ -30,6 +30,11 @@ public class ListRoverNodesRequest extends com.oracle.bmc.requests.BmcRequest<ja
     private String displayName;
 
     /**
+     * A filter to return only Nodes of type matched with the given node type.
+     */
+    private com.oracle.bmc.rover.model.NodeType nodeType;
+
+    /**
      * The maximum number of items to return.
      */
     private Integer limit;
@@ -133,6 +138,7 @@ public class ListRoverNodesRequest extends com.oracle.bmc.requests.BmcRequest<ja
         public Builder copy(ListRoverNodesRequest o) {
             compartmentId(o.getCompartmentId());
             displayName(o.getDisplayName());
+            nodeType(o.getNodeType());
             limit(o.getLimit());
             page(o.getPage());
             lifecycleState(o.getLifecycleState());

--- a/bmc-sch/pom.xml
+++ b/bmc-sch/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-sch</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-secrets/pom.xml
+++ b/bmc-secrets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-secrets</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicecatalog/pom.xml
+++ b/bmc-servicecatalog/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicecatalog</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-servicemanagerproxy/pom.xml
+++ b/bmc-servicemanagerproxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-servicemanagerproxy</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-shaded/bmc-shaded-full/pom.xml
+++ b/bmc-shaded/bmc-shaded-full/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk-shaded</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-shaded-full</artifactId>

--- a/bmc-shaded/pom.xml
+++ b/bmc-shaded/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bmc-streaming/pom.xml
+++ b/bmc-streaming/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-streaming</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-tenantmanagercontrolplane/pom.xml
+++ b/bmc-tenantmanagercontrolplane/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-tenantmanagercontrolplane</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-threatintelligence/pom.xml
+++ b/bmc-threatintelligence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-threatintelligence</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usage/pom.xml
+++ b/bmc-usage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usage</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-usageapi/pom.xml
+++ b/bmc-usageapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-usageapi</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vault/pom.xml
+++ b/bmc-vault/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vault</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-visualbuilder/pom.xml
+++ b/bmc-visualbuilder/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-visualbuilder</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-vulnerabilityscanning/pom.xml
+++ b/bmc-vulnerabilityscanning/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-vulnerabilityscanning</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waas/pom.xml
+++ b/bmc-waas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waas</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-waf/pom.xml
+++ b/bmc-waf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-waf</artifactId>
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/bmc-workrequests/pom.xml
+++ b/bmc-workrequests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-java-sdk</artifactId>
-    <version>2.18.0</version>
+    <version>2.19.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>oci-java-sdk-workrequests</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-java-sdk-common</artifactId>
-      <version>2.18.0</version>
+      <version>2.19.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-java-sdk</artifactId>
-  <version>2.18.0</version>
+  <version>2.19.0</version>
   <packaging>pom</packaging>
   <name>Oracle Cloud Infrastructure SDK</name>
   <description>This project contains the SDK used for Oracle Cloud Infrastructure</description>


### PR DESCRIPTION
### Added

- Support for the Sales Accelerator license option in the Content Management service

- Support for VCN hostname cluster endpoints in the Container Engine for Kubernetes service

- Support for optionally specifying an admin username and password when creating a database system during a restore operation in the MySQL Database service

- Support for automatic tablespace creation on non-autonomous and autonomous database dedicated targets in the Database Migration service

- Support for reporting excluded objects based on static exclusion rules and dynamic exclusion settings in the Database Migration service

- Support for removing, listing, and adding database objects reported by the Cloud Premigration Advisor Tool (CPAT) in the Database Migration service

- Support for migrating Oracle databases from the AWS RDS service to OCI as autonomous databases, using the AWS S3 service and DBLINK for data transfer, in the Database Migration service

- Support for querying additional fields of a resource using return clauses in the Search service

- Support for clusters and station clusters in the Roving Edge Infrastructure service

- Support for creating database systems and database homes using customer-managed keys in the Database service



### Breaking Changes

- Parameter 2 of `public com.oracle.bmc.waiter.Waiter forOceInstance(com.oracle.bmc.oce.requests.GetOceInstanceRequest, com.oracle.bmc.oce.model.OceInstance$LifecycleState[])` has changed its type to `com.oracle.bmc.oce.model.LifecycleState[]` in `com.oracle.bmc.oce.OceInstanceWaiters` in the Content Management service

- Parameter 2 of `public com.oracle.bmc.waiter.Waiter forOceInstance(com.oracle.bmc.oce.requests.GetOceInstanceRequest, com.oracle.bmc.oce.model.OceInstance$LifecycleState, com.oracle.bmc.waiter.TerminationStrategy, com.oracle.bmc.waiter.DelayStrategy)` has changed its type to `com.oracle.bmc.oce.model.LifecycleState` in `com.oracle.bmc.oce.OceInstanceWaiters` in the Content Management service 

- Parameter 4 of `public com.oracle.bmc.waiter.Waiter forOceInstance(com.oracle.bmc.oce.requests.GetOceInstanceRequest, com.oracle.bmc.waiter.TerminationStrategy, com.oracle.bmc.waiter.DelayStrategy, com.oracle.bmc.oce.model.OceInstance$LifecycleState[])` has changed its type to `com.oracle.bmc.oce.model.LifecycleState[]` in `com.oracle.bmc.oce.OceInstanceWaiters` in the Content Management service

- Return type of method `public com.oracle.bmc.oce.model.OceInstance$LifecycleState getLifecycleState()` has been changed to `com.oracle.bmc.oce.model.LifecycleState` in the model `com.oracle.bmc.oce.model.OceInstance` in the Content Management service 

- Class `com.oracle.bmc.oce.model.OceInstance$LifecycleState` has been removed in the Content Management service

- Return type of method `public com.oracle.bmc.oce.model.OceInstanceSummary$LifecycleState getLifecycleState()` has been changed to `com.oracle.bmc.oce.model.LifecycleState` in the model `com.oracle.bmc.oce.model.OceInstanceSummary` in the Content Management service 

- Class `com.oracle.bmc.oce.model.OceInstanceSummary$LifecycleState` has been removed in the Content Management service

- Return type of method `public com.oracle.bmc.oce.requests.ListOceInstancesRequest$LifecycleState getLifecycleState()` has been changed to `com.oracle.bmc.oce.model.LifecycleState` in `com.oracle.bmc.oce.requests.ListOceInstancesRequest` in the Content Management service

- Class `com.oracle.bmc.oce.requests.ListOceInstancesRequest$LifecycleState` has been removed in the Content Management service

- Support for retries enabled by default on operations in the Container Engine for Kubernetes service

- Support for retries enabled by default on operations in the Resource Manager service

- Support for retries enabled by default on operations in the Search service